### PR TITLE
LR2 judge autoadjust logic

### DIFF
--- a/core/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/core/src/bms/player/beatoraja/play/JudgeManager.java
@@ -150,6 +150,8 @@ public class JudgeManager {
 	 */
 	private int recentJudgesIndex = 0;
 
+	private int pressesSinceLastAutoadjust = 0;
+
 	private MultiBadCollector multiBadCollector = new MultiBadCollector();
 
 	public JudgeManager(BMSPlayer main) {
@@ -740,9 +742,15 @@ public class JudgeManager {
 		if(player.isNotesDisplayTimingAutoAdjust()) {
 			final BMSPlayerMode autoplay = main.resource.getPlayMode();
 			if(autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
-				if (judge <= 2 && mfast >= -150000 && mfast <= 150000) {
-					player.setJudgetiming(player.getJudgetiming() - (int)((mfast >= 0 ? mfast + 15000 : mfast - 15000) / 30000));
-				}			
+				if (judge <= 3) {
+					pressesSinceLastAutoadjust++;
+					if (pressesSinceLastAutoadjust > 9) {
+						if (mfast <= -500 || mfast >= 500) {
+							player.setJudgetiming(player.getJudgetiming() + (int) (mfast < 0 ? 1 : -1));
+						}
+						pressesSinceLastAutoadjust = 0;
+					}
+				}
 			}			
 		}
 	}


### PR DESCRIPTION
I studied autoadjust logic in LR2 disassembly and recreated that logic here.

It fixes an issue of beatoraja autoadjust being too reactive, which results in too big changes of adjust at bursts, which results in a net negative for score.
On the other hand, it won't be able to reach the generally correct offset as quickly, but it's not as important. Previous logic is very capable of completely ruining the plays, which is the reason to choose against it for many.

Doesn't impact the game in any other way. Currently is under user testing.

Reference disassembly with comments in the attached screenshot.
![image](https://github.com/seraxis/lr2oraja-endlessdream/assets/19263830/3f9b1b53-a7bc-41c5-bbde-7b923f701ea2)
