### PR TITLE
Add configurations for easier linux debugging in IDEA

### DIFF
--- a/.idea/runConfigurations/Gradle___Test_JAR__Linux_.xml
+++ b/.idea/runConfigurations/Gradle___Test_JAR__Linux_.xml
@@ -1,0 +1,29 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Gradle - Test JAR (Linux)" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="_JAVA_OPTIONS" value="-Dsun.java2d.opengl=true -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true -Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel -Dfile.encoding=&quot;UTF-8&quot;" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-Dplatform=linux" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="core:runShadow" />
+        </list>
+      </option>
+      <option name="vmOptions" value="-Djdk.gtk.version=2" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -46,6 +46,7 @@ tasks {
     // shadow task that extends java `application` plugin JavaExec to cover fatjars
     // used to test builds, does not contain portaudio natives.
     runShadow {
+        jvmArgs = listOf("-Djdk.gtk.version=2")
         val runDirProp = System.getProperty("runDir")
         val runDir = when(runDirProp != null)  {
             true -> FileSystems.getDefault().getPath(runDirProp).normalize().toAbsolutePath().toFile()


### PR DESCRIPTION
I've modified the gradle configuration to append `-Djdk.gtk.version=2` when running from IDE since there are issues otherwise when working on Linux under Wayland.

I've also added run configs under `.idea` for debugging the created JAR