### PR TITLE
Fix wrong lwjgl dependency suffix for x86 macos

### DIFF
--- a/buildSrc/src/main/kotlin/org/endlessdream/extra/PlatformFilter.kt
+++ b/buildSrc/src/main/kotlin/org/endlessdream/extra/PlatformFilter.kt
@@ -38,7 +38,7 @@ abstract class PlatformFilter : TransformAction<PlatformFilter.Parameters> {
         // Remove all platform natives for platforms other than the current one
         // hack for macos-arm64
         val lwjglSuffixName = when (parameters.platformString) {
-            "macos" -> if (parameters.archString == "aarch64") "macos-arm64" else "macos-x86_64"
+            "macos" -> if (parameters.archString == "aarch64") "macos-arm64" else "macos"
             else -> parameters.platformString
         }
         if (fileName.contains("lwjgl") && fileName.contains("natives")) {


### PR DESCRIPTION
This pr fixes the wrong filter strategy which only affects the x86 macos: the correct lwjgl dependency suffix name should be `macos` rather than `macos-x86_64`. The test has already been done on a real x86 mac.

Here is a small list for comparing:

- MacOS(arm): `lwjgl-natives-macos-arm64.jar`
- MacOS(x86): `lwjgl-natives-macos.jar`
- Windows(arm): `lwjgl-natives-windows-x86.jar` / `lwjgl-natives-windows.jar` (no idea why)
- Windows(x86): `lwjgl-natives-windows-arm64.jar`

See [here](https://www.lwjgl.org/browse/stable/bin/lwjgl) for reference