### PR TITLE
Support MacOS(arm based)

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -40,6 +40,10 @@ jobs:
       run: ./gradlew -Dplatform=windows shadowJar
     - name: Execute Linux Gradle build
       run: ./gradlew -Dplatform=linux shadowJar
+    - name: Execute Macos(x86) Gradle build
+      run: ./gradlew -Dplatform=macos shadowJar
+    - name: Execute Macos(arm) Gradle build
+      run: ./gradlew -Dplatform=macos -Darch=aarch64 shadowJar
 
     - name: Make Github release with build artifacts
       uses: "marvinpinto/action-automatic-releases@latest"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Run the gradle wrapper for your operating system and specify your desired platfo
 ```sh
 ./gradlew core:shadowJar -Dplatform=linux
 ```
+**MacOS:**
+```sh
+./gradlew core:shadowJar -Dplatform=macos
+```
+
+> [!NOTE]
+> For `arm` user: add -Darch=aarch64
 
 This task will create a jar located in `dist/` that can be used with any working installation of the game.
 ### Testing changes

--- a/buildSrc/src/main/kotlin/org/endlessdream/extra/PlatformFilter.kt
+++ b/buildSrc/src/main/kotlin/org/endlessdream/extra/PlatformFilter.kt
@@ -24,6 +24,8 @@ abstract class PlatformFilter : TransformAction<PlatformFilter.Parameters> {
     interface Parameters : TransformParameters {
         @get:Input
         var platformString: String
+        @get:Input
+        var archString: String
     }
 
     @get:PathSensitive(PathSensitivity.NAME_ONLY)
@@ -33,10 +35,15 @@ abstract class PlatformFilter : TransformAction<PlatformFilter.Parameters> {
     override
     fun transform(outputs: TransformOutputs) {
         val fileName = primaryInput.get().asFile.name
-        // Remove all platform natives for platforms other than the current one,
+        // Remove all platform natives for platforms other than the current one
+        // hack for macos-arm64
+        val lwjglSuffixName = when (parameters.platformString) {
+            "macos" -> if (parameters.archString == "aarch64") "macos-arm64" else "macos-x86_64"
+            else -> parameters.platformString
+        }
         if (fileName.contains("lwjgl") && fileName.contains("natives")) {
             val nameWithoutExtension = fileName.substring(0, fileName.length - 4)
-            if (!nameWithoutExtension.endsWith(parameters.platformString)) {
+            if (!nameWithoutExtension.endsWith(lwjglSuffixName)) {
                 return
             }
         }
@@ -46,6 +53,7 @@ abstract class PlatformFilter : TransformAction<PlatformFilter.Parameters> {
             }
         }
         if (fileName.contains("javacpp-1.5.9-windows-x86_64")) return
+        if (fileName.contains("javacpp-1.5.9-macos-arm64")) return
 
         outputs.file(primaryInput)
     }

--- a/buildSrc/src/main/kotlin/org/endlessdream/extra/multiplatform-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/endlessdream/extra/multiplatform-convention.gradle.kts
@@ -12,6 +12,15 @@ var platform = when(System.getProperty("platform") != null)  {
     false -> "windows"
 }!!
 
+// use `-Darch=[arch]` or change this value to set the target arch for the jar
+// Available arch:
+//    "x86-64", "aarch64"
+// Defauls to x86-64
+var arch = when(System.getProperty("arch") != null) {
+    true -> System.getProperty("arch")
+    false -> "x86-64"
+}
+
 tasks {
     register<Copy>("resolveRuntimeClasspath") {
         from(configurations.runtimeClasspath)
@@ -24,7 +33,7 @@ configurations.matching {
 }.configureEach {
     attributes {
         attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(platform))
-        attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named("x86-64"))
+        attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(arch))
         attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
     }
 }
@@ -53,6 +62,7 @@ dependencies {
 
         parameters {
             platformString = platform
+            archString = arch
         }
     }
     components {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
     flatDir{
         dirs("../lib")
     }
+    maven(url = "https://jitpack.io" )
 }
 
 version = libs.versions.beatoraja.get()
@@ -33,8 +34,13 @@ tasks {
     // fat/uber-jar task provided by https://github.com/johnrengelman/shadow
     shadowJar {
         val platformProp = System.getProperty("platform")
+        val archProp = System.getProperty("arch")
+        val archVariant = when(archProp != null) {
+            true -> archProp.plus("-")
+            false -> ""
+        }
         val classifierPlatform = when(platformProp != null)  {
-            true -> platformProp.plus("-").plus(libs.versions.endlessdream.get())
+            true -> platformProp.plus("-").plus(archVariant).plus(libs.versions.endlessdream.get())
             false -> "".plus(libs.versions.endlessdream.get())
         }
         destinationDirectory.set(projectDir.resolveSibling("dist"))
@@ -83,6 +89,9 @@ dependencies {
 
     implementation(libs.javadiscord)
     implementation(libs.twitter4j)
+
+    implementation(libs.shapedrawer)
+    implementation(libs.guacamole)
 
     // non-gradle managed file dependencies. jportaudio not on maven. "custom" scares me.
     implementation(":jportaudio")

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -39,6 +39,10 @@ import bms.player.beatoraja.skin.SkinProperty;
 import bms.player.beatoraja.song.*;
 import bms.player.beatoraja.stream.StreamController;
 import bms.tool.mdprocessor.MusicDownloadProcessor;
+import de.damios.guacamole.gdx.graphics.ShaderCompatibilityHelper;
+import de.damios.guacamole.gdx.graphics.ShaderProgramFactory;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import space.earlygrey.shapedrawer.ShapeDrawer;
 
 /**
  * アプリケーションのルートクラス
@@ -323,7 +327,7 @@ public class MainController {
 
 	public void create() {
 		final long t = System.currentTimeMillis();
-		sprite = new SpriteBatch();
+		sprite = SpriteBatchHelper.createSpriteBatch();
 		SkinLoader.initPixmapResourcePool(config.getSkinPixmapGen());
 
 

--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -129,7 +129,16 @@ public class MainLoader extends Application {
 			MainController main = new MainController(bmsPath, config, player, playerMode, songUpdated);
 
 			Lwjgl3ApplicationConfiguration gdxConfig = new Lwjgl3ApplicationConfiguration();
-
+			// This line is provided for macos-fix, the original issue is mac dropped the OpenGL full support,
+			// according to the document from libgdx, mac machine now only supports OpenGL 3.2 and needs to emulate GL30
+			// to make libgdx work
+			// However, this line may break some old machine which has no OpenGL 3.2 support. It seems that libgdx defaults
+			// to emulate GL20, this version gap might be danger. Therefore, this line is wrapped as macos only
+			// NOTE: SpriteBatchHelper is also macos only, it degenerates to beatoraja's default behaviour when executing
+			// on other platforms
+			if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+				gdxConfig.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 3, 2);
+			}
 			final int w = config.getResolution().width;
 			final int h = config.getResolution().height;
 			if (config.getDisplaymode() == Config.DisplayMode.FULLSCREEN) {

--- a/core/src/bms/player/beatoraja/SpriteBatchHelper.java
+++ b/core/src/bms/player/beatoraja/SpriteBatchHelper.java
@@ -1,0 +1,57 @@
+package bms.player.beatoraja;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import de.damios.guacamole.gdx.graphics.ShaderCompatibilityHelper;
+import de.damios.guacamole.gdx.graphics.ShaderProgramFactory;
+
+/**
+ * Hack for macos<br>
+ * See <a href="https://github.com/libgdx/libgdx/issues/6897">libgdx #6897</a>
+ */
+public class SpriteBatchHelper {
+    public static ShaderProgram createSpriteBatchShader() {
+        // @formatter:off
+        String vertexShader = "#version 150\n" //
+                + "in vec4 " + ShaderProgram.POSITION_ATTRIBUTE + ";\n" //
+                + "in vec4 " + ShaderProgram.COLOR_ATTRIBUTE + ";\n" //
+                + "in vec2 " + ShaderProgram.TEXCOORD_ATTRIBUTE + "0;\n" //
+                + "uniform mat4 u_projTrans;\n" //
+                + "out vec4 v_color;\n" //
+                + "out vec2 v_texCoords;\n" //
+                + "\n" //
+                + "void main()\n" //
+                + "{\n" //
+                + "   v_color = " + ShaderProgram.COLOR_ATTRIBUTE + ";\n" //
+                + "   v_color.a = v_color.a * (255.0/254.0);\n" //
+                + "   v_texCoords = " + ShaderProgram.TEXCOORD_ATTRIBUTE
+                + "0;\n" //
+                + "   gl_Position =  u_projTrans * "
+                + ShaderProgram.POSITION_ATTRIBUTE + ";\n" //
+                + "}\n";
+        String fragmentShader = "#version 150\n" //
+                + "#ifdef GL_ES\n" //
+                + "#define LOWP lowp\n" //
+                + "precision mediump float;\n" //
+                + "#else\n" //
+                + "#define LOWP \n" //
+                + "#endif\n" //
+                + "in LOWP vec4 v_color;\n" //
+                + "in vec2 v_texCoords;\n" //
+                + "uniform sampler2D u_texture;\n" //
+                + "out vec4 fragColor;\n" + "void main()\n"//
+                + "{\n" //
+                + "  fragColor = v_color * texture(u_texture, v_texCoords);\n" //
+                + "}";
+        // @formatter:on
+        return ShaderProgramFactory.fromString(vertexShader, fragmentShader,
+                true, true);
+    }
+
+    public static SpriteBatch createSpriteBatch() {
+        return new SpriteBatch(1000,
+                ShaderCompatibilityHelper.mustUse32CShader()
+                        ? createSpriteBatchShader()
+                        : null);
+    }
+}

--- a/core/src/bms/player/beatoraja/config/KeyConfiguration.java
+++ b/core/src/bms/player/beatoraja/config/KeyConfiguration.java
@@ -1,27 +1,32 @@
 package bms.player.beatoraja.config;
 
+import bms.model.Mode;
+import bms.player.beatoraja.*;
+import bms.player.beatoraja.PlayModeConfig.ControllerConfig;
+import bms.player.beatoraja.PlayModeConfig.KeyboardConfig;
+import bms.player.beatoraja.PlayModeConfig.MidiConfig;
+import bms.player.beatoraja.input.BMControllerInputProcessor;
+import bms.player.beatoraja.input.BMSPlayerInputProcessor;
+import bms.player.beatoraja.input.KeyBoardInputProcesseor;
+import bms.player.beatoraja.input.KeyBoardInputProcesseor.ControlKeys;
+import bms.player.beatoraja.input.MidiInputProcessor;
 import bms.player.beatoraja.skin.SkinHeader;
 import bms.player.beatoraja.skin.SkinType;
-
-import java.util.logging.Logger;
-
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator.FreeTypeFontParameter;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import space.earlygrey.shapedrawer.ShapeDrawer;
 
-import bms.model.Mode;
-import bms.player.beatoraja.*;
-import bms.player.beatoraja.PlayModeConfig.*;
-import bms.player.beatoraja.input.*;
-import bms.player.beatoraja.input.KeyBoardInputProcesseor.ControlKeys;
+import java.util.logging.Logger;
 
 /**
  * キーコンフィグ画面
@@ -75,7 +80,7 @@ public class KeyConfiguration extends MainState {
 
 	private int mode = 0;
 
-	private ShapeRenderer shape;
+	private ShapeDrawer shape;
 
 	private BMSPlayerInputProcessor input;
 	private KeyBoardInputProcesseor keyboard;
@@ -92,7 +97,6 @@ public class KeyConfiguration extends MainState {
 
 	public KeyConfiguration(MainController main) {
 		super(main);
-
 	}
 
 	public void create() {
@@ -115,8 +119,6 @@ public class KeyConfiguration extends MainState {
 			Logger.getGlobal().severe("Font読み込み失敗");
 		}
 
-		shape = new ShapeRenderer();
-
 		input = main.getInputProcessor();
 		keyboard = input.getKeyBoardInputProcesseor();
 		controllers = input.getBMInputProcessor();
@@ -131,6 +133,15 @@ public class KeyConfiguration extends MainState {
 		final SpriteBatch sprite = main.getSpriteBatch();
 		final float scaleX = (float) getSkin().getScaleX();
 		final float scaleY = (float) getSkin().getScaleY();
+
+		if (this.shape == null) {
+			Pixmap plainPixmap = new Pixmap(2,1, Pixmap.Format.RGBA8888);
+			plainPixmap.setColor(Color.WHITE);
+			plainPixmap.drawPixel(0, 0);
+			Texture plainTexture = new Texture(plainPixmap);
+			plainPixmap.dispose();
+			this.shape = new ShapeDrawer(sprite, new TextureRegion(plainTexture, 0, 0, 1, 1));
+		}
 
 		Gdx.gl.glClearColor(0, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
@@ -286,12 +297,12 @@ public class KeyConfiguration extends MainState {
 		for (int i = scrollpos; i < keys.length; i++) {
 			int y = 576 - (i - scrollpos) * 24;
 			if (i == cursorpos) {
-				shape.begin(ShapeType.Filled);
+				sprite.begin();
 				shape.setColor(keyinput ? Color.RED : Color.BLUE);
-				shape.rect(200 * scaleX, y * scaleY, 80 * scaleX, 24 * scaleY);
-				shape.rect(350 * scaleX, y * scaleY, 80 * scaleX, 24 * scaleY);
-				shape.rect(650 * scaleX, y * scaleY, 80 * scaleX, 24 * scaleY);
-				shape.end();
+				shape.filledRectangle(200 * scaleX, y * scaleY, 80 * scaleX, 24 * scaleY);
+				shape.filledRectangle(350 * scaleX, y * scaleY, 80 * scaleX, 24 * scaleY);
+				shape.filledRectangle(650 * scaleX, y * scaleY, 80 * scaleX, 24 * scaleY);
+				sprite.end();
 			}
 			sprite.begin();
 			if(titlefont != null) {
@@ -595,10 +606,6 @@ public class KeyConfiguration extends MainState {
 		if (titlefont != null) {
 			titlefont.dispose();
 			titlefont = null;
-		}
-		if (shape != null) {
-			shape.dispose();
-			shape = null;
 		}
 	}
 }

--- a/core/src/bms/player/beatoraja/select/MusicSelectCommand.java
+++ b/core/src/bms/player/beatoraja/select/MusicSelectCommand.java
@@ -1,6 +1,11 @@
 package bms.player.beatoraja.select;
 
-import static bms.player.beatoraja.SystemSoundManager.SoundType.*;
+import bms.player.beatoraja.select.bar.*;
+import bms.player.beatoraja.song.SongData;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.utils.Queue;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
 
 import java.util.Arrays;
 import java.util.List;
@@ -8,18 +13,11 @@ import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import bms.player.beatoraja.select.bar.*;
-import bms.player.beatoraja.song.SongData;
-
-import java.awt.datatransfer.StringSelection;
-import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
-
-import com.badlogic.gdx.utils.Queue;
-import com.badlogic.gdx.graphics.Color;
+import static bms.player.beatoraja.SystemSoundManager.SoundType.FOLDER_OPEN;
+import static bms.player.beatoraja.SystemSoundManager.SoundType.OPTION_CHANGE;
 
 public enum MusicSelectCommand {
-	
+
 	// TODO 最終的には全てEventFactoryへ移動
 
 	RESET_REPLAY(selector -> {
@@ -66,9 +64,13 @@ public enum MusicSelectCommand {
 			if (song != null) {
 				String hash = song.getMd5();
 				if (hash != null && hash.length() > 0) {
-					StringSelection stringSelection = new StringSelection(hash);
-					Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-					clipboard.setContents(stringSelection, null);
+                    // NOTE: Previous clipboard management is using the java.awt library
+                    // which is broken only on macos.
+                    // COPY_SHA256_HASH has the same issue
+					Clipboard clipboard = Clipboard.getSystemClipboard();
+                    ClipboardContent clipboardContent = new ClipboardContent();
+                    clipboardContent.putString(hash);
+                    clipboard.setContent(clipboardContent);
 					selector.main.getMessageRenderer().addMessage("MD5 hash copied : " + hash, 2000, Color.GOLD, 0);
 				}
 			}
@@ -83,9 +85,10 @@ public enum MusicSelectCommand {
 			if (song != null) {
 				String hash = song.getSha256();
 				if (hash != null && hash.length() > 0) {
-					StringSelection stringSelection = new StringSelection(hash);
-					Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-					clipboard.setContents(stringSelection, null);
+					Clipboard clipboard = Clipboard.getSystemClipboard();
+                    ClipboardContent clipboardContent = new ClipboardContent();
+                    clipboardContent.putString(hash);
+                    clipboard.setContent(clipboardContent);
 					selector.main.getMessageRenderer().addMessage("SHA256 hash copied : " + hash, 2000, Color.GOLD, 0);
 				}
 			}

--- a/core/src/bms/player/beatoraja/select/SearchTextField.java
+++ b/core/src/bms/player/beatoraja/select/SearchTextField.java
@@ -1,6 +1,7 @@
 package bms.player.beatoraja.select;
 
 import bms.player.beatoraja.Resolution;
+import bms.player.beatoraja.SpriteBatchHelper;
 import bms.player.beatoraja.input.KeyBoardInputProcesseor.ControlKeys;
 import bms.player.beatoraja.select.bar.SearchWordBar;
 
@@ -47,7 +48,7 @@ public class SearchTextField extends Stage {
 	private Group screen;
 
 	public SearchTextField(MusicSelector selector, Resolution resolution) {
-		super(new FitViewport(resolution.width, resolution.height));
+		super(new FitViewport(resolution.width, resolution.height), SpriteBatchHelper.createSpriteBatch());
 
 		final Rectangle r = ((MusicSelectSkin) selector.getSkin()).getSearchTextRegion();
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,20 +2,23 @@
 beatoraja = "0.8.8-endlessdream"
 endlessdream = "0.3.0"
 kotlin = "1.9.20"
-gdx = "1.12.1"
+gdx = "1.13.0"
 gdx-controllers = "2.2.3"
 lwjgl = "3.3.3"
-imgui = "1.86.11"
+imgui = "1.86.12"
 javacv = "1.5.9"
 ffmpeg = "6.0-1.5.9"
 jflac = "1.5.2"
 commons-codec = "1.15"
 commons-compress = "1.16.1"
 commons-dbutils = "1.6"
-sqlite = "3.23.1"
+sqlite = "3.42.0.0"
 jackson = "2.13.4"
 twitter4j = "4.0.4"
 java-discord = "2.0.1-all"
+shapedrawer = "2.5.0"
+guacamole = "0.3.5"
+
 
 [libraries]
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -30,6 +33,9 @@ gdx-controllers = { group = "com.badlogicgames.gdx", name = "gdx-", version.ref 
 
 gdx-controllers-core = { group = "com.badlogicgames.gdx-controllers", name = "gdx-controllers-core", version.ref = "gdx-controllers" }
 gdx-controllers-desktop = { group = "com.badlogicgames.gdx-controllers", name = "gdx-controllers-desktop", version.ref = "gdx-controllers" }
+
+shapedrawer = { group = "space.earlygrey", name = "shapedrawer", version.ref = "shapedrawer" }
+guacamole = { group = "com.github.crykn.guacamole", name = "gdx", version.ref = "guacamole" }
 
 lwjgl = { group = "org.lwjgl", name = "lwjgl", version.ref = "lwjgl" }
 lwjgl-glfw = { group = "org.lwjgl", name = "lwjgl-glfw", version.ref = "lwjgl" }


### PR DESCRIPTION
This commit makes it possible to run endless dream on MacOS(arm based, one x86 mac user confirms it is working).

## Details:
- Upgrade imgui 1.86.11 -> 1.86.12 and sqlite 3.23.1 -> 3.42.0 and a
new property `arch`(`x86-64` or `aarch64`) to get support for macos
binding and the correct dependency.
- Replace `new SpriteBatch()` with
`SpriteBatchHelper.createSpriteBatch()`. Default `SpriteBatch`
constructor involves a shader that macos cannot complie.
- Replace `ShapeRenderer` with `ShapeDrawer`, the old one has the
similar shader problem which directly crashes when opening key-config
menu.
- Upgrading libgdx 1.12.1 -> 1.13.0 to solve fps issue
- Replace `java.awt.Clipboard` with `javafx.Clipboard`, the clipboard
support from awt is **only** broken on macos.
- Update readme
- Update github workflow
- Rearrange the frame's color order on MacOS only, which is grabbed by ffmpeg

## Drop-in compatibility:
Tested on several windows and linux machines, one glitch found for macos user only:

- Cannot play video contents' color correctly 

This could be fixed by handling the color order manually but I still have no idea why this is happening. And know nothing about the performance impact or compatibility issue (e.g. what if other video format doesn't have this issue?).

This pr contains two danger changes:

- ~~Might be broken on old machines(see the comments from [here](https://github.com/seraxis/lr2oraja-endlessdream/blob/79e456191231c20989088d6002558b675011f2ec/core/src/bms/player/beatoraja/MainLoader.java#L132))~~ This line is now macos only.
- The clipboard support from `java.awt.Toolkit` is only broken on macos and this pr replaces it with the one from `javafx`. See [here](https://github.com/seraxis/lr2oraja-endlessdream/blob/79e456191231c20989088d6002558b675011f2ec/core/src/bms/player/beatoraja/select/MusicSelectCommand.java#L67)