### PR TITLE
IR send rework: bugfix for multiple IRs

### DIFF
--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -115,7 +115,7 @@ public class MusicResult extends AbstractResult {
 					if (!main.irSendStatus.isEmpty()) {
 						scores = main.irSendStatus.subList(main.irSendStatus.size() - ir.length, main.irSendStatus.size());
 					}
-                	for (IRSendStatus score : scores) {
+					for (IRSendStatus score : scores) {
 						if(irsend == 0) {
 							timer.switchTimer(TIMER_IR_CONNECT_BEGIN, true);
 						}


### PR DESCRIPTION
I made an oversight in the PR that is already merged, it had a bug that it would never send a score for any but the primary IR server, in case multiple IRs are connected.