### PR TITLE
Issue #20: Plays with Rate Modifier on always considered as a No Play Clear on Result screen

### DIFF
--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -438,7 +438,7 @@ public class MusicResult extends AbstractResult {
 			newscore = cscore;
 		}
 
-		if (isFreqTrainerEnabled()) {
+		if (isFreqTrainerEnabled() && resource.getScoreData().getClear() != ClearType.Failed.id) {
 			resource.getScoreData().setClear(NoPlay.id);
 		}
 


### PR DESCRIPTION
This makes the game display the fail lamp with rates enabled. All the other lamps will still be overridden into NO PLAY. In case of negative FREQ the lamp is not gonna be saved. In case of positive FREQ, the fail lamp will be saved together with the score, which i think is in line with original behavior for that scenario.