### PR TITLE
Fix crash on first GetLaneOrder call with bw permute

### DIFF
--- a/core/src/bms/player/beatoraja/modmenu/RandomTrainer.java
+++ b/core/src/bms/player/beatoraja/modmenu/RandomTrainer.java
@@ -6,7 +6,7 @@ import java.util.*;
 import java.util.logging.Logger;
 
 public class RandomTrainer {
-    private static String laneOrder;
+    private static String laneOrder = "1234567";
 
 
 


### PR DESCRIPTION
Fixes an issue #27 by initializing laneOrder variable. The crash occurs on first "Trainer Enable", if blackwhite permute was enabled, because the method GetLaneOrder is called before the first call to SetLaneOrder. If bw permute is enabled, GetLaneOrder will try to access the contents of laneOrder, which don't yet exist.