### PR TITLE
logical operators for random select filters

### DIFF
--- a/core/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/core/src/bms/player/beatoraja/select/BarRenderer.java
@@ -414,7 +414,7 @@ public class BarRenderer {
 				String getterMethodName = "get" + key.substring(0, 1).toUpperCase()
 						+ key.substring(1);
 				try {
-					if (this.getFilter().get(key) instanceof Integer) {
+					if (this.getFilter().get(key) instanceof Integer) { // Fork for integer values of the filter key.
 						Integer value = (Integer)this.getFilter().get(key);
 						if (scoreData == null) {
 							if (0 != value) {
@@ -430,15 +430,13 @@ public class BarRenderer {
 						return true;
 					}
 					Object valueArr[] = ((String)this.getFilter().get(key)).split("&&");
-					for (Object value : valueArr)
+					for (Object value : valueArr) // Fork for string values of the filter key.
 					{
-						value = ((String)value).replaceAll("\\s","");
+						value = ((String)value).replaceAll("\\s",""); // Clean from whitespaces.
 						if (scoreData == null) {
-							if (value instanceof String) {
-								String stringValue = (String) value;
-								if (!stringValue.isEmpty() && !stringValue.substring(0, 1).equals("<")) {
-									return false;
-								}
+							String stringValue = (String) value;
+							if (!stringValue.isEmpty() && !stringValue.substring(0, 1).equals("<")) {
+								return false; // Because lack of value would be less than anything.
 							}
 						} else {
 							Method getterMethod = ScoreData.class.getMethod(getterMethodName);
@@ -447,12 +445,14 @@ public class BarRenderer {
 								String valueString = (String)value;
 								Integer propertyValueInt = (Integer)propertyValue;
 								Integer filterValueInt;
-								if (valueString.substring(1,2).equals("=")){
-									filterValueInt = Integer.parseInt(valueString.substring(2,valueString.length()));
+								// Checking the position for the integer bit of the key value.
+								if (valueString.substring(1,2).equals("=")){ // If the operation is either >= or <=.
+									filterValueInt = Integer.parseInt(valueString.substring(2));
 								}
-								else filterValueInt = Integer.parseInt(valueString.substring(1,valueString.length()));
+								// If the operation is > or <.
+								else filterValueInt = Integer.parseInt(valueString.substring(1));
 
-								if (valueString.substring(0,1).equals(">"))
+								if (valueString.substring(0,1).equals(">")) // Fork for > and >= operations.
 								{
 									if (valueString.substring(1,2).equals("="))
 									{
@@ -466,7 +466,7 @@ public class BarRenderer {
 										return false;
 									}
 								}
-								if (valueString.substring(0,1).equals("<"))
+								if (valueString.substring(0,1).equals("<")) // Fork for < and <= operations.
 								{
 									if (valueString.substring(1,2).equals("="))
 									{

--- a/core/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/core/src/bms/player/beatoraja/select/BarRenderer.java
@@ -1023,19 +1023,56 @@ public class BarRenderer {
 									String getterMethodName = "get" + key.substring(0, 1).toUpperCase()
 											+ key.substring(1);
 									try {
-										Object value = randomFolder.getFilter().get(key);
-										if (scoreData == null) {
-											if (value instanceof String && !"".equals((String) value)) {
-												return false;
-											}
-											if (value instanceof Integer && 0 != (Integer) value) {
-												return false;
-											}
-										} else {
-											Method getterMethod = ScoreData.class.getMethod(getterMethodName);
-											Object propertyValue = getterMethod.invoke(scoreData);
-											if (!propertyValue.equals(value)) {
-												return false;
+										Object valueArr[] = ((String)randomFolder.getFilter().get(key)).split("&&");
+										for (Object value : valueArr)
+										{
+											value = ((String)value).replaceAll("\\s","");
+											if (scoreData == null) {
+												{
+													if (value instanceof String && !((String)value).isEmpty() && !((String)value).substring(0,1).equals("<")) {
+														return false;
+													}
+													if (value instanceof Integer && 0 != (Integer) value) {
+														return false;
+													}
+												}
+											} else {
+												Method getterMethod = ScoreData.class.getMethod(getterMethodName);
+												Object propertyValue = getterMethod.invoke(scoreData);
+												if (value instanceof String && propertyValue instanceof Integer) {
+													if (((String)value).substring(0,1).equals(">"))
+													{
+														if (((String)value).substring(1,2).equals("="))
+														{
+
+															if (!((Integer)propertyValue >= Integer.parseInt(((String)value).substring(2,((String)value).length()))))
+															{
+																return false;
+															}
+														}
+														else if (!((Integer)propertyValue > Integer.parseInt(((String)value).substring(1,((String)value).length()))))
+														{
+															return false;
+														}
+													}
+													if (((String)value).substring(0,1).equals("<"))
+													{
+														if (((String)value).substring(1,2).equals("="))
+														{
+															if (!((Integer)propertyValue <= Integer.parseInt(((String)value).substring(2,((String)value).length()))))
+															{
+																return false;
+															}
+														}
+														else if (!((Integer)propertyValue < Integer.parseInt(((String)value).substring(1,((String)value).length()))))
+														{
+															return false;
+														}
+													}
+												}
+												else if (!propertyValue.equals(value)) {
+													return false;
+												}
 											}
 										}
 									} catch (Throwable e) {

--- a/core/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/core/src/bms/player/beatoraja/select/BarRenderer.java
@@ -414,24 +414,36 @@ public class BarRenderer {
 				String getterMethodName = "get" + key.substring(0, 1).toUpperCase()
 						+ key.substring(1);
 				try {
+					if (this.getFilter().get(key) instanceof Integer) {
+						Integer value = (Integer)this.getFilter().get(key);
+						if (scoreData == null) {
+							if (0 != value) {
+								return false;
+							}
+						} else {
+							Method getterMethod = ScoreData.class.getMethod(getterMethodName);
+							Object propertyValue = getterMethod.invoke(scoreData);
+							if (!propertyValue.equals(value)) {
+								return false;
+							}
+						}
+						return true;
+					}
 					Object valueArr[] = ((String)this.getFilter().get(key)).split("&&");
 					for (Object value : valueArr)
 					{
 						value = ((String)value).replaceAll("\\s","");
 						if (scoreData == null) {
 							if (value instanceof String) {
-								String stringValue = (String)value;
-								if (!stringValue.isEmpty() && !stringValue.substring(0,1).equals("<")) {
+								String stringValue = (String) value;
+								if (!stringValue.isEmpty() && !stringValue.substring(0, 1).equals("<")) {
 									return false;
 								}
-							}
-							if (value instanceof Integer && 0 != (Integer) value) {
-								return false;
 							}
 						} else {
 							Method getterMethod = ScoreData.class.getMethod(getterMethodName);
 							Object propertyValue = getterMethod.invoke(scoreData);
-							if (value instanceof String && propertyValue instanceof Integer) {
+							if (propertyValue instanceof Integer) {
 								String valueString = (String)value;
 								Integer propertyValueInt = (Integer)propertyValue;
 								Integer filterValueInt;


### PR DESCRIPTION
A feature to add logical operators to random select filters, particularly for keys with integer values. Implements "<", ">", "<=", ">=" and "&&" operations. 

Normally, beatoraja as of 0.8.6 allows for fixed value keys in random select filters, such as "clear": 6, which would select a song with Hard-Clear lamp. It isn't possible to have it select from a range of values, such as 4-5, which would describe all songs with lamp ranging from Easy-Clear to Groove-Clear. This PR allows doing it as such:
```json
{
        "name":"RANDOM EASY-GROOVE",
        "filter": {
            "clear": ">=4 && <6"
        }
 }
 ```
 This has no effect on normal beatoraja behavior, otherwise. Everything that would work in upstream still holds, it only expands on it.