### PR TITLE
Global FREQ+

### DIFF
--- a/core/src/bms/player/beatoraja/ImGuiRenderer.java
+++ b/core/src/bms/player/beatoraja/ImGuiRenderer.java
@@ -13,6 +13,7 @@ import com.badlogic.gdx.controllers.ControllerManager;
 import com.badlogic.gdx.controllers.Controllers;
 import com.badlogic.gdx.controllers.desktop.JamepadControllerManager;
 
+import com.sun.javafx.util.Utils;
 import imgui.*;
 import imgui.flag.*;
 import imgui.callback.ImGuiInputTextCallback;
@@ -51,7 +52,6 @@ public class ImGuiRenderer {
     private static ImBoolean BLACK_WHITE_RANDOM_PERMUTATION = new ImBoolean(false);
 
     private static ArrayList<String> LANE_ORDER = new ArrayList<>(Arrays.asList("1","2","3","4","5","6","7"));
-    //private static ArrayList<Integer> FREQ_LIST = new ArrayList<>(Arrays.asList(100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200));
     private static int[] FREQ = new int[] {100};
 
     public static void init() {
@@ -166,6 +166,8 @@ public class ImGuiRenderer {
                     100,
                     200);
             // formatString="%d", ImGuiSliderFlags=0);
+            FREQ[0] = Utils.clamp(100, FREQ[0], 200);
+
             RandomTrainer.setFreaky((FREQ[0]>100));
             RandomTrainer.setFreq(FREQ[0]);
 

--- a/core/src/bms/player/beatoraja/ImGuiRenderer.java
+++ b/core/src/bms/player/beatoraja/ImGuiRenderer.java
@@ -51,6 +51,8 @@ public class ImGuiRenderer {
     private static ImBoolean BLACK_WHITE_RANDOM_PERMUTATION = new ImBoolean(false);
 
     private static ArrayList<String> LANE_ORDER = new ArrayList<>(Arrays.asList("1","2","3","4","5","6","7"));
+    //private static ArrayList<Integer> FREQ_LIST = new ArrayList<>(Arrays.asList(100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200));
+    private static int[] FREQ = new int[] {100};
 
     public static void init() {
         imGuiGlfw = new ImGuiImplGlfw();
@@ -154,6 +156,19 @@ public class ImGuiRenderer {
                 ImGui.text("GLFW version: " + GLFW.glfwGetVersionString());
                 ImGui.treePop();
             }
+            ImGui.newLine();
+
+            ImGui.text("FREQ+");
+            ImGui.indent();
+
+            ImGui.sliderInt("%",
+                    FREQ,
+                    100,
+                    200);
+            // formatString="%d", ImGuiSliderFlags=0);
+            RandomTrainer.setFreaky((FREQ[0]>100));
+            RandomTrainer.setFreq(FREQ[0]);
+
             ImGui.end();
         }
 

--- a/core/src/bms/player/beatoraja/RandomTrainer.java
+++ b/core/src/bms/player/beatoraja/RandomTrainer.java
@@ -13,12 +13,14 @@ public class RandomTrainer {
 
     private static boolean blackWhitePermute;
     private static boolean active;
+    private static boolean freaky;
 
     private static final ArrayList<Boolean> laneMask = new ArrayList<>(Arrays.asList(false, false, false, false, false, false, false));
 
     private static HashMap<Integer, Long> randomSeedMap;
 
     private static final ArrayDeque<RandomHistoryEntry> laneOrderHistory = new ArrayDeque<RandomHistoryEntry>();
+    private static int freq = 100;
 
     public RandomTrainer() {
         if (randomSeedMap == null) {
@@ -73,7 +75,19 @@ public class RandomTrainer {
     public static void setActive(boolean active) {
         RandomTrainer.active = active;
     }
+    public static boolean isFreaky() {
+        return freaky;
+    }
 
+    public static void setFreaky(boolean freaky) {
+        RandomTrainer.freaky = freaky;
+    }
+    public static int getFreq() {
+        return RandomTrainer.freq;
+    }
+    public static void setFreq(int freq) {
+        RandomTrainer.freq = freq;
+    }
     public static HashMap<Integer, Long> getRandomSeedMap() {
         return randomSeedMap;
     }

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -214,6 +214,24 @@ public class BMSPlayer extends MainState {
 		playtime = (autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY ? model.getLastTime() : model.getLastNoteTime()) + TIME_MARGIN;
 
 		if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY) {
+			if(RandomTrainer.isFreaky() && autoplay.mode != BMSPlayerMode.Mode.AUTOPLAY) {
+				int freq = RandomTrainer.getFreq();
+
+				practice.create(model);
+				PracticeProperty property = practice.getPracticeProperty();
+				// Don't need this? Pending testing
+				//starttimeoffset = (property.starttime > 1000 ? property.starttime - 1000 : 0) * 100 / freq;
+				playtime = (property.endtime + 1000) * 100 / freq + TIME_MARGIN;
+
+				// Chart render scale, note judge is handled by create()::judge.init() later
+				BMSModelUtils.changeFrequency(model, freq / 100f);
+
+				// Audio
+				if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
+					main.getAudioProcessor().setGlobalPitch(freq / 100f);
+				}
+			}
+
 			if (config.isBpmguide() && (model.getMinBPM() < model.getMaxBPM())) {
 				// BPM変化がなければBPMガイドなし
 				assist = Math.max(assist, 1);
@@ -512,35 +530,6 @@ public class BMSPlayer extends MainState {
 		switch (state) {
 		// 楽曲ロード
 		case STATE_PRELOAD:
-			if(RandomTrainer.isFreaky()) {
-				resource.reloadBMSFile();
-				model = resource.getBMSModel();
-				resource.getSongdata().setBMSModel(model);
-
-				int freq = RandomTrainer.getFreq();
-
-				practice.create(model);
-				PracticeProperty property = practice.getPracticeProperty();
-
-				// Chart render scale
-				BMSModelUtils.changeFrequency(model, freq / 100f);
-				lanerender.init(model);
-
-				// Update note rate
-				judge.init(model, resource);
-
-				// BG Audio
-				//setPlaySpeed(freq);
-
-				// Keysound Audio
-				if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
-					main.getAudioProcessor().setGlobalPitch(freq / 100f);
-				}
-
-				starttimeoffset = (property.starttime > 1000 ? property.starttime - 1000 : 0) * 100 / freq;
-				playtime = (property.endtime + 1000) * 100 / freq + TIME_MARGIN;
-
-			}
 			if(config.isChartPreview()) {
 				if(timer.isTimerOn(TIMER_PLAY) && micronow > startpressedtime) {
 					timer.setTimerOff(TIMER_PLAY);

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -529,9 +529,16 @@ public class BMSPlayer extends MainState {
 				// Update note rate
 				judge.init(model, resource);
 
+				// BG Audio
+				//setPlaySpeed(freq);
+
+				// Keysound Audio
 				if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
 					main.getAudioProcessor().setGlobalPitch(freq / 100f);
 				}
+
+				starttimeoffset = (property.starttime > 1000 ? property.starttime - 1000 : 0) * 100 / freq;
+				playtime = (property.endtime + 1000) * 100 / freq + TIME_MARGIN;
 
 			}
 			if(config.isChartPreview()) {

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -523,26 +523,16 @@ public class BMSPlayer extends MainState {
 
 			if(RandomTrainer.isFreaky()) {
 				int freq = RandomTrainer.getFreq();
-				//int starttime = 0;
+
 				//model = resource.getBMSModel();
 				practice.create(model);
 				PracticeProperty property = practice.getPracticeProperty();
-				////int endtime = model.getLastTime() + 1000;
-				//Logger.getGlobal().info(
-				//		"-- FreakyTrainer --\nFreaky Power:\t" + freq + "%" +
-				//		"\nStart Time:\t" + property.starttime +
-				//		"\nEnd Time:\t" + property.endtime);
 
 				BMSModelUtils.changeFrequency(model, freq / 100f);
 				lanerender.init(model);
 				if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
 					main.getAudioProcessor().setGlobalPitch(freq / 100f);
 				}
-
-				// This is probably just for the compressed PMode chart view
-				//PracticeModifier freakyrave = new PracticeModifier(property.starttime * 100 / freq,
-				//		property.endtime * 100 / freq);
-				//freakyrave.modify(model);
 			}
 			if(config.isChartPreview()) {
 				if(timer.isTimerOn(TIMER_PLAY) && micronow > startpressedtime) {
@@ -574,33 +564,6 @@ public class BMSPlayer extends MainState {
 				timer.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
 				timer.setTimerOn(TIMER_PM_CHARA_2P_NEUTRAL);
 			}
-
-/*
-			if(RandomTrainer.isFreaky()) {
-				int freq = RandomTrainer.getFreq();
-				//Logger.getGlobal().info("-- FreakyTrainer --\nFreaky Power:\t" + freq + "%");
-
-				// Does not re-scale chart to new speed
-				// i.e. 200 freq will be 2x fast scroll, still need to remodel chart:
-				//setPlaySpeed(freq);
-
-				int starttime = 0;
-				model = resource.getBMSModel();
-				PracticeProperty property = practice.getPracticeProperty();
-				//int endtime = model.getLastTime() + 1000;
-				//Logger.getGlobal().info(
-				//		"-- FreakyTrainer --\nFreaky Power:\t" + freq + "%" +
-				//		"\nStart Time:\t" + property.starttime +
-				//		"\nEnd Time:\t" + property.endtime);
-
-				BMSModelUtils.changeFrequency(model, freq / 100f);
-				if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
-					main.getAudioProcessor().setGlobalPitch(freq / 100f);
-				}
-				//PracticeModifier freakyrave = new PracticeModifier(property.starttime * 100 / freq,
-				//		property.endtime * 100 / freq);
-				//freakyrave.modify(model);
-			}*/
 
 			break;
 		// practice mode
@@ -701,11 +664,8 @@ public class BMSPlayer extends MainState {
 			final long deltatime = micronow - prevtime;
 			final long deltaplay = deltatime * (100 - playspeed) / 100;
 			PracticeProperty property = practice.getPracticeProperty();
-			//if(RandomTrainer.isFreaky()) { property.freq = RandomTrainer.getFreq();}
 
 			timer.setMicroTimer(TIMER_PLAY, timer.getMicroTimer(TIMER_PLAY) + deltaplay);
-
-			// Does freq+ need to do anything for the following?:
 
 			rhythm.update(this, deltatime, lanerender.getNowBPM(), property.freq);
 

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -543,6 +543,30 @@ public class BMSPlayer extends MainState {
 				timer.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
 				timer.setTimerOn(TIMER_PM_CHARA_2P_NEUTRAL);
 			}
+
+			if(RandomTrainer.isFreaky()) {
+				int freq = RandomTrainer.getFreq();
+				Logger.getGlobal().info("-- FreakyTrainer --\nFreaky Power:\t" + freq);
+
+				// Does not re-scale chart to new speed
+				// i.e. 200 freq will be 2x fast scroll, still need to remodel chart:
+				//setPlaySpeed(freq);
+
+				int starttime = 0;
+				int endtime = model.getLastTime() + 1000;
+				Logger.getGlobal().info("-- FreakyTrainer --\nFreaky Power:\t" + freq +
+						"\nStart Time:\t" + starttime +
+						"\nEnd Time:\t" + endtime);
+
+				BMSModelUtils.changeFrequency(model, freq / 100f);
+				if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
+					main.getAudioProcessor().setGlobalPitch(freq / 100f);
+				}
+				PracticeModifier freakyrave = new PracticeModifier(starttime * 100 / freq,
+						endtime * 100 / freq);
+				freakyrave.modify(model);
+			}
+
 			break;
 		// practice mode
 		case STATE_PRACTICE:
@@ -644,6 +668,11 @@ public class BMSPlayer extends MainState {
 			PracticeProperty property = practice.getPracticeProperty();
 			timer.setMicroTimer(TIMER_PLAY, timer.getMicroTimer(TIMER_PLAY) + deltaplay);
 
+			//if(RandomTrainer.isFreaky()) {
+			//
+			//}
+
+			// Does freq+ need to do anything for the following?:
 			rhythm.update(this, deltatime, lanerender.getNowBPM(), property.freq);
 
 			final long ptime = timer.getNowTime(TIMER_PLAY);

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -512,27 +512,27 @@ public class BMSPlayer extends MainState {
 		switch (state) {
 		// 楽曲ロード
 		case STATE_PRELOAD:
-
-			// Do we actually need all of these for FREQ+?
-			// Move to inside conditional?
-			resource.reloadBMSFile();
-			model = resource.getBMSModel();
-			resource.getSongdata().setBMSModel(model);
-			lanerender.init(model); // Likely Need
-			keyinput.setKeyBeamStop(false);
-
 			if(RandomTrainer.isFreaky()) {
+				resource.reloadBMSFile();
+				model = resource.getBMSModel();
+				resource.getSongdata().setBMSModel(model);
+
 				int freq = RandomTrainer.getFreq();
 
-				//model = resource.getBMSModel();
 				practice.create(model);
 				PracticeProperty property = practice.getPracticeProperty();
 
+				// Chart render scale
 				BMSModelUtils.changeFrequency(model, freq / 100f);
 				lanerender.init(model);
+
+				// Update note rate
+				judge.init(model, resource);
+
 				if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
 					main.getAudioProcessor().setGlobalPitch(freq / 100f);
 				}
+
 			}
 			if(config.isChartPreview()) {
 				if(timer.isTimerOn(TIMER_PLAY) && micronow > startpressedtime) {
@@ -564,7 +564,6 @@ public class BMSPlayer extends MainState {
 				timer.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
 				timer.setTimerOn(TIMER_PM_CHARA_2P_NEUTRAL);
 			}
-
 			break;
 		// practice mode
 		case STATE_PRACTICE:
@@ -664,6 +663,7 @@ public class BMSPlayer extends MainState {
 			final long deltatime = micronow - prevtime;
 			final long deltaplay = deltatime * (100 - playspeed) / 100;
 			PracticeProperty property = practice.getPracticeProperty();
+			if(RandomTrainer.isFreaky()) { property.freq = RandomTrainer.getFreq();}
 
 			timer.setMicroTimer(TIMER_PLAY, timer.getMicroTimer(TIMER_PLAY) + deltaplay);
 

--- a/core/src/bms/player/beatoraja/result/CourseResult.java
+++ b/core/src/bms/player/beatoraja/result/CourseResult.java
@@ -7,6 +7,7 @@ import java.util.*;
 import java.util.logging.Logger;
 
 import bms.player.beatoraja.input.KeyCommand;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.utils.FloatArray;
 
 import bms.model.BMSModel;
@@ -44,6 +45,10 @@ public class CourseResult extends AbstractResult {
 		setSound(SOUND_CLEAR, "course_clear.wav", SoundType.SOUND, isLoopSound);
 		setSound(SOUND_FAIL, "course_fail.wav", SoundType.SOUND, isLoopSound);
 		setSound(SOUND_CLOSE, "course_close.wav", SoundType.SOUND, false);
+
+		if(RandomTrainer.isFreaky()) {
+			main.getMessageRenderer().addMessage("FREQ+ " + RandomTrainer.getFreq() + "%", 20000, Color.GOLD, 0);
+		}
 
 		for(int i = resource.getCourseGauge().size;i < resource.getCourseBMSModels().length;i++) {
 			FloatArray[] list = new FloatArray[resource.getGrooveGauge().getGaugeTypeLength()];

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 import bms.player.beatoraja.input.KeyCommand;
 import bms.player.beatoraja.input.KeyBoardInputProcesseor.ControlKeys;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.FloatArray;
 
@@ -47,6 +48,8 @@ public class MusicResult extends AbstractResult {
 		setSound(SOUND_CLEAR, "clear.wav", SoundType.SOUND, isLoopSound);
 		setSound(SOUND_FAIL, "fail.wav", SoundType.SOUND, isLoopSound);
 		setSound(SOUND_CLOSE, "resultclose.wav", SoundType.SOUND, false);
+
+		main.getMessageRenderer().addMessage("FREQ+ " + RandomTrainer.getFreq() + "%", 20000, Color.GOLD, 0);
 
 		property = ResultKeyProperty.get(resource.getBMSModel().getMode());
 		if (property == null) {

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -49,7 +49,9 @@ public class MusicResult extends AbstractResult {
 		setSound(SOUND_FAIL, "fail.wav", SoundType.SOUND, isLoopSound);
 		setSound(SOUND_CLOSE, "resultclose.wav", SoundType.SOUND, false);
 
-		main.getMessageRenderer().addMessage("FREQ+ " + RandomTrainer.getFreq() + "%", 20000, Color.GOLD, 0);
+		if(RandomTrainer.isFreaky()) {
+			main.getMessageRenderer().addMessage("FREQ+ " + RandomTrainer.getFreq() + "%", 20000, Color.GOLD, 0);
+		}
 
 		property = ResultKeyProperty.get(resource.getBMSModel().getMode());
 		if (property == null) {


### PR DESCRIPTION
Added a global set-and-forget FREQ+, integrated into the random trainer:
![image](https://github.com/seraxis/lr2oraja-endlessdream/assets/87740032/9f8a9148-2f6a-477a-8664-228a19e0a9ee)

Additional considerations:
- Limit the slider to steps?
    - Currently, any integer between 100-200
    - Sliders can be Ctrl-clicked for manual input
- Skinnable FREQ+ %
- More testing
    - During dev it messed with the practice mode freq, but I think it's isolated now.
- Clean up code