### PR TITLE
Add `SongManager` menu for rendering current reverse table lookup

### DIFF
--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 
 import bms.player.beatoraja.exceptions.PlayerConfigException;
 import bms.player.beatoraja.modmenu.ImGuiRenderer;
+import bms.player.beatoraja.modmenu.SongManagerMenu;
 import com.badlogic.gdx.*;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.g2d.*;
@@ -360,6 +361,7 @@ public class MainController {
 		    streamController = new StreamController(selector, (player.getRequestNotify() ? messageRenderer : null));
 	        streamController.run();
 		}
+		SongManagerMenu.injectMusicSelector(selector);
 		decide = new MusicDecide(this);
 		result = new MusicResult(this);
 		gresult = new CourseResult(this);

--- a/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
+++ b/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
@@ -60,7 +60,12 @@ public class ImGuiRenderer {
         rangesBuilder.addRanges(io.getFonts().getGlyphRangesDefault());
         rangesBuilder.addRanges(io.getFonts().getGlyphRangesCyrillic());
         rangesBuilder.addRanges(io.getFonts().getGlyphRangesJapanese());
-        rangesBuilder.addChar('★');
+        // TODO: After ImGUI 1.92, manual glyph setup is no longer required. We can delete this garbage line after
+        // ImGui-java has upgraded to 1.92 or above
+        // This line is provided for "reverse difficult table lookup" feature. Because some difficult tables' symbol
+        // is not baked in above glyph ranges, this line manually adds them into the ranges. Otherwise, the symbol
+        // would be rendered as a '?' in ImGUI window.
+        rangesBuilder.addText("☆★▽▼δ白黒◆◎縦≡田⇒●∽");
 
         // Font config for additional fonts
         // This is a natively allocated struct so don't forget to call destroy after atlas is built

--- a/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
+++ b/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
@@ -35,10 +35,9 @@ public class ImGuiRenderer {
 
     private static ImBoolean SHOW_MOD_MENU = new ImBoolean(false);
     private static ImBoolean SHOW_RANDOM_TRAINER = new ImBoolean(false);
-
     private static ImBoolean SHOW_FREQ_PLUS = new ImBoolean(false);
-
     private static ImBoolean SHOW_JUDGE_TRAINER = new ImBoolean(false);
+    private static ImBoolean SHOW_SONG_MANAGER = new ImBoolean(false);
 
 
     public static void init() {
@@ -61,6 +60,7 @@ public class ImGuiRenderer {
         rangesBuilder.addRanges(io.getFonts().getGlyphRangesDefault());
         rangesBuilder.addRanges(io.getFonts().getGlyphRangesCyrillic());
         rangesBuilder.addRanges(io.getFonts().getGlyphRangesJapanese());
+        rangesBuilder.addChar('★');
 
         // Font config for additional fonts
         // This is a natively allocated struct so don't forget to call destroy after atlas is built
@@ -97,6 +97,7 @@ public class ImGuiRenderer {
             ImGui.checkbox("Show Rate Modifier Window", SHOW_FREQ_PLUS);
             ImGui.checkbox("Show Random Trainer Window", SHOW_RANDOM_TRAINER);
             ImGui.checkbox("Show Judge Trainer Window", SHOW_JUDGE_TRAINER);
+            ImGui.checkbox("Show Song Manager Menu", SHOW_SONG_MANAGER);
 
             if (SHOW_FREQ_PLUS.get()) {
                 FreqTrainerMenu.show(SHOW_FREQ_PLUS);
@@ -107,7 +108,9 @@ public class ImGuiRenderer {
             if (SHOW_JUDGE_TRAINER.get()) {
                 JudgeTrainerMenu.show(SHOW_JUDGE_TRAINER);
             }
-
+            if (SHOW_SONG_MANAGER.get()) {
+                SongManagerMenu.show(SHOW_SONG_MANAGER);
+            }
 
             if (ImGui.treeNode("Controller Input Debug Information")) {
                 float axis;

--- a/core/src/bms/player/beatoraja/modmenu/SongManagerMenu.java
+++ b/core/src/bms/player/beatoraja/modmenu/SongManagerMenu.java
@@ -1,0 +1,99 @@
+package bms.player.beatoraja.modmenu;
+
+import bms.player.beatoraja.ScoreData;
+import bms.player.beatoraja.select.MusicSelector;
+import bms.player.beatoraja.select.bar.SongBar;
+import bms.player.beatoraja.song.SongData;
+import imgui.ImGui;
+import imgui.flag.ImGuiWindowFlags;
+import imgui.type.ImBoolean;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+
+public class SongManagerMenu {
+    // I cannot think of a better solution than hold a ref of MusicSelector
+    private static MusicSelector selector;
+    /**
+     * Current song's reverse lookup result
+     */
+    private static List<String> currentReverseLookupList = new ArrayList<>();
+    private static SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    public static void show(ImBoolean showSongManager) {
+        Optional<SongData> currentSongData = getCurrentSongData();
+        Optional<ScoreData> currentScoreData = getCurrentScoreData();
+        if (ImGui.begin("Song Manager", showSongManager, ImGuiWindowFlags.AlwaysAutoResize)) {
+            String songName = currentSongData.map(SongData::getTitle).orElse("");
+            String bestPlayRecordTime = currentScoreData.map(scoreData -> {
+                Date date = new Date(scoreData.getDate() * 1000L);
+                return simpleDateFormat.format(date);
+            }).orElse("No Data");
+            ImGui.text("current picking: " + songName);
+            ImGui.text("Best Record: " + bestPlayRecordTime);
+            if (songName.isEmpty()) {
+                ImGui.text("Not a selectable song");
+            } else {
+                if (ImGui.button("Show Reverse Lookup")) {
+                    updateReverseLookupData(currentSongData);
+                    ImGui.openPopup("Reverse Lookup");
+                }
+                if (ImGui.beginPopup("Reverse Lookup", ImGuiWindowFlags.AlwaysAutoResize)) {
+                    for (int i = 0;i < currentReverseLookupList.size();++i) {
+                        ImGui.pushID(i);
+                        ImGui.bulletText(currentReverseLookupList.get(i));
+                        ImGui.popID();
+                    }
+                    ImGui.endPopup();;
+                }
+            }
+        }
+        ImGui.end();
+    }
+
+    public static void injectMusicSelector(MusicSelector musicSelector) {
+        selector = musicSelector;
+    }
+
+    /**
+     * Update current reverse lookup result by current song data
+     *
+     * @param currentSongData clear reverse lookup result if empty
+     */
+    private static void updateReverseLookupData(Optional<SongData> currentSongData) {
+        if (currentSongData.isEmpty()) {
+            currentReverseLookupList.clear();
+            return ;
+        }
+        String currentMd5 = currentSongData.get().getMd5();
+        String currentSha256 = currentSongData.get().getSha256();
+
+        currentReverseLookupList = getReverseLookupData(currentMd5, currentSha256);
+    }
+
+    private static Optional<SongData> getCurrentSongData() {
+        if (selector.getSelectedBar() instanceof SongBar) {
+            final SongData sd = ((SongBar) selector.getSelectedBar()).getSongData();
+            if (sd != null && sd.getPath() != null) {
+                return Optional.of(sd);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<ScoreData> getCurrentScoreData() {
+        if (selector.getSelectedBar() instanceof SongBar) {
+            final ScoreData sd = ((SongBar) selector.getSelectedBar()).getScore();
+            return Optional.ofNullable(sd);
+        }
+        return Optional.empty();
+    }
+
+    private static List<String> getReverseLookupData(String md5, String sha256) {
+        return selector.main.getPlayerResource().getReverseLookupData(md5, sha256);
+    }
+}


### PR DESCRIPTION
close #26 

This commit adds a new menu called `Song Manager`, which is designed for rendering current song's status and providing easy access to some operations (e.g. reverse table lookup & favorite folder management).

As for now, the menu shows the `best record set time` as a "current song's status" example and `reverse table lookup` button as an "extra operations" example.

For future reviewers: this pr picks a temporary solution for adding the difficult tables' symbols, it can be deleted after ImGUI-java upgraded it's dependency version to 1.92 or above. See below comments for details.