### PR TITLE
Persist some freq related data to avoid changing freq during gameplay

### DIFF
--- a/core/src/bms/player/beatoraja/PlayerResource.java
+++ b/core/src/bms/player/beatoraja/PlayerResource.java
@@ -1,15 +1,5 @@
 package bms.player.beatoraja;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.*;
-import java.io.FileInputStream;
-import java.io.ObjectInputStream;
-import java.io.IOException;
-import java.util.logging.Logger;
-
-import com.badlogic.gdx.utils.*;
-
 import bms.model.*;
 import bms.player.beatoraja.CourseData.CourseDataConstraint;
 import bms.player.beatoraja.TableData.TableFolder;
@@ -19,6 +9,16 @@ import bms.player.beatoraja.play.BMSPlayerRule;
 import bms.player.beatoraja.play.GrooveGauge;
 import bms.player.beatoraja.play.bga.BGAProcessor;
 import bms.player.beatoraja.song.SongData;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.FloatArray;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * プレイヤーのコンポーネント間でデータをやり取りするためのクラス
@@ -127,6 +127,8 @@ public final class PlayerResource {
 	private String tablename = "";
 	private String tablelevel = "";
 	private String tablefull;
+	private boolean freqOn;
+	private String freqString;
 	// Full list of difficult tables that contains current song
 	private List<String> reverseLookup = new ArrayList<>();
 
@@ -594,5 +596,21 @@ public final class PlayerResource {
 
 	public void setOriginalMode(bms.model.Mode orgmode) {
 		this.orgmode = orgmode;
+	}
+
+	public boolean isFreqOn() {
+		return freqOn;
+	}
+
+	public void setFreqOn(boolean freqOn) {
+		this.freqOn = freqOn;
+	}
+
+	public String getFreqString() {
+		return freqString;
+	}
+
+	public void setFreqString(String freqString) {
+		this.freqString = freqString;
 	}
 }

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -204,6 +204,8 @@ public class BMSPlayer extends MainState {
 		// 通常プレイの場合は最後のノーツ、オートプレイの場合はBG/BGAを含めた最後のノーツ
 		playtime = (autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY ? model.getLastTime() : model.getLastNoteTime()) + TIME_MARGIN;
 
+		resource.setFreqOn(false);
+		resource.setFreqString("");
 		if(FreqTrainerMenu.isFreqTrainerEnabled() && autoplay.mode == BMSPlayerMode.Mode.PLAY && resource.getCourseBMSModels() == null) {
 			int freq = FreqTrainerMenu.getFreq();
 
@@ -216,6 +218,10 @@ public class BMSPlayer extends MainState {
 			if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
 				main.getAudioProcessor().setGlobalPitch(freq / 100f);
 			}
+
+			// "Persist" some states in resource
+			resource.setFreqOn(true);
+			resource.setFreqString(FreqTrainerMenu.getFreqString());
 		}
 		if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY) {
 			if (config.isBpmguide() && (model.getMinBPM() < model.getMaxBPM())) {

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -51,7 +51,7 @@ public class MusicResult extends AbstractResult {
 
 		updateScoreDatabase();
 		// リプレイの自動保存
-		if (resource.getPlayMode().mode == BMSPlayerMode.Mode.PLAY && !isFreqTrainerEnabled()) {
+		if (resource.getPlayMode().mode == BMSPlayerMode.Mode.PLAY && !resource.isFreqOn()) {
 			for (int i = 0; i < REPLAY_SIZE; i++) {
 				if (ReplayAutoSaveConstraint.get(resource.getPlayerConfig().getAutoSaveReplay()[i]).isQualified(oldscore,
 						resource.getScoreData())) {
@@ -78,7 +78,7 @@ public class MusicResult extends AbstractResult {
 		rankingOffset = 0;
 		// TODO スコアハッシュがあり、有効期限が切れていないものを送信する？
 		final IRStatus[] ir = main.getIRStatus();
-		if (ir.length > 0 && resource.getPlayMode().mode == BMSPlayerMode.Mode.PLAY && !isFreqTrainerEnabled()) {
+		if (ir.length > 0 && resource.getPlayMode().mode == BMSPlayerMode.Mode.PLAY && !resource.isFreqOn()) {
 			state = STATE_IR_PROCESSING;
 			
         	for(IRStatus irc : ir) {

--- a/core/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
@@ -82,8 +82,8 @@ public class StringPropertyFactory {
 				return state.resource.getCoursetitle();						
 			}
 			final SongData song = state.resource.getSongdata();
-			if (song != null && (state instanceof AbstractResult || state instanceof BMSPlayer) && FreqTrainerMenu.isFreqTrainerEnabled()) {
-				return FreqTrainerMenu.getFreqString() + " " + song.getTitle();
+			if (song != null && (state instanceof AbstractResult || state instanceof BMSPlayer) && state.resource.isFreqOn()) {
+				return state.resource.getFreqString() + " " + song.getTitle();
 			}
 			return song != null ? song.getTitle() : "";
 		}),
@@ -98,8 +98,8 @@ public class StringPropertyFactory {
 				return state.resource.getCoursetitle();
 			}
 			final SongData song = state.resource.getSongdata();
-			if (song != null && (state instanceof AbstractResult || state instanceof BMSPlayer) && FreqTrainerMenu.isFreqTrainerEnabled()) {
-				return FreqTrainerMenu.getFreqString() + " " + song.getFullTitle();
+			if (song != null && (state instanceof AbstractResult || state instanceof BMSPlayer) && state.resource.isFreqOn()) {
+				return state.resource.getFreqString() + " " + song.getFullTitle();
 			}
 			return song != null ? song.getFullTitle() : "";
 		}),


### PR DESCRIPTION
close #45 

This pr should fix two problems that pointed out:

- Disabling the freq trainer will confuse endless dream and think it's a normal score and submit it to IRs
- Title will be changed when changing freq during the game play

by persisting some "flags/data".

This pr intentionally leaves the local score save related code unchanged. Also the clear type won't be NO_PLAY if the user used the trick above.