### PR TITLE
BugFix: Avoid constructing overlength sql

### DIFF
--- a/core/src/bms/player/beatoraja/ScoreDatabaseAccessor.java
+++ b/core/src/bms/player/beatoraja/ScoreDatabaseAccessor.java
@@ -26,6 +26,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 	private final ResultSetHandler<List<PlayerInformation>> infoHandler = new BeanListHandler<PlayerInformation>(PlayerInformation.class);
 	private final ResultSetHandler<List<ScoreData>> scoreHandler = new BeanListHandler<ScoreData>(ScoreData.class);
 	private final ResultSetHandler<List<PlayerData>> playerHandler = new BeanListHandler<PlayerData>(PlayerData.class);
+	private static final int LOAD_CHUNK_SIZE = 1000;
 
 	public ScoreDatabaseAccessor(String path) throws ClassNotFoundException {
 		super(new Table("info", 
@@ -157,17 +158,28 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 	
 	private void getScoreDatas(ScoreDataCollector collector, SongData[] songs, int mode, StringBuilder str, boolean hasln) {
 		try {
-			for (SongData song : songs) {
-				if((hasln && song.hasUndefinedLongNote()) || (!hasln && !song.hasUndefinedLongNote())) {
-					if (str.length() > 0) {
-						str.append(',');
+			int songLength = songs.length;
+			int chunkLength = (songLength + LOAD_CHUNK_SIZE - 1) / LOAD_CHUNK_SIZE;
+			List<ScoreData> scores = new ArrayList<>();
+			for (int i = 0; i < chunkLength;++i) {
+				// [i * CHUNK_SIZE, min(length, (i + 1) * CHUNK_SIZE)
+				final int chunkStart = i * LOAD_CHUNK_SIZE;
+				final int chunkEnd = Math.min(songLength, (i + 1) * LOAD_CHUNK_SIZE);
+				for (int j = chunkStart; j < chunkEnd; ++j) {
+					SongData song = songs[j];
+					if((hasln && song.hasUndefinedLongNote()) || (!hasln && !song.hasUndefinedLongNote())) {
+						if (str.length() > 0) {
+							str.append(',');
+						}
+						str.append('\'').append(song.getSha256()).append('\'');
 					}
-					str.append('\'').append(song.getSha256()).append('\'');					
 				}
-			}
 
-			List<ScoreData> scores = Validatable.removeInvalidElements(qr
-					.query("SELECT * FROM score WHERE sha256 IN (" + str.toString() + ") AND mode = " + mode, scoreHandler));
+				List<ScoreData> subScores = Validatable.removeInvalidElements(qr
+						.query("SELECT * FROM score WHERE sha256 IN (" + str.toString() + ") AND mode = " + mode, scoreHandler));
+				str.setLength(0);
+				scores.addAll(subScores);
+			}
 			for(SongData song : songs) {
 				if((hasln && song.hasUndefinedLongNote()) || (!hasln && !song.hasUndefinedLongNote())) {
 					boolean b = true;
@@ -179,8 +191,8 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 						}
 					}
 					if(b) {
-						collector.collect(song, null);					
-					}					
+						collector.collect(song, null);
+					}
 				}
 			}
 		} catch (Exception e) {

--- a/core/src/bms/player/beatoraja/song/SongInformationAccessor.java
+++ b/core/src/bms/player/beatoraja/song/SongInformationAccessor.java
@@ -2,6 +2,7 @@ package bms.player.beatoraja.song;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -33,6 +34,7 @@ public class SongInformationAccessor extends SQLiteDatabaseAccessor {
 	private final QueryRunner qr;
 
 	private Connection conn;
+	private final static int LOAD_CHUNK_SIZE = 1000;
 
 	public SongInformationAccessor(String filepath) throws ClassNotFoundException {
 		super(new Table("information", 
@@ -89,21 +91,32 @@ public class SongInformationAccessor extends SQLiteDatabaseAccessor {
 
 	public void getInformation(SongData[] songs) {
 		try {
-			StringBuilder str = new StringBuilder(songs.length * 64);
-			for (SongData song : songs) {
-				if(song.getSha256() != null) {
-					if (str.length() > 0) {
-						str.append(',');
+			int songLength = songs.length;
+			int chunkLength = (songLength + LOAD_CHUNK_SIZE - 1) / LOAD_CHUNK_SIZE;
+			List<SongInformation> infos = new ArrayList<>();
+			for (int i = 0; i < chunkLength;++i) {
+				// [i * CHUNK_SIZE, min(length, (i + 1) * CHUNK_SIZE)
+				final int chunkStart = i * LOAD_CHUNK_SIZE;
+				final int chunkEnd = Math.min(songLength, (i + 1) * LOAD_CHUNK_SIZE);
+				for (int j = chunkStart; j < chunkEnd; ++j) {
+					SongData song = songs[j];
+					StringBuilder str = new StringBuilder(songs.length * 64);
+					if (song.getSha256() != null) {
+						if (str.length() > 0) {
+							str.append(',');
+						}
+						str.append('\'').append(song.getSha256()).append('\'');
 					}
-					str.append('\'').append(song.getSha256()).append('\'');
+
+					List<SongInformation> subInfos = Validatable.removeInvalidElements(qr
+							.query("SELECT * FROM information WHERE sha256 IN (" + str + ")", songhandler));
+					infos.addAll(subInfos);
+					str.setLength(0);
 				}
 			}
-
-			List<SongInformation> infos = Validatable.removeInvalidElements(qr
-					.query("SELECT * FROM information WHERE sha256 IN (" + str.toString() + ")", songhandler));
-			for(SongData song : songs) {
-				for(SongInformation info : infos) {
-					if(info.getSha256().equals(song.getSha256())) {
+			for (SongData song : songs) {
+				for (SongInformation info : infos) {
+					if (info.getSha256().equals(song.getSha256())) {
 						song.setInformation(info);
 						break;
 					}


### PR DESCRIPTION
Problem: If you happen to have a very big BMS directory, this exception might occur:
```
严重: スコア取得時の例外:[SQLITE_TOOBIG] String or BLOB exceeds size
limit (statement too long) Query: SELECT * FROM score WHERE sha256 IN
(...)`
```

And the whole sqlite query statement would be printed in log file.

This commit fixed two overlength sql generate code place by forcing them to query data chunk by chunk. And one chunk size is set to be 1000.