### PR TITLE
IR sendPlayData use flow rework

### DIFF
--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -431,17 +431,17 @@ public class MainController extends ApplicationAdapter {
 						try {
 							List<IRSendStatus> removeIrSendStatus = new ArrayList<IRSendStatus>();
 
-							for(IRSendStatus irc : irSendStatus) {
-								long timeUntilNextTry = (long)(Math.pow(4, irc.retry) * 1000);
-								if (irc.retry != 0 && now - irc.lastTry >= timeUntilNextTry) {
-									irc.send();
+							for(IRSendStatus score : irSendStatus) {
+								long timeUntilNextTry = (long)(Math.pow(4, score.retry) * 1000);
+								if (score.retry != 0 && now - score.lastTry >= timeUntilNextTry) {
+									score.send();
 								}
-								if(irc.retry < 0) {
-									removeIrSendStatus.add(irc);
+								if(score.isSent) {
+									removeIrSendStatus.add(score);
 								}
-								if(irc.retry > getConfig().getIrSendCount()) {
-									removeIrSendStatus.add(irc);
-									messageRenderer.addMessage("Failed to send a score for " + irc.song.getTitle() + irc.song.getSubtitle(),5000, Color.RED, 1);
+								if(score.retry > getConfig().getIrSendCount()) {
+									removeIrSendStatus.add(score);
+									messageRenderer.addMessage("Failed to send a score for " + score.song.getTitle() + score.song.getSubtitle(),5000, Color.RED, 1);
 								}
 							}
 							irSendStatus.removeAll(removeIrSendStatus);
@@ -989,7 +989,7 @@ public class MainController extends ApplicationAdapter {
 		public final ScoreData score;
 		public int retry = 0;
 		public long lastTry = 0;
-
+		public boolean isSent = false;
 		public IRSendStatus(IRConnection ir, SongData song, ScoreData score) {
 			this.ir = ir;
 			this.song = song;
@@ -1000,13 +1000,13 @@ public class MainController extends ApplicationAdapter {
 			Logger.getGlobal().info("IRへスコア送信中 : " + song.getTitle());
 			lastTry = System.currentTimeMillis();
 			IRResponse<Object> send1 = ir.sendPlayData(new IRChartData(song), new bms.player.beatoraja.ir.IRScoreData(score));
+			retry++;
 			if(send1.isSucceeded()) {
 				Logger.getGlobal().info("IRスコア送信完了 : " + song.getTitle());
-				retry = -255;
+				isSent = true;
 				return true;
 			} else {
 				Logger.getGlobal().warning("IRスコア送信失敗 : " + send1.getMessage());
-				retry++;
 				return false;
 			}
 

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -436,8 +436,12 @@ public class MainController extends ApplicationAdapter {
 								if (irc.retry != 0 && now - irc.lastTry >= timeUntilNextTry) {
 									irc.send();
 								}
-								if(irc.retry < 0 || irc.retry > getConfig().getIrSendCount()) {
+								if(irc.retry < 0) {
 									removeIrSendStatus.add(irc);
+								}
+								if(irc.retry > getConfig().getIrSendCount()) {
+									removeIrSendStatus.add(irc);
+									messageRenderer.addMessage("Failed to send a score for " + irc.song.getTitle() + irc.song.getSubtitle(),5000, Color.RED, 1);
 								}
 							}
 							irSendStatus.removeAll(removeIrSendStatus);

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -42,8 +42,6 @@ import bms.player.beatoraja.song.*;
 import bms.player.beatoraja.stream.StreamController;
 import bms.tool.mdprocessor.MusicDownloadProcessor;
 
-import static bms.player.beatoraja.skin.SkinProperty.*;
-
 /**
  * アプリケーションのルートクラス
  *

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -16,6 +16,7 @@ import com.badlogic.gdx.utils.FloatArray;
 import bms.model.*;
 import bms.player.beatoraja.*;
 import bms.player.beatoraja.MainController.IRStatus;
+import bms.player.beatoraja.MainController.IRSendStatus;
 import bms.player.beatoraja.input.BMSPlayerInputProcessor;
 import bms.player.beatoraja.ir.*;
 import bms.player.beatoraja.play.GrooveGauge;
@@ -31,8 +32,6 @@ import bms.player.beatoraja.song.SongData;
 public class MusicResult extends AbstractResult {
 
 	private ResultKeyProperty property;
-	
-	private List<IRSendStatus> irSendStatus = new ArrayList<IRSendStatus>();
 
 	public MusicResult(MainController main) {
 		super(main);
@@ -103,40 +102,34 @@ public class MusicResult extends AbstractResult {
     			}
     			
     			if(send) {
-    				irSendStatus.add(new IRSendStatus(irc.connection, resource.getSongdata(), newscore));
+    				main.irSendStatus.add(new IRSendStatus(irc.connection, resource.getSongdata(), newscore));
     			}
         	}
 			
 			Thread irprocess = new Thread(() -> {
                 try {
-                	int irsend = 0;
                 	boolean succeed = true;
-                	List<IRSendStatus> removeIrSendStatus = new ArrayList<IRSendStatus>();
-                	
-                	for(IRSendStatus irc : irSendStatus) {
-        				if(irsend == 0) {
-        					timer.switchTimer(TIMER_IR_CONNECT_BEGIN, true);                					
-        				}
-        				irsend++;
+					IRSendStatus irc = null;
+					if (!main.irSendStatus.isEmpty()) {
+						irc = main.irSendStatus.get(main.irSendStatus.size() - 1);
+					}
+                	if (irc != null) {
+        				timer.switchTimer(TIMER_IR_CONNECT_BEGIN, true);
                         succeed &= irc.send();
                         if(irc.retry < 0 || irc.retry > main.getConfig().getIrSendCount()) {
-                        	removeIrSendStatus.add(irc);
+							main.irSendStatus.remove(irc);
                         }
-                	}
-                	irSendStatus.removeAll(removeIrSendStatus);
-                	                	
-                	if(irsend > 0) {
-                		timer.switchTimer(succeed ? TIMER_IR_CONNECT_SUCCESS : TIMER_IR_CONNECT_FAIL, true);
-                        
-                        IRResponse<bms.player.beatoraja.ir.IRScoreData[]> response = ir[0].connection.getPlayData(null, new IRChartData(resource.getSongdata()));
-                        if(response.isSucceeded()) {
-                    		ranking.updateScore(response.getData(), newscore.getExscore() > oldscore.getExscore() ? newscore : oldscore);
-                    		rankingOffset = ranking.getRank() > 10 ? ranking.getRank() - 5 : 0;
-                            Logger.getGlobal().warning("IRからのスコア取得成功 : " + response.getMessage());
-                        } else {
-                            Logger.getGlobal().warning("IRからのスコア取得失敗 : " + response.getMessage());
-                        }                    		
-                	}
+						timer.switchTimer(succeed ? TIMER_IR_CONNECT_SUCCESS : TIMER_IR_CONNECT_FAIL, true);
+
+						IRResponse<bms.player.beatoraja.ir.IRScoreData[]> response = ir[0].connection.getPlayData(null, new IRChartData(resource.getSongdata()));
+						if(response.isSucceeded()) {
+							ranking.updateScore(response.getData(), newscore.getExscore() > oldscore.getExscore() ? newscore : oldscore);
+							rankingOffset = ranking.getRank() > 10 ? ranking.getRank() - 5 : 0;
+							Logger.getGlobal().warning("IRからのスコア取得成功 : " + response.getMessage());
+						} else {
+							Logger.getGlobal().warning("IRからのスコア取得失敗 : " + response.getMessage());
+						}
+					}
                 } catch (Exception e) {
                     Logger.getGlobal().severe(e.getMessage());
                 } finally {
@@ -484,33 +477,5 @@ public class MusicResult extends AbstractResult {
 
 	public ScoreData getNewScore() {
 		return resource.getScoreData();
-	}
-
-	static class IRSendStatus {
-		public final IRConnection ir;
-		public final SongData song;
-		public final ScoreData score;
-		public int retry = 0;
-		
-		public IRSendStatus(IRConnection ir, SongData song, ScoreData score) {
-			this.ir = ir;
-			this.song = song;
-			this.score = score;
-		}
-		
-		public boolean send() {
-			Logger.getGlobal().info("IRへスコア送信中 : " + song.getTitle());
-            IRResponse<Object> send1 = ir.sendPlayData(new IRChartData(song), new bms.player.beatoraja.ir.IRScoreData(score));
-            if(send1.isSucceeded()) {
-                Logger.getGlobal().info("IRスコア送信完了 : " + song.getTitle());
-                retry = -255;
-                return true;
-            } else {
-                Logger.getGlobal().warning("IRスコア送信失敗 : " + send1.getMessage());
-                retry++;
-                return false;
-            }
-
-		}
 	}
 }

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -286,7 +286,7 @@ public class MusicResult extends AbstractResult {
 					if (((MusicResultSkin) getSkin()).getRankTime() != 0
 							&& !timer.isTimerOn(TIMER_RESULT_UPDATESCORE)) {
 						timer.switchTimer(TIMER_RESULT_UPDATESCORE, true);
-					} else if (state == STATE_OFFLINE || state == STATE_IR_FINISHED) {
+					} else if (state == STATE_OFFLINE || state == STATE_IR_FINISHED ||  time - timer.getTimer(TIMER_IR_CONNECT_BEGIN) >=  3000) {
 						timer.switchTimer(TIMER_FADEOUT, true);
 						if (getSound(SOUND_CLOSE) != null) {
 							stop(SOUND_CLEAR);

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -109,15 +109,15 @@ public class MusicResult extends AbstractResult {
 			Thread irprocess = new Thread(() -> {
                 try {
                 	boolean succeed = true;
-					IRSendStatus irc = null;
+					IRSendStatus score = null;
 					if (!main.irSendStatus.isEmpty()) {
-						irc = main.irSendStatus.get(main.irSendStatus.size() - 1);
+						score = main.irSendStatus.get(main.irSendStatus.size() - 1);
 					}
-                	if (irc != null) {
+                	if (score != null) {
         				timer.switchTimer(TIMER_IR_CONNECT_BEGIN, true);
-                        succeed &= irc.send();
-                        if(irc.retry < 0 || irc.retry > main.getConfig().getIrSendCount()) {
-							main.irSendStatus.remove(irc);
+                        succeed &= score.send();
+                        if(score.isSent || score.retry > main.getConfig().getIrSendCount()) {
+							main.irSendStatus.remove(score);
                         }
 						timer.switchTimer(succeed ? TIMER_IR_CONNECT_SUCCESS : TIMER_IR_CONNECT_FAIL, true);
 


### PR DESCRIPTION
Original beatoraja code sends the scores only on prepare() method of MusicResult scene. Before the send thread finishes its job, result screen will never let you go back to music select, so in the case IR lags, you have to wait until timeout. Failed to send scores are then resent on next MusicResult.prepare() call.

This PR allows to return to song select if the score takes more than 3 seconds to submit.
Failed to submit scores are resent to IR every 4^retry seconds in a background thread, which starts if connection to IR on game start succeeded. 
Code to resend scores from result scene is deleted, only the immediate score is sent from result screen. 
The number of maximum retries is set in "config_sys.json" file in the parameter "irSendCount", default value is 5. After failing to send the score for 5 times total, it's gonna be removed from the array, which is a behavior identical to original beatoraja flow. To prevent scores from being removed too soon in case of short IR or user connection downtime, the scores are sent in intervals of 4^retry seconds. With default irSendCount value of 5, it would take 1364 seconds to drop the score, or roughly 23 minutes.

