### PR TITLE
fix hispeedfix display without selected song

### DIFF
--- a/core/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -1032,7 +1032,13 @@ public class IntegerPropertyFactory {
 		option_dp(54, (state) -> (state.resource.getPlayerConfig().getDoubleoption())),
 
 		hsfix(55, (state) -> {
-			PlayConfig pc = ((MusicSelector)state).getSelectedBarPlayConfig();
+			PlayConfig pc = null;
+			if (state instanceof MusicSelector) {
+				pc = ((MusicSelector) state).getSelectedBarPlayConfig();
+			}
+			else {
+				pc = state.resource.getPlayerConfig().getPlayConfig(state.resource.getPlayerConfig().getMode()).getPlayconfig();
+			}
 			if (pc != null) {
 				return pc.getFixhispeed();
 			}

--- a/core/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -1032,30 +1032,9 @@ public class IntegerPropertyFactory {
 		option_dp(54, (state) -> (state.resource.getPlayerConfig().getDoubleoption())),
 
 		hsfix(55, (state) -> {
-			if (state.resource.getSongdata() != null) {
-				SongData song = state.resource.getSongdata();
-				PlayConfig pc = state.resource.getPlayerConfig().getPlayConfig(song.getMode())
-						.getPlayconfig();
+			PlayConfig pc = ((MusicSelector)state).getSelectedBarPlayConfig();
+			if (pc != null) {
 				return pc.getFixhispeed();
-			} else if (state.resource.getCourseData() != null) {
-				PlayConfig pc = null;
-				for (SongData song : state.resource.getCourseData().getSong()) {
-					if (song.getPath() == null) {
-						pc = null;
-						break;
-					}
-					PlayConfig pc2 = state.resource.getPlayerConfig().getPlayConfig(song.getMode()).getPlayconfig();
-					if (pc == null) {
-						pc = pc2;
-					}
-					if (pc != pc2) {
-						pc = null;
-						break;
-					}
-				}
-				if (pc != null) {
-					return pc.getFixhispeed();
-				}
 			}
 			return Integer.MIN_VALUE;
 		}),


### PR DESCRIPTION
Normally, Hi-Speed Fix mode isn't displayed in song select menu, if current bar doesn't belong to a song or a course. However, it is still possible to set this value by pressing START+5 - Start menu will not display current value in that case, but it will still update it for 7K mode. 
Every other option is displayed regardless of current bar type and defaults to displaying the value for 7K, if the option is keymode specific.
This commit changes the behavior for hispeedfix getter, so it matches that of other options.