### PR TITLE
delay extract & update process of in-game download mechanism 

### DIFF
--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -136,6 +136,8 @@ public class MainController {
 
 	public List<IRSendStatus> irSendStatus = new ArrayList<IRSendStatus>();
 
+	private boolean suspendPlaySceneTransition = false;
+
 	public MainController(Path f, Config config, PlayerConfig player, BMSPlayerMode auto, boolean songUpdated) {
 		this.auto = auto;
 		this.config = config;
@@ -290,6 +292,10 @@ public class MainController {
 			newState = decide;
 			break;
 		case PLAY:
+			if (suspendPlaySceneTransition) {
+				messageRenderer.addMessage("Cannot transition to play scene, please wait!", Color.CYAN, 1);
+				return ;
+			}
 			if (bmsplayer != null) {
 				bmsplayer.dispose();
 			}
@@ -848,6 +854,14 @@ public class MainController {
 
 	public void setHttpDownloadProcessor(HttpDownloadProcessor httpDownloadProcessor) {
 		this.httpDownloadProcessor = httpDownloadProcessor;
+	}
+
+	public boolean isSuspendPlaySceneTransition() {
+		return suspendPlaySceneTransition;
+	}
+
+	public void setSuspendPlaySceneTransition(boolean suspendPlaySceneTransition) {
+		this.suspendPlaySceneTransition = suspendPlaySceneTransition;
 	}
 
 	public void switchTimer(int id, boolean on) {


### PR DESCRIPTION
Related to #83, this pr delays the two steps after downloading file:

- Extract archive file
- Update songdata.db contents

to reduce the performance impact when playing BMS

Here's a flame graph when trying to download bms at background while playing
<img width="3404" height="1939" alt="image" src="https://github.com/user-attachments/assets/c0abdd05-aed7-466d-9823-04a1f8dd520b" />
