### PR TITLE
Useful error message on failed bms parse

### DIFF
--- a/core/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
+++ b/core/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
@@ -534,12 +534,20 @@ public class SQLiteSongDatabaseAccessor extends SQLiteDatabaseAccessor implement
 					if (bmsondecoder == null) {
 						bmsondecoder = new BMSONDecoder(BMSModel.LNTYPE_LONGNOTE);
 					}
-					model = bmsondecoder.decode(path);
+					try {
+						model = bmsondecoder.decode(path);
+					} catch (Exception e) {
+						Logger.getGlobal().severe("Error while decoding bmson at path: " + pathname + e.getMessage());
+					}
 				} else {
 					if (bmsdecoder == null) {
 						bmsdecoder = new BMSDecoder(BMSModel.LNTYPE_LONGNOTE);
 					}
-					model = bmsdecoder.decode(path);
+					try {
+						model = bmsdecoder.decode(path);
+					} catch (Exception e) {
+						Logger.getGlobal().severe("Error while decoding bms at path: " + pathname + e.getMessage());
+					}
 				}
 
 				if (model == null) {


### PR DESCRIPTION
Catch NPE on failed bms parse. Very rare but happens with some `bmson` charts, also added to `bm*` for posterity.

Will log the offending charts rather than an ambiguous NPE trace some function calls higher.