### PR TITLE
fix: ir score is still wouldn't send

### DIFF
--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -98,6 +98,7 @@ public class MusicResult extends AbstractResult {
     			
     			if(send) {
     				main.irSendStatus.add(new IRSendStatus(irc.connection, resource.getSongdata(), newscore));
+					irSendStatus.add(new IRSendStatus(irc.connection, resource.getSongdata(), newscore));
     			}
         	}
 			


### PR DESCRIPTION
`irSendStatus` from `MainController` one is a retry thread, the initial one is located at `MusicResult`. However it does nothing because its `irSendStatus` is always empty. This commit fills the empty.