### PR TITLE
feat: in-game download through Big Sister BMS Project

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     implementation(libs.sqlite)
     implementation(libs.commons.compress)
     implementation(libs.commons.dbutils)
+    implementation(libs.xz)
 
     implementation(libs.javadiscord)
     implementation(libs.twitter4j)

--- a/core/src/bms/player/beatoraja/Config.java
+++ b/core/src/bms/player/beatoraja/Config.java
@@ -158,6 +158,8 @@ public class Config implements Validatable {
 	private int songResourceGen = 1;
 
 	private boolean enableIpfs = true;
+	// TODO: This field has no related javafx option currently
+	private boolean enableWriggle = true;
 	private String ipfsurl = "https://gateway.ipfs.io/";
 
 	private int irSendCount = 5;
@@ -622,7 +624,15 @@ public class Config implements Validatable {
 		this.useResolution = useResolution;
 	}
 
-	public enum DisplayMode {
+    public boolean isEnableWriggle() {
+        return enableWriggle;
+    }
+
+    public void setEnableWriggle(boolean enableWriggle) {
+        this.enableWriggle = enableWriggle;
+    }
+
+    public enum DisplayMode {
 		FULLSCREEN,BORDERLESS,WINDOW;
 	}
 

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 
 import bms.player.beatoraja.exceptions.PlayerConfigException;
 import bms.player.beatoraja.modmenu.ImGuiRenderer;
+import bms.tool.mdprocessor.HttpDownloadProcessor;
 import com.badlogic.gdx.*;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.g2d.*;
@@ -75,7 +76,7 @@ public class MainController {
 	private MessageRenderer messageRenderer;
 
 	private MainState current;
-	
+
 	private TimerManager timer;
 
 	private Config config;
@@ -112,7 +113,8 @@ public class MainController {
 	private Thread screenshot;
 
 	private MusicDownloadProcessor download;
-	
+	private HttpDownloadProcessor httpDownloadProcessor;
+
 	private StreamController streamController;
 
 	public static final int offsetCount = SkinProperty.OFFSET_MAX + 1;
@@ -157,6 +159,16 @@ public class MainController {
 				getConfig().setBmsroot(roots.toArray(new String[roots.size()]));
 			}
 		}
+		if (config.isEnableWriggle()) {
+			Path wrigglePath = Paths.get("wriggle_download").toAbsolutePath();
+			if (!wrigglePath.toFile().exists())
+				wrigglePath.toFile().mkdirs();
+			List<String> roots = new ArrayList<>(Arrays.asList(getConfig().getBmsroot()));
+			if (wrigglePath.toFile().exists() && !roots.contains(wrigglePath.toString())) {
+				roots.add(wrigglePath.toString());
+				getConfig().setBmsroot(roots.toArray(new String[roots.size()]));
+			}
+		}
 		try {
 			Class.forName("org.sqlite.JDBC");
 			if(config.isUseSongInfo()) {
@@ -195,7 +207,7 @@ public class MainController {
 
 		}
 		ir = irarray.toArray(IRStatus.class);
-		
+
 		rivals.update(this);
 
 		switch(config.getAudioConfig().getDriver()) {
@@ -211,7 +223,7 @@ public class MainController {
 
 		timer = new TimerManager();
 		sound = new SystemSoundManager(this);
-		
+
 		if(config.isUseDiscordRPC()) {
 			stateListener.add(new DiscordListener());
 		}
@@ -232,11 +244,11 @@ public class MainController {
 	public PlayDataAccessor getPlayDataAccessor() {
 		return playdata;
 	}
-	
+
 	public RivalDataAccessor getRivalDataAccessor() {
 		return rivals;
 	}
-	
+
 	public RankingDataCache getRankingDataCache() {
 		return ircache;
 	}
@@ -418,6 +430,10 @@ public class MainController {
 				return result;
 			});
 			download.start(null);
+		}
+
+		if (config.isEnableWriggle()) {
+			httpDownloadProcessor = new HttpDownloadProcessor();
 		}
 
 		if(ir.length > 0) {
@@ -814,6 +830,14 @@ public class MainController {
 
 	public void setMicroTimer(int id, long microtime) {
 		timer.setMicroTimer(id, microtime);
+	}
+
+	public HttpDownloadProcessor getHttpDownloadProcessor() {
+		return httpDownloadProcessor;
+	}
+
+	public void setHttpDownloadProcessor(HttpDownloadProcessor httpDownloadProcessor) {
+		this.httpDownloadProcessor = httpDownloadProcessor;
 	}
 
 	public void switchTimer(int id, boolean on) {

--- a/core/src/bms/player/beatoraja/select/MusicSelectCommand.java
+++ b/core/src/bms/player/beatoraja/select/MusicSelectCommand.java
@@ -123,6 +123,20 @@ public enum MusicSelectCommand {
 
 		}
 	}),
+	DOWNLOAD_HTTP(selector -> {
+		Bar current = selector.getBarManager().getSelected();
+		if (current instanceof SongBar) {
+			final SongData song = ((SongBar) current).getSongData();
+			if (song == null) {
+				Logger.getGlobal().info("Not a valid song bar? Skipped...");
+				return ;
+			}
+			Logger.getGlobal().info("Missing song md5: " + song.getMd5());
+			if (song.getMd5() != null && !song.getMd5().isEmpty()) {
+				selector.main.getHttpDownloadProcessor().submitMD5Task(song.getMd5());
+			}
+		}
+	}),
 	/**
 	 * 同一フォルダにある譜面を全て表示する．コースの場合は構成譜面を全て表示する
 	 */

--- a/core/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/core/src/bms/player/beatoraja/select/MusicSelector.java
@@ -271,6 +271,8 @@ public final class MusicSelector extends MainState {
 				} else if (song.getIpfs() != null && main.getMusicDownloadProcessor() != null
 						&& main.getMusicDownloadProcessor().isAlive()) {
 					execute(MusicSelectCommand.DOWNLOAD_IPFS);
+				} else if (main.getHttpDownloadProcessor() != null && main.getHttpDownloadProcessor() != null) {
+					execute(MusicSelectCommand.DOWNLOAD_HTTP);
 				} else {
 	                executeEvent(EventType.open_download_site);
 				}

--- a/core/src/bms/tool/mdprocessor/DownloadTask.java
+++ b/core/src/bms/tool/mdprocessor/DownloadTask.java
@@ -1,0 +1,98 @@
+package bms.tool.mdprocessor;
+
+import java.nio.file.Path;
+
+public class DownloadTask {
+    public enum DownloadTaskStatus {
+        Prepare(0, "Prepare"),
+        Downloading(1, "Downloading"),
+        Success(2, "Success"),
+        Error(3, "Error"),
+        Cancel(4, "Cancel");
+
+        private final int value;
+        private final String name;
+
+        DownloadTaskStatus(int value, String name) {
+            this.value = value;
+            this.name = name;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    private int id;
+    private String url;
+    private DownloadTaskStatus downloadTaskStatus;
+    private Path downloadFilePath;
+    private double downloadSize;
+    private double contentLength;
+    private String errorMessage;
+
+    public DownloadTask(String url, Path downloadFilePath) {
+        this.url = url;
+        this.downloadFilePath = downloadFilePath;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public DownloadTaskStatus getDownloadTaskStatus() {
+        return downloadTaskStatus;
+    }
+
+    public void setDownloadTaskStatus(DownloadTaskStatus downloadTaskStatus) {
+        this.downloadTaskStatus = downloadTaskStatus;
+    }
+
+    public Path getDownloadFilePath() {
+        return downloadFilePath;
+    }
+
+    public void setDownloadFilePath(Path downloadFilePath) {
+        this.downloadFilePath = downloadFilePath;
+    }
+
+    public double getDownloadSize() {
+        return downloadSize;
+    }
+
+    public void setDownloadSize(double downloadSize) {
+        this.downloadSize = downloadSize;
+    }
+
+    public double getContentLength() {
+        return contentLength;
+    }
+
+    public void setContentLength(double contentLength) {
+        this.contentLength = contentLength;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/core/src/bms/tool/mdprocessor/HttpDownloadProcessor.java
+++ b/core/src/bms/tool/mdprocessor/HttpDownloadProcessor.java
@@ -1,0 +1,61 @@
+package bms.tool.mdprocessor;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+public class HttpDownloadProcessor {
+    public static final int MAXIMUM_DOWNLOAD_COUNT = 5;
+    // id => task
+    private final Map<Integer, DownloadTask> tasks = new HashMap<>();
+    // In-memory self-add id generator
+    private final AtomicInteger idGenerator = new AtomicInteger(0);
+    // Multi-thread download thread pool
+    private final ExecutorService executor = Executors.newFixedThreadPool(MAXIMUM_DOWNLOAD_COUNT);
+
+    private Optional<DownloadTask> getTaskById(int taskId) {
+        return Optional.ofNullable(tasks.get(taskId));
+    }
+
+    /**
+     * Submit a download task based on md5
+     *
+     * @param md5 missing sabun's md5
+     */
+    public void submitMD5Task(String md5) {
+        Logger.getGlobal().info("[HttpDownloadProcessor] New md5" + md5 + " download task submitted");
+        String fileName = String.format("%s.7z", md5);
+        Path downloadFilePath = Path.of("wriggle_download", fileName);
+        DownloadTask downloadTask = new DownloadTask(String.format("https://bms.wrigglebug.xyz/download/package/%s", md5), downloadFilePath);
+        // If you want to render all tasks for user, you'll have to store all task's reference
+        // tasks.put(taskId, downloadTask);
+        executor.submit(() -> {
+            try {
+                URL url = new URL(downloadTask.getUrl());
+                ReadableByteChannel readChannel = Channels.newChannel(url.openStream());
+                try (FileOutputStream outputStream = new FileOutputStream(downloadFilePath.toFile())) {
+                    FileChannel writeChannel = outputStream.getChannel();
+                    writeChannel.transferFrom(readChannel, 0, Long.MAX_VALUE);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            } catch (FileNotFoundException e) {
+                System.out.println("No such song on wriggle site?");
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,12 +10,13 @@ javacv = "1.5.9"
 ffmpeg = "6.0-1.5.9"
 jflac = "1.5.2"
 commons-codec = "1.15"
-commons-compress = "1.16.1"
+commons-compress = "1.26.1"
 commons-dbutils = "1.6"
 sqlite = "3.23.1"
 jackson = "2.13.4"
 twitter4j = "4.0.4"
 java-discord = "2.0.1-all"
+xz = "1.10"
 
 [libraries]
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -53,6 +54,7 @@ commons-codec = { group = "commons-codec", name = "commons-codec", version.ref =
 
 commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commons-compress" }
 commons-dbutils = { group = "commons-dbutils", name = "commons-dbutils", version.ref = "commons-dbutils" }
+xz = { group = "org.tukaani", name = "xz", version.ref = "xz" }
 sqlite = { group = "org.xerial", name = "sqlite-jdbc", version.ref = "sqlite" }
 
 jackson-core = { group = "com.fasterxml.jackson.core", name = "jackson-core", version.ref = "jackson" }


### PR DESCRIPTION
## Motivation

Download missing bms in game through wriggle's [Big Sister BMS Project](https://bms.wrigglebug.xyz/).

## Current status

It's usable now but no protection has been done. Selecting a missing bms would submit the download task immediately.

## Goals

- [x] Add a in-memory download task manage module
    - [x] Create a standalone directory like `ipfs`.
    - [ ] Display downloading tasks status by using `ImGUI`
    - [ ] Download to an intermediate file and rename it
    - [x] Auto-extract the downloaded archive
    - [ ] Auto-update the download directory?
    - [ ] Send an in-game notification for user
    - [ ] Prevent duplicate downloads?
- [ ] Make download source configurable?