### PR TITLE
Extend GetAssignedLane to BMSPlayer

### DIFF
--- a/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -1320,7 +1320,7 @@ public class IntegerPropertyFactory {
 		 */
 		private static IntegerProperty getAssignedLane(int key, boolean is2PSide){
 			return (state) -> {
-				if (!(state instanceof MusicResult)){
+				if (!(state instanceof MusicResult || state instanceof BMSPlayer)){
 					return 0;
 				}
 


### PR DESCRIPTION
allows skins to fetch lane assignments during Play stage