### PR TITLE
Last played sort

### DIFF
--- a/core/src/bms/player/beatoraja/modmenu/SongManagerMenu.java
+++ b/core/src/bms/player/beatoraja/modmenu/SongManagerMenu.java
@@ -8,7 +8,9 @@ import imgui.ImGui;
 import imgui.flag.ImGuiWindowFlags;
 import imgui.type.ImBoolean;
 
+import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.stream.IntStream;
 
 
 public class SongManagerMenu {
@@ -20,12 +22,24 @@ public class SongManagerMenu {
     private static List<String> currentReverseLookupList = new ArrayList<>();
 
     private static ImBoolean LAST_PLAYED_SORT = new ImBoolean(false);
+    private static SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     public static void show(ImBoolean showSongManager) {
         Optional<SongData> currentSongData = getCurrentSongData();
+        Optional<ScoreData> currentScoreData = getCurrentScoreData();
         if (ImGui.begin("Song Manager", showSongManager, ImGuiWindowFlags.AlwaysAutoResize)) {
             String songName = currentSongData.map(SongData::getTitle).orElse("");
+            String lastPlayRecordTime = currentScoreData.map(scoreData -> {
+                Date date = new Date(scoreData.getDate() * 1000L);
+                return simpleDateFormat.format(date);
+            }).orElse("No Data");
             ImGui.text("current picking: " + songName);
+
+            ImGui.text("Last played: " + lastPlayRecordTime);
+            if (ImGui.checkbox("Sort by last played", LAST_PLAYED_SORT)) {
+                selector.getBarManager().updateBar();
+            }
+
             if (songName.isEmpty()) {
                 ImGui.text("Not a selectable song");
             } else {
@@ -43,11 +57,6 @@ public class SongManagerMenu {
                 }
             }
         }
-
-        if (ImGui.checkbox("Sort by last played", LAST_PLAYED_SORT)) {
-            selector.getBarManager().updateBar();
-        }
-
         ImGui.end();
     }
 

--- a/core/src/bms/player/beatoraja/modmenu/SongManagerMenu.java
+++ b/core/src/bms/player/beatoraja/modmenu/SongManagerMenu.java
@@ -8,9 +8,7 @@ import imgui.ImGui;
 import imgui.flag.ImGuiWindowFlags;
 import imgui.type.ImBoolean;
 
-import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.stream.IntStream;
 
 
 public class SongManagerMenu {
@@ -20,19 +18,14 @@ public class SongManagerMenu {
      * Current song's reverse lookup result
      */
     private static List<String> currentReverseLookupList = new ArrayList<>();
-    private static SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    private static ImBoolean LAST_PLAYED_SORT = new ImBoolean(false);
 
     public static void show(ImBoolean showSongManager) {
         Optional<SongData> currentSongData = getCurrentSongData();
-        Optional<ScoreData> currentScoreData = getCurrentScoreData();
         if (ImGui.begin("Song Manager", showSongManager, ImGuiWindowFlags.AlwaysAutoResize)) {
             String songName = currentSongData.map(SongData::getTitle).orElse("");
-            String bestPlayRecordTime = currentScoreData.map(scoreData -> {
-                Date date = new Date(scoreData.getDate() * 1000L);
-                return simpleDateFormat.format(date);
-            }).orElse("No Data");
             ImGui.text("current picking: " + songName);
-            ImGui.text("Best Record: " + bestPlayRecordTime);
             if (songName.isEmpty()) {
                 ImGui.text("Not a selectable song");
             } else {
@@ -50,6 +43,11 @@ public class SongManagerMenu {
                 }
             }
         }
+
+        if (ImGui.checkbox("Sort by last played", LAST_PLAYED_SORT)) {
+            selector.getBarManager().updateBar();
+        }
+
         ImGui.end();
     }
 
@@ -93,5 +91,13 @@ public class SongManagerMenu {
 
     private static List<String> getReverseLookupData(String md5, String sha256) {
         return selector.main.getPlayerResource().getReverseLookupData(md5, sha256);
+    }
+
+    public static boolean isLastPlayedSortEnabled() {
+        return LAST_PLAYED_SORT.get();
+    }
+
+    public static void forceDisableLastPlayedSort() {
+        LAST_PLAYED_SORT.set(false);
     }
 }

--- a/core/src/bms/player/beatoraja/select/BarManager.java
+++ b/core/src/bms/player/beatoraja/select/BarManager.java
@@ -374,8 +374,9 @@ public class BarManager {
 			if(isSortable) {
 				final BarSorter sorter = BarSorter.valueOf(select.main.getPlayerConfig().getSortid());
 			    Sort.instance().sort(newcurrentsongs, sorter != null ? sorter.sorter : BarSorter.TITLE.sorter);
-             if (SongManagerMenu.isLastPlayedSortEnabled())
-                 Sort.instance().sort(newcurrentsongs, BarSorter.LASTUPDATE.sorter);
+                if (SongManagerMenu.isLastPlayedSortEnabled()) {
+                    Sort.instance().sort(newcurrentsongs, BarSorter.LASTUPDATE.sorter);
+                }
 			}
 
 			Array<Bar> bars = new Array<Bar>();

--- a/core/src/bms/player/beatoraja/select/BarManager.java
+++ b/core/src/bms/player/beatoraja/select/BarManager.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import bms.player.beatoraja.modmenu.SongManagerMenu;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.Queue;
@@ -373,6 +374,8 @@ public class BarManager {
 			if(isSortable) {
 				final BarSorter sorter = BarSorter.valueOf(select.main.getPlayerConfig().getSortid());
 			    Sort.instance().sort(newcurrentsongs, sorter != null ? sorter.sorter : BarSorter.TITLE.sorter);
+             if (SongManagerMenu.isLastPlayedSortEnabled())
+                 Sort.instance().sort(newcurrentsongs, BarSorter.LASTUPDATE.sorter);
 			}
 
 			Array<Bar> bars = new Array<Bar>();

--- a/core/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
+++ b/core/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
@@ -8,6 +8,8 @@ import bms.player.beatoraja.input.KeyBoardInputProcesseor.ControlKeys;
 import bms.player.beatoraja.select.MusicSelectKeyProperty.MusicSelectKey;
 import bms.player.beatoraja.select.bar.*;
 import bms.player.beatoraja.skin.property.EventFactory.EventType;
+
+import bms.player.beatoraja.modmenu.SongManagerMenu;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 
@@ -91,6 +93,7 @@ public final class MusicSelectInputProcessor {
         }
         // ソートの切り替え
         if (input.isControlKeyPressed(ControlKeys.NUM2)) {
+            SongManagerMenu.forceDisableLastPlayedSort();
             select.executeEvent(EventType.sort);
         }
         // LNモードの切り替え

--- a/core/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 
 import bms.model.Mode;
+import bms.player.beatoraja.modmenu.SongManagerMenu;
 import bms.player.beatoraja.pattern.Random;
 import bms.player.beatoraja.result.MusicResult;
 import com.badlogic.gdx.Gdx;
@@ -1031,7 +1032,10 @@ public class IntegerPropertyFactory {
 			}
 			return Integer.MIN_VALUE;
 		}),
-		sort(12, (state) -> ((state instanceof MusicSelector) ? ((MusicSelector) state).getSort() : Integer.MIN_VALUE)),
+		sort(12, (state) ->
+             ((state instanceof MusicSelector && !SongManagerMenu.isLastPlayedSortEnabled())
+              ? ((MusicSelector) state).getSort()
+              : Integer.MIN_VALUE)),
 		gaugetype_1p(40, (state) -> {
 			if(state instanceof BMSPlayer) {
 				return ((BMSPlayer)state).getGauge().getType();


### PR DESCRIPTION
This PR adds a song manager mod menu checkmark to temporarily sort charts by their last played date.

<img width="245" height="100" alt="Screenshot_2025-09-24_14-00-41" src="https://github.com/user-attachments/assets/70d5ab9f-4337-48aa-99d1-207449bcac56" />

On Catizard's request, the previously displayed score date in the same menu is removed.

While this option is enabled, the skin's sort property is hidden, which I think should work acceptably with most skins.

<img width="432" height="50" alt="Screenshot_2025-09-24_14-00-47" src="https://github.com/user-attachments/assets/1a6be1aa-68f7-432e-8b8e-8e8391df6ad6" />

Pressing keyboard 2 while this sort option is enabled will disable it and restore normal functionality.

Should close https://github.com/seraxis/lr2oraja-endlessdream/issues/95
