### PR TITLE
block start and sel settings on play end sub-states

### DIFF
--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -690,6 +690,8 @@ public class BMSPlayer extends MainState {
 			}
 			// 閉店処理
 			case STATE_FAILED -> {
+                control.setEnableControl(false);
+                control.setEnableCursor(false);
 				keyinput.stopJudge();
 				keysound.stopBGPlay();
 				if ((input.startPressed() ^ input.isSelectPressed()) && resource.getCourseBMSModels() == null
@@ -742,7 +744,9 @@ public class BMSPlayer extends MainState {
 			}
 			// 完奏処理
 			case STATE_FINISHED -> {
-				keyinput.stopJudge();
+                control.setEnableControl(false);
+                control.setEnableCursor(false);
+                keyinput.stopJudge();
 				keysound.stopBGPlay();
 				if (timer.getNowTime(TIMER_MUSIC_END) > skin.getFinishMargin()) {
 					timer.switchTimer(TIMER_FADEOUT, true);


### PR DESCRIPTION
This blocks the ability to change settings like green number or lanecover through holding START or SELECT at play scene, when you are at "stopped playing" sub-states. This greatly reduces the number of accidental value changes when playing on controller, as START button can be pressed to skip the fade-out animation, and your turntable may be spinning at this moment from inertia of last scratch note, resulting in unintentional lanecover position change.