### PR TITLE
Hidden enable/disable on SELECT, change setCoverValue priority

### DIFF
--- a/core/src/bms/player/beatoraja/play/LaneRenderer.java
+++ b/core/src/bms/player/beatoraja/play/LaneRenderer.java
@@ -217,6 +217,10 @@ public class LaneRenderer {
 		playconfig.setHidden(hiddenCover < 0 ? 0 : (hiddenCover > 1 ? 1 : hiddenCover));
 	}
 
+	public void setEnableHidden(boolean b) {
+		playconfig.setEnablehidden(b);
+	}
+
 	public boolean isEnableHidden() {
 		return playconfig.isEnablehidden();
 	}


### PR DESCRIPTION
This allow enabling/disabling hidden cover from play scene by double press of SELECT, as well as changing every value of SUD, HID and LIFT without having to exit the scene, by changing the priority of HID vs LIFT when holding START. This way you don't need to disable lift, which is only doable from outside the scene, to change hidden cover value, but lift can be adjusted by disabling hidden cover with double press of SELECT. 