### PR TITLE
feat: open full-screen mode at specified monitor

### DIFF
--- a/core/src/bms/player/beatoraja/Config.java
+++ b/core/src/bms/player/beatoraja/Config.java
@@ -164,6 +164,7 @@ public class Config implements Validatable {
 
 	private boolean useDiscordRPC = false;
 	private boolean setClipboardScreenshot = false;
+	private String monitorName = "";
 
 	private static final String[] DEFAULT_TABLEURL = { "http://bmsnormal2.syuriken.jp/table.html",
 			"http://bmsnormal2.syuriken.jp/table_insane.html",
@@ -514,6 +515,14 @@ public class Config implements Validatable {
 
 	public void setMessagefontpath(String messagefontpath) {
 		this.messagefontpath = messagefontpath;
+	}
+
+	public String getMonitorName() {
+		return monitorName;
+	}
+
+	public void setMonitorName(String monitorName) {
+		this.monitorName = monitorName;
 	}
 
 	public boolean validate() {

--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -11,6 +11,7 @@ import javax.swing.JOptionPane;
 
 import bms.player.beatoraja.exceptions.PlayerConfigException;
 import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -130,40 +131,80 @@ public class MainLoader extends Application {
 
 			Lwjgl3ApplicationConfiguration gdxConfig = new Lwjgl3ApplicationConfiguration();
 
-			final int w = config.getResolution().width;
-			final int h = config.getResolution().height;
-			if (config.getDisplaymode() == Config.DisplayMode.FULLSCREEN) {
-				Graphics.DisplayMode d = null;
-				for (Graphics.DisplayMode display : Lwjgl3ApplicationConfiguration.getDisplayModes()) {
-					System.out.println("available DisplayMode : w - " + display.width + " h - " + display.height
-							+ " refresh - " + display.refreshRate + " color bit - " + display.bitsPerPixel);
-					if (display.width == w
-							&& display.height == h
-							&& (d == null || (d.refreshRate <= display.refreshRate && d.bitsPerPixel <= display.bitsPerPixel))) {
-						d = display;
-					}
-				}
-				if (d != null) {
-					gdxConfig.setFullscreenMode(d);
-				} else {
-					gdxConfig.setWindowedMode(w, h);
-				}
-			} else {
-				if (config.getDisplaymode() == Config.DisplayMode.BORDERLESS) {
+            final int w = config.getResolution().width;
+            final int h = config.getResolution().height;
+            String targetMonitorName = config.getMonitorName();
+            Graphics.Monitor targetMonitor = null;
+			Graphics.DisplayMode gdxDisplayMode = null;
+            if (targetMonitorName != null && !targetMonitorName.isEmpty()) {
+                Optional<Graphics.Monitor> optMonitor = Arrays.stream(Lwjgl3ApplicationConfiguration.getMonitors())
+                        .filter(monitor -> monitor.name.equals(targetMonitorName))
+                        .findAny();
+                if (optMonitor.isPresent()) {
+                    targetMonitor = optMonitor.get();
+                }
+            }
+            if (config.getDisplaymode() == Config.DisplayMode.FULLSCREEN) {
+                Graphics.DisplayMode d = null;
+                Graphics.DisplayMode[] displayModes = Lwjgl3ApplicationConfiguration.getDisplayModes();
+                if (targetMonitor != null) {
+                    displayModes = Lwjgl3ApplicationConfiguration.getDisplayModes(targetMonitor);
+                }
+                for (Graphics.DisplayMode display : displayModes) {
+                    System.out.println("available DisplayMode : w - " + display.width + " h - " + display.height
+                            + " refresh - " + display.refreshRate + " color bit - " + display.bitsPerPixel);
+                    if (display.width == w
+                            && display.height == h
+                            && (d == null || (d.refreshRate <= display.refreshRate && d.bitsPerPixel <= display.bitsPerPixel))) {
+                        d = display;
+                    }
+                }
+
+                if (d != null) {
 					gdxConfig.setDecorated(false);
-					//System.setProperty("org.lwjgl.opengl.Window.undecorated", "true");
-				}
-				gdxConfig.setWindowedMode(w, h);
-			}
-			// vSync
-			gdxConfig.useVsync(config.isVsync());
-			gdxConfig.setIdleFPS(config.getMaxFramePerSecond());
-			gdxConfig.setForegroundFPS(config.getMaxFramePerSecond());
-			gdxConfig.setTitle(MainController.getVersion());
+					gdxConfig.setWindowedMode(w, h);
+                    // Move screen to the correct monitor position
+                    if (targetMonitor != null) {
+                        int posX = targetMonitor.virtualX;
+                        int posY = targetMonitor.virtualY;
+                        gdxConfig.setWindowPosition(posX, posY);
+                    }
+					gdxDisplayMode = d;
+                } else {
+                    gdxConfig.setWindowedMode(w, h);
+					if (targetMonitor != null) {
+						gdxDisplayMode = Lwjgl3ApplicationConfiguration.getDisplayMode(targetMonitor);
+					} else {
+						gdxDisplayMode = Lwjgl3ApplicationConfiguration.getDisplayMode();
+					}
+                }
+            } else {
+                if (config.getDisplaymode() == Config.DisplayMode.BORDERLESS) {
+                    gdxConfig.setDecorated(false);
+                    //System.setProperty("org.lwjgl.opengl.Window.undecorated", "true");
+                }
+                gdxConfig.setWindowedMode(w, h);
+                if (targetMonitor != null) {
+                    Graphics.DisplayMode d = Lwjgl3ApplicationConfiguration.getDisplayMode(targetMonitor);
+                    int posX = targetMonitor.virtualX;
+                    int posY = targetMonitor.virtualY;
+                    gdxConfig.setWindowPosition(posX, posY);
+					gdxDisplayMode = d;
+                } else {
+					gdxDisplayMode = Lwjgl3ApplicationConfiguration.getDisplayMode();
+                }
+            }
+            // vSync
+            gdxConfig.useVsync(config.isVsync());
+            gdxConfig.setIdleFPS(config.getMaxFramePerSecond());
+            gdxConfig.setForegroundFPS(config.getMaxFramePerSecond());
+            gdxConfig.setTitle(MainController.getVersion());
 
 			gdxConfig.setAudioConfig(config.getAudioConfig().getDeviceSimultaneousSources(), config.getAudioConfig().getDeviceBufferSize(), 1);
 
+			Config.DisplayMode displaymode = config.getDisplaymode();
 			//new Lwjgl3Application(main, gdxConfig);
+			Graphics.DisplayMode finalGdxDisplayMode = gdxDisplayMode;
 			new Lwjgl3Application(new ApplicationListener() {
 				public void resume() {
 					main.resume();
@@ -187,6 +228,9 @@ public class MainLoader extends Application {
 
 				public void create() {
 					main.create();
+					if (displaymode == Config.DisplayMode.FULLSCREEN) {
+						Gdx.graphics.setFullscreenMode(finalGdxDisplayMode);
+					}
 				}
 			}, gdxConfig);
 			//System.exit(0);

--- a/core/src/bms/player/beatoraja/launcher/VideoConfigurationView.fxml
+++ b/core/src/bms/player/beatoraja/launcher/VideoConfigurationView.fxml
@@ -67,6 +67,9 @@
             </items>
         </ComboBox>
 
+        <Label text="%MONITOR" GridPane.rowIndex="9" GridPane.columnIndex="0" styleClass="optionLabel"/>
+        <ComboBox fx:id="monitor" GridPane.rowIndex="9" GridPane.columnIndex="1"/>
+
         <stylesheets>
             <URL value="@LauncherStyle.css"/>
         </stylesheets>

--- a/core/src/bms/player/beatoraja/launcher/VideoConfigurationView.java
+++ b/core/src/bms/player/beatoraja/launcher/VideoConfigurationView.java
@@ -5,13 +5,16 @@ import bms.player.beatoraja.MainLoader;
 import bms.player.beatoraja.PlayerConfig;
 import bms.player.beatoraja.Resolution;
 import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Spinner;
+import javafx.util.Pair;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.ResourceBundle;
 
 public class VideoConfigurationView implements Initializable {
@@ -32,17 +35,22 @@ public class VideoConfigurationView implements Initializable {
 	@FXML
 	private Spinner<Integer> missLayerTime;
 
+	@FXML
+	private ComboBox<String> monitor;
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
 		updateResolutions();
 
 		displayMode.getItems().setAll(Config.DisplayMode.values());
+		monitor.getItems().setAll(Arrays.stream(Lwjgl3ApplicationConfiguration.getMonitors()).map(monitor -> monitor.name).toList());
     }
 
     public void update(Config config) {
 		displayMode.setValue(config.getDisplaymode());
 		resolution.setValue(config.getResolution());
 		vSync.setSelected(config.isVsync());
+		monitor.setValue(config.getMonitorName());
 		bgaOp.getSelectionModel().select(config.getBga());
 		bgaExpand.getSelectionModel().select(config.getBgaExpand());
 		maxFps.getValueFactory().setValue(config.getMaxFramePerSecond());
@@ -56,6 +64,7 @@ public class VideoConfigurationView implements Initializable {
 		config.setResolution(resolution.getValue());
 		config.setDisplaymode(displayMode.getValue());
 		config.setVsync(vSync.isSelected());
+		config.setMonitorName(monitor.getValue());
 		config.setBga(bgaOp.getSelectionModel().getSelectedIndex());
 		config.setBgaExpand(bgaExpand.getSelectionModel().getSelectedIndex());
 		config.setMaxFramePerSecond(maxFps.getValue());

--- a/core/src/resources/UIResources.properties
+++ b/core/src/resources/UIResources.properties
@@ -1,6 +1,7 @@
 PLAYER_ID=Player ID
 TAB_VIDEO=Video
 DISPLAYMODE=Display Mode
+MONITOR=Monitor
 RESOLUTION=Resolution
 VSYNC=Vsync
 MAXFPS=Max FPS


### PR DESCRIPTION
This commit fixes the issue that user open full-screen mode while specify the monitor to use.

> I will refactor the code as soon as I find some time

## Details

`libgdx` doesn't provide an api allows us to open on specified monitor, but provides an api allows us speicfy the window position before opening. This commit's appoarch is first open the window in `boardless` mode and move the window to the speicifed monitor. Then once the window is created, entering full-screen mode.

> Why not `windowed` mode but `boardless` mode?
> `windowed` mode ships with a `title bar`, which would make the 
window's content moves up after entering full-screen, it looks like some of the game's content is being cut out.

## Drop-in Compatebility

This commit handles the cases that `monitor` option is empty, cannot be found to keep the drop-in compatebiliity. The only possible break is the upstream beatoraja also provides `monitor` option one day, which may have different definition that conflicts the one from this pr.