### PR TITLE
play timing properties rework

### DIFF
--- a/core/src/bms/player/beatoraja/ScoreData.java
+++ b/core/src/bms/player/beatoraja/ScoreData.java
@@ -85,6 +85,12 @@ public class ScoreData implements Validatable {
 	private long avgjudge = Long.MAX_VALUE;
 	
 	private long totalDuration = 0;
+
+	private long avg = Long.MAX_VALUE;
+
+	private long totalAvg = 0;
+
+	private long stddev = Long.MAX_VALUE;
 	/**
 	 * 各譜面オプションのクリア履歴
 	 */
@@ -353,9 +359,21 @@ public class ScoreData implements Validatable {
 		return totalDuration;
 	}
 
-	public void setTotalDuration(long ttoalDuration) {
-		this.totalDuration = ttoalDuration;
+	public void setTotalDuration(long totalDuration) {
+		this.totalDuration = totalDuration;
 	}
+
+	public long getAvg() { return avg; }
+
+	public void setAvg(long avg) { this.avg = avg; }
+
+	public void setTotalAvg(long totalAvg) { this.totalAvg = totalAvg; }
+
+	public long getTotalAvg() { return totalAvg; }
+
+	public long getStddev() { return stddev; }
+
+	public void setStddev(long stddev) { this.stddev = stddev; }
 
 	public String getTrophy() {
 		return trophy;

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -890,9 +890,11 @@ public class BMSPlayer extends MainState {
 
 		score.setPassnotes(judge.getPastNotes());
 		score.setMinbp(score.getEbd() + score.getLbd() + score.getEpr() + score.getLpr() + score.getEms() + score.getLms() + resource.getSongdata().getNotes() - judge.getPastNotes());
-		
-		long count = 0;
+
 		long avgduration = 0;
+		long average = 0;
+		long stddev = 0;
+		ArrayList<Long> playTimes = new ArrayList<Long>();
 		final int lanes = model.getMode().key;
 		for (TimeLine tl : model.getAllTimeLines()) {
 			for (int i = 0; i < lanes; i++) {
@@ -903,15 +905,29 @@ public class BMSPlayer extends MainState {
 								&& ((LongNote) n).isEnd())))) {
 					int state = n.getState();
 					long time = n.getMicroPlayTime();
-					avgduration += state >= 1 && state <= 4 ? Math.abs(time) : 1000000;
-					count++;
-//					System.out.println(time);
+					if (state >= 1 && state <= 4) {
+						playTimes.add(time);
+						avgduration += Math.abs(time);
+						average += time;
+					}
 				}
 			}
 		}
 		score.setTotalDuration(avgduration);
-		score.setAvgjudge(avgduration / count);
-//		System.out.println(avgduration + " / " + count + " = " + score.getAvgjudge());
+		score.setTotalAvg(average);
+		if (!playTimes.isEmpty()) {
+			score.setAvgjudge(avgduration / playTimes.size());
+			score.setAvg(average / playTimes.size());
+		}
+
+		for (long time : playTimes) {
+			long meanOffset = time - score.getAvg();
+			stddev += meanOffset * meanOffset;
+		}
+		if (!playTimes.isEmpty()) {
+			stddev = (long)Math.sqrt((double)(stddev / playTimes.size()));
+		}
+		score.setStddev(stddev);
 
 		score.setDeviceType(main.getInputProcessor().getDeviceType());
 		score.setSkin(getSkin().header.getName());

--- a/core/src/bms/player/beatoraja/result/AbstractResult.java
+++ b/core/src/bms/player/beatoraja/result/AbstractResult.java
@@ -41,6 +41,10 @@ public abstract class AbstractResult extends MainState {
 	 * 全ノーツの平均ズレ(us)
 	 */
 	protected long avgduration;
+
+	protected long avg;
+
+	protected long stddev;
 	/**
 	 * タイミング分布
 	 */
@@ -233,6 +237,10 @@ public abstract class AbstractResult extends MainState {
 	public long getAverageDuration() {
 		return avgduration;
 	}
+
+	public long getAverage() { return avg; }
+
+	public long getStddev() { return stddev; }
 	
 	public abstract ScoreData getNewScore();
 	

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -347,6 +347,8 @@ public class MusicResult extends AbstractResult {
 		// duration average
 		int count = 0;
 		avgduration = newscore.getAvgjudge();
+		avg = newscore.getAvg();
+		stddev = newscore.getStddev();
 		timingDistribution.init();
 		BMSModel model = resource.getBMSModel();
 		final int lanes = model.getMode().key;

--- a/core/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -746,22 +746,27 @@ public class IntegerPropertyFactory {
 			}
 			return Integer.MIN_VALUE;
 		}),
-		timing_average(374, state -> (state instanceof AbstractResult result ? (int) result.getTimingDistribution().getAverage() : Integer.MIN_VALUE)),
-		timing_average_afterdot(375, (state) -> {
+		timing_average(374, (state) -> {
 			if (state instanceof AbstractResult) {
-				TimingDistribution timingDistribution = ((AbstractResult) state).getTimingDistribution();
-				if (timingDistribution.getAverage() >= 0.0) {
-					return (int) (timingDistribution.getAverage() * 100) % 100;
-				} else {
-					return (int) ( -1 * ((Math.abs(timingDistribution.getAverage()) * 100) % 100));
-				}
+				return (int) (((AbstractResult) state).getAverage() / 1000);
 			}
 			return Integer.MIN_VALUE;
 		}),
-		timing_stddev(376, (state) -> (state instanceof AbstractResult result ? (int) result.getTimingDistribution().getStdDev() :  Integer.MIN_VALUE)),
+		timing_average_afterdot(375, (state) -> {
+			if (state instanceof AbstractResult) {
+				return (int) ((((AbstractResult) state).getAverage() / 10) % 100);
+			}
+			return Integer.MIN_VALUE;
+		}),
+		timing_stddev(376, (state) -> {
+			if (state instanceof AbstractResult) {
+				return (int) (((AbstractResult) state).getStddev() / 1000);
+			}
+			return Integer.MIN_VALUE;
+		}),
 		timing_atddev_afterdot(377, (state) -> {
 			if (state instanceof AbstractResult) {
-				return (int) (((AbstractResult) state).getTimingDistribution().getStdDev() * 100) % 100;
+				return (int) ((((AbstractResult) state).getStddev() / 10) % 100);
 			}
 			return Integer.MIN_VALUE;
 		}),


### PR DESCRIPTION
This modifies the calculation for values of DURATION, MEAN and STDDEV.

DURATION: it calculates the average judgement you get while playing the chart, as the average unsigned value of hit offset. Originally, missed notes impact this value, there they got the 1 second offset, which makes average value meaningless if you didnt play the chart fully. Even when you did play it whole, i dont believe including missed judgements has any meaning, and skews the resulting value greatly.
 
MEAN and STDDEV: those two values are originally calculated from a dataset meant for building the timing graph. This dataset is imprecise and strips your hits from actual offset values, instead its in a form of timing distribution, and timing values are assumed from it. This results in those values being imprecise, and in my opinion fractions of a millisecond matter in their case. This PR calculates them from hit offset data, just like DURATION does.