### PR TITLE
#23: Option to skip decide screen

### DIFF
--- a/core/src/bms/player/beatoraja/Config.java
+++ b/core/src/bms/player/beatoraja/Config.java
@@ -72,6 +72,10 @@ public class Config implements Validatable {
 	 */
 	private int maxSearchBarCount = 10;
 	/**
+	 * When selecting a song, if set to true, game changes to play scene instead of decide scene
+	 */
+	private boolean skipDecideScreen = false;
+	/**
 	 * 所持していない楽曲バーを表示するかどうか
 	 */
 	private boolean showNoSongExistingBar = true;
@@ -320,6 +324,14 @@ public class Config implements Validatable {
     public void setMaxSearchBarCount(int maxSearchBarCount) {
 	    this.maxSearchBarCount = maxSearchBarCount;
     }
+
+	public void setSkipDecideScreen(boolean skipDecideScreen) {
+		this.skipDecideScreen = skipDecideScreen;
+	}
+
+	public boolean isSkipDecideScreen() {
+		return skipDecideScreen;
+	}
 
 	public boolean isShowNoSongExistingBar() {
 		return showNoSongExistingBar;
@@ -670,7 +682,7 @@ public class Config implements Validatable {
 		this.useResolution = useResolution;
 	}
 
-	public enum DisplayMode {
+    public enum DisplayMode {
 		FULLSCREEN,BORDERLESS,WINDOW;
 	}
 

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -23,7 +23,6 @@ import com.badlogic.gdx.utils.StringBuilder;
 
 import bms.player.beatoraja.AudioConfig.DriverType;
 import bms.player.beatoraja.MainState.MainStateType;
-import bms.player.beatoraja.MessageRenderer.Message;
 import bms.player.beatoraja.audio.*;
 import bms.player.beatoraja.config.KeyConfiguration;
 import bms.player.beatoraja.config.SkinConfiguration;
@@ -44,10 +43,6 @@ import bms.player.beatoraja.skin.SkinProperty;
 import bms.player.beatoraja.song.*;
 import bms.player.beatoraja.stream.StreamController;
 import bms.tool.mdprocessor.MusicDownloadProcessor;
-import de.damios.guacamole.gdx.graphics.ShaderCompatibilityHelper;
-import de.damios.guacamole.gdx.graphics.ShaderProgramFactory;
-import com.badlogic.gdx.graphics.glutils.ShaderProgram;
-import space.earlygrey.shapedrawer.ShapeDrawer;
 
 /**
  * アプリケーションのルートクラス
@@ -287,14 +282,10 @@ public class MainController {
 			}
 			break;
 		case DECIDE:
-			newState = decide;
+			newState = config.isSkipDecideScreen() ? createBMSPlayerState() : decide;
 			break;
 		case PLAY:
-			if (bmsplayer != null) {
-				bmsplayer.dispose();
-			}
-			bmsplayer = new BMSPlayer(this, resource);
-			newState = bmsplayer;
+			newState = createBMSPlayerState();
 			break;
 		case RESULT:
 			newState = result;
@@ -329,6 +320,13 @@ public class MainController {
 		} else {
 			Gdx.input.setInputProcessor(input.getKeyBoardInputProcesseor());
 		}
+	}
+
+	private MainState createBMSPlayerState() {
+		if (bmsplayer != null) {
+			bmsplayer.dispose();
+		}
+		return new BMSPlayer(this, resource);
 	}
 
 	public MainState getCurrentState() {

--- a/core/src/bms/player/beatoraja/launcher/MusicSelectConfigurationView.fxml
+++ b/core/src/bms/player/beatoraja/launcher/MusicSelectConfigurationView.fxml
@@ -81,5 +81,6 @@
         <Label text="Chart Replication Mode" prefHeight="25.0"/>
         <ComboBox fx:id="chartReplicationMode" prefHeight="25.0"/>
     </HBox>
+	<CheckBox fx:id="skipDecideScreen" mnemonicParsing="false" prefHeight="25.0" text="%SKIP_DECIDE_SCREEN" />
 </VBox>
 

--- a/core/src/bms/player/beatoraja/launcher/MusicSelectConfigurationView.java
+++ b/core/src/bms/player/beatoraja/launcher/MusicSelectConfigurationView.java
@@ -46,6 +46,9 @@ public class MusicSelectConfigurationView implements Initializable {
 	@FXML
 	private ComboBox<String> chartReplicationMode;
 
+	@FXML
+	private CheckBox skipDecideScreen;
+
     private Config config;
     private PlayerConfig player;
 
@@ -69,6 +72,7 @@ public class MusicSelectConfigurationView implements Initializable {
 		songPreview.setValue(config.getSongPreview());
 		
 		maxsearchbar.getValueFactory().setValue(config.getMaxSearchBarCount());
+		skipDecideScreen.setSelected(config.isSkipDecideScreen());
 		
 	}
 	
@@ -85,6 +89,7 @@ public class MusicSelectConfigurationView implements Initializable {
         config.setSongPreview(songPreview.getValue());
         
         config.setMaxSearchBarCount(maxsearchbar.getValue());
+		config.setSkipDecideScreen(skipDecideScreen.isSelected());
 	}
 
 	public void updatePlayer(PlayerConfig player) {

--- a/core/src/resources/UIResources.properties
+++ b/core/src/resources/UIResources.properties
@@ -85,6 +85,7 @@ BGA=BGA
 BGA_EXPAND=BGA Expand
 FOLDER_LAMP=Enable folder lamps
 SHOW_NO_SONG_EXISTING_BAR=Show No Song Existing Bar
+SKIP_DECIDE_SCREEN=Skip decide screen
 PLAY_PREVIEW=Play preview music
 MINIMUM_INPUT_DURATION=Minimum input duration(ms)
 JUDGE_ALGORITHM=Judge algorithm


### PR DESCRIPTION
Addresses #23. This PR adds a config option under the "Music Select" tab in the launcher to allow skipping the decide screen when selecting a song.

- This option is disabled by default in the launcher
- When selecting a song, the game switches directly to the play scene instead of switching to the decide scene, skipping the animation and decide BGM sound.

## Videos

### Skip decide screen enabled

https://github.com/user-attachments/assets/140b7c78-855c-485c-bb96-1d7bfbe830b7

### Skip decide screen disabled (default)

https://github.com/user-attachments/assets/72e4fd5b-c6a6-47aa-9447-7c1e09e05cf8

