### PR TITLE
Fix build error in MSADPCMDecoder.java

### DIFF
--- a/core/src/bms/player/beatoraja/audio/MSADPCMDecoder.java
+++ b/core/src/bms/player/beatoraja/audio/MSADPCMDecoder.java
@@ -72,7 +72,9 @@ public class MSADPCMDecoder {
 
         while (in.hasRemaining()) {
 //            in.get(adpcmBlock, 0, blockSize);
-            ByteBuffer block = in.slice().limit(blockSize).order(ByteOrder.LITTLE_ENDIAN);
+            ByteBuffer block = in.slice();
+            block.limit(blockSize);
+            block = block.order(ByteOrder.LITTLE_ENDIAN);
             decode_block(out.asShortBuffer(), block);
             in.position(in.position() + blockSize);
             out.position(out.position() + blockSampleSize);


### PR DESCRIPTION
Very minor fix for a build error in #61 - could do with a quick test in-game as I don't have any affected charts on hand.

Build test run: https://github.com/llm96/lr2oraja-endlessdream/actions/runs/14550170295