### PR TITLE
Upgrade Actions version and JDK Version

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -50,3 +50,4 @@ jobs:
         title: "Latest Development Build"
         files: |
           dist/*
+

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -32,7 +32,7 @@ jobs:
         java-package: jdk+fx
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v4
+      uses: gradle/actions/setup-gradle@v4
       with:
         gradle-version: wrapper
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,17 +22,17 @@ jobs:
         submodules: true
 
     - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1.0.5
+      uses: gradle/actions/wrapper-validation@v4
 
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v2
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
         distribution: liberica
-        java-version: 8.0.392+9
+        java-version: 17
         java-package: jdk+fx
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@v4
       with:
         gradle-version: wrapper
 


### PR DESCRIPTION
Since some builds were failing due to the use of an older JDK, we have changed to use JDK17, which is also a minimum requirement for beatoraja. Also, Actions used in workflow have been brought up to date.

This PR message uses DeepL for translation.