### PR TITLE
Initial performance monitoring support

### DIFF
--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -577,6 +577,8 @@ public class MainController {
 		imGui.render();
 		imGui.end();
 
+        PerformanceMetrics.get().commit();
+
 		// TODO renderループに入れるのではなく、MusicDownloadProcessorのListenerとして実装したほうがいいのでは
 		if(download != null && download.isDownload()){
 			downloadIpfsMessageRenderer(download.getMessage());

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -344,8 +344,7 @@ public class MainController {
             ImGuiRenderer.init();
         }
 
-
-		try {
+        try (var perf = PerformanceMetrics.get().Event("System font load")) {
 			FreeTypeFontGenerator generator = new FreeTypeFontGenerator(Gdx.files.internal(config.getSystemfontpath()));
 			FreeTypeFontParameter parameter = new FreeTypeFontParameter();
 			parameter.size = 24;

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -340,8 +340,10 @@ public class MainController {
 		sprite = SpriteBatchHelper.createSpriteBatch();
 		SkinLoader.initPixmapResourcePool(config.getSkinPixmapGen());
 
+        try (var perf = PerformanceMetrics.get().Event("ImGui init")) {
+            ImGuiRenderer.init();
+        }
 
-		ImGuiRenderer.init();
 
 		try {
 			FreeTypeFontGenerator generator = new FreeTypeFontGenerator(Gdx.files.internal(config.getSystemfontpath()));
@@ -353,7 +355,10 @@ public class MainController {
 			Logger.getGlobal().severe("System Font読み込み失敗");
 		}
 
-		input = new BMSPlayerInputProcessor(config, player);
+        try (var perf = PerformanceMetrics.get().Event("Input Processor constructor")) {
+			input = new BMSPlayerInputProcessor(config, player);
+		}
+
 		switch(config.getAudioConfig().getDriver()) {
 		case OpenAL:
 			audio = new GdxSoundDriver(config);
@@ -364,7 +369,10 @@ public class MainController {
 		}
 
 		resource = new PlayerResource(audio, config, player);
-		selector = new MusicSelector(this, songUpdated);
+        try (var perf = PerformanceMetrics.get().Event("MusicSelector constructor")) {
+            selector = new MusicSelector(this, songUpdated);
+        }
+
 		if(player.getRequestEnable()) {
 		    streamController = new StreamController(selector);
 	        streamController.run();

--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -118,9 +118,12 @@ public class MainLoader extends Application {
             }
         }
 
-		for(SongData song : getScoreDatabaseAccessor().getSongDatas(SongUtils.illegalsongs)) {
-			MainLoader.putIllegalSong(song.getSha256());
-		}
+        try (var perf = PerformanceMetrics.get().Event("Illegal song read")) {
+            for (SongData song : getScoreDatabaseAccessor().getSongDatas(SongUtils.illegalsongs)) {
+                MainLoader.putIllegalSong(song.getSha256());
+            }
+        }
+
 		if(illegalSongs.size() > 0) {
 			JOptionPane.showMessageDialog(null, "This Application detects " + illegalSongs.size() + " illegal BMS songs. \n Remove them, update song database and restart.", "Error", JOptionPane.ERROR_MESSAGE);
 			System.exit(1);

--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -118,10 +118,8 @@ public class MainLoader extends Application {
             }
         }
 
-        try (var perf = PerformanceMetrics.get().Event("Illegal song read")) {
-            for (SongData song : getScoreDatabaseAccessor().getSongDatas(SongUtils.illegalsongs)) {
-                MainLoader.putIllegalSong(song.getSha256());
-            }
+        for (SongData song : getScoreDatabaseAccessor().getSongDatas(SongUtils.illegalsongs)) {
+            MainLoader.putIllegalSong(song.getSha256());
         }
 
 		if(illegalSongs.size() > 0) {

--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -229,8 +229,10 @@ public class MainLoader extends Application {
 				}
 
 				public void render() {
-					main.render();
-				}
+                    try (var perf = PerformanceMetrics.get().Watch("render")) {
+                        main.render();
+                    }
+                }
 
 				public void pause() {
 					main.pause();

--- a/core/src/bms/player/beatoraja/MainState.java
+++ b/core/src/bms/player/beatoraja/MainState.java
@@ -132,8 +132,10 @@ public abstract class MainState {
 	}
 
 	public void loadSkin(SkinType skinType) {
-		setSkin(SkinLoader.load(this, skinType));
-	}
+        try (var perf = PerformanceMetrics.get().Event("Load skin: " + skinType)) {
+            setSkin(SkinLoader.load(this, skinType));
+        }
+    }
 
 	public int getJudgeCount(int judge, boolean fast) {
 		ScoreData sd = score.getScoreData();

--- a/core/src/bms/player/beatoraja/PerformanceMetrics.java
+++ b/core/src/bms/player/beatoraja/PerformanceMetrics.java
@@ -1,0 +1,42 @@
+package bms.player.beatoraja;
+
+import java.util.Vector;
+import java.util.Stack;
+
+public class PerformanceMetrics {
+    private static PerformanceMetrics self = new PerformanceMetrics();
+
+    public static PerformanceMetrics get() { return self; }
+
+    public EventBlock Event(String eventName) { return new EventBlock(eventName); }
+
+    public record EventResult(String name, int id, int parent, long startTime, long duration) {}
+    public Vector<EventResult> eventResults = new Vector<EventResult>();
+
+    public Stack<Integer> activeBlocks = new Stack<Integer>();
+
+    public class EventBlock implements AutoCloseable {
+        private final String name;
+        private final int id;
+        private final int parent;
+        private final long startTime;
+
+        private static int nextId = 1;
+
+        public EventBlock(String name) {
+            this.name = name;
+            this.id = nextId;
+            nextId++;
+            parent = get().activeBlocks.empty() ? 0 : get().activeBlocks.peek();
+            get().activeBlocks.push(this.id);
+            startTime = System.nanoTime();
+        }
+
+        @Override
+        public void close() {
+            var endTime = System.nanoTime();
+            get().activeBlocks.pop();
+            eventResults.add(new EventResult(name, id, parent, startTime, (endTime - startTime)));
+        }
+    }
+}

--- a/core/src/bms/player/beatoraja/PerformanceMetrics.java
+++ b/core/src/bms/player/beatoraja/PerformanceMetrics.java
@@ -2,18 +2,56 @@ package bms.player.beatoraja;
 
 import java.util.Vector;
 import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import javafx.util.Pair;
 
 public class PerformanceMetrics {
     private static PerformanceMetrics self = new PerformanceMetrics();
 
     public static PerformanceMetrics get() { return self; }
 
+    // should make this thread safe
     public EventBlock Event(String eventName) { return new EventBlock(eventName); }
 
+    // thread safe
+    // relies on name identity, so only pass string literals as the name argument
+    public WatchBlock Watch(String eventName) { return new WatchBlock(eventName); }
+
     public record EventResult(String name, int id, int parent, long startTime, long duration) {}
+
     public Vector<EventResult> eventResults = new Vector<EventResult>();
 
     public Stack<Integer> activeBlocks = new Stack<Integer>();
+
+    private IdentityHashMap<String, ArrayDeque<Pair<Long, Long>>> watchRecords =
+        new IdentityHashMap<String, ArrayDeque<Pair<Long, Long>>>();
+
+    public synchronized void submitWatchResult(String name, long time, long duration) {
+        if (!watchRecords.containsKey(name)) {
+            watchRecords.put(name, new ArrayDeque<Pair<Long, Long>>());
+        }
+        watchRecords.get(name).add(new Pair<Long, Long>(time, duration));
+    }
+
+    public synchronized void commit() {
+        long now = System.nanoTime();
+        long keep = now - 3000000000L;
+        // drop all measurements older than 3s (we could make this configurable per watch name)
+        watchRecords.forEach((k, v) -> {
+            // might want to split these into two arrays to simply the monitor
+            while (!v.isEmpty() && v.peek().getKey() < keep) {
+                v.pop();
+            }
+        });
+    }
+
+	// TODO: this isn't a great interface for plotting the performance
+    public synchronized Set<String> getWatchNames() { return watchRecords.keySet(); }
+    public synchronized ArrayDeque<Pair<Long, Long>> getWatchRecords(String name) {
+        return watchRecords.get(name);
+    }
 
     public class EventBlock implements AutoCloseable {
         private final String name;
@@ -37,6 +75,21 @@ public class PerformanceMetrics {
             var endTime = System.nanoTime();
             get().activeBlocks.pop();
             eventResults.add(new EventResult(name, id, parent, startTime, (endTime - startTime)));
+        }
+    }
+
+    public class WatchBlock implements AutoCloseable {
+        private final String name;
+        private final long startTime;
+        public WatchBlock(String name) {
+            this.name = name;
+            startTime = System.nanoTime();
+        }
+
+        @Override
+        public void close() {
+            var endTime = System.nanoTime();
+            get().submitWatchResult(name, startTime, endTime - startTime);
         }
     }
 }

--- a/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
+++ b/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
@@ -39,6 +39,7 @@ public class ImGuiRenderer {
     private static ImBoolean SHOW_JUDGE_TRAINER = new ImBoolean(false);
     private static ImBoolean SHOW_SONG_MANAGER = new ImBoolean(false);
     private static ImBoolean SHOW_DOWNLOAD_MENU = new ImBoolean(false);
+    private static ImBoolean SHOW_PERFORMANCE_MONITOR = new ImBoolean(false);
     private static ImBoolean SHOW_MISC_SETTING = new ImBoolean(false);
 
 
@@ -106,6 +107,10 @@ public class ImGuiRenderer {
             ImGui.checkbox("Show Judge Trainer Window", SHOW_JUDGE_TRAINER);
             ImGui.checkbox("Show Song Manager Menu", SHOW_SONG_MANAGER);
             ImGui.checkbox("Show Download Tasks Window", SHOW_DOWNLOAD_MENU);
+            if (ImGui.checkbox("Show Performance Monitor", SHOW_PERFORMANCE_MONITOR) &&
+                SHOW_PERFORMANCE_MONITOR.get()) {
+                PerformanceMonitor.reloadEventTree();
+            }
             ImGui.checkbox("Show Misc Setting Menu", SHOW_MISC_SETTING);
 
             if (SHOW_FREQ_PLUS.get()) {
@@ -123,6 +128,9 @@ public class ImGuiRenderer {
             // TODO: This menu should based on config. Should not be rendered if user doesn't flag the http download feature
             if (SHOW_DOWNLOAD_MENU.get()) {
                 DownloadTaskMenu.show(SHOW_DOWNLOAD_MENU);
+            }
+            if (SHOW_PERFORMANCE_MONITOR.get()) {
+                PerformanceMonitor.show(SHOW_PERFORMANCE_MONITOR);
             }
             if (SHOW_MISC_SETTING.get()) {
                 MiscSettingMenu.show(SHOW_MISC_SETTING);

--- a/core/src/bms/player/beatoraja/modmenu/PerformanceMonitor.java
+++ b/core/src/bms/player/beatoraja/modmenu/PerformanceMonitor.java
@@ -1,0 +1,84 @@
+package bms.player.beatoraja.modmenu;
+
+import bms.player.beatoraja.PerformanceMetrics;
+
+import imgui.ImGui;
+import imgui.flag.ImGuiWindowFlags;
+import imgui.flag.ImGuiTableFlags;
+import imgui.flag.ImGuiTableColumnFlags;
+import imgui.flag.ImGuiTreeNodeFlags;
+import imgui.type.ImBoolean;
+
+import java.util.*;
+
+public class PerformanceMonitor {
+
+    static HashMap<Integer, Vector<PerformanceMetrics.EventResult>> eventTree;
+
+    public static void show(ImBoolean showPerformanceMonitor) {
+        if (eventTree == null) {
+            reloadEventTree();
+        }
+        if (ImGui.begin("Performance Monitor", showPerformanceMonitor)) {
+            if (ImGui.collapsingHeader("Events")) {
+                renderEventTable();
+            }
+        }
+        ImGui.end();
+    }
+
+
+
+
+    public static void reloadEventTree() {
+        // copy the vector to avoid constantly reading the events  while other threads might be writing
+        eventTree = new HashMap<Integer, Vector<PerformanceMetrics.EventResult>>();
+        Vector<PerformanceMetrics.EventResult> events =
+            new Vector<PerformanceMetrics.EventResult>(PerformanceMetrics.get().eventResults);
+        for (var event : events) {
+            if (!eventTree.containsKey(event.parent())) {
+                eventTree.put(event.parent(), new Vector<PerformanceMetrics.EventResult>());
+            }
+            // I'm not sure if this works out to always be sorted chronologically,
+            // should make sure that it is
+            eventTree.get(event.parent()).add(event);
+        }
+    }
+
+    private static void renderEventTable() {
+        if (ImGui.beginTable("event-table", 2, ImGuiTableFlags.ScrollY)) {
+            ImGui.tableSetupColumn("Event", ImGuiTableColumnFlags.WidthStretch, 2.0f);
+            ImGui.tableSetupColumn("Time", ImGuiTableColumnFlags.WidthStretch, 1.0f);
+            ImGui.tableHeadersRow();
+
+            ImGui.tableNextRow();
+            ImGui.tableNextColumn();
+
+            renderEventTree(0);
+
+            ImGui.endTable();
+        }
+    }
+
+    private static void renderEventTree(int groupId) {
+        if (!eventTree.containsKey(groupId))
+            return;
+
+        Vector<PerformanceMetrics.EventResult> group = eventTree.get(groupId);
+
+        for (var event : group) {
+            boolean leaf = !eventTree.containsKey(event.id());
+            var flags = leaf ? ImGuiTreeNodeFlags.Leaf | ImGuiTreeNodeFlags.NoTreePushOnOpen |
+                                   ImGuiTreeNodeFlags.Bullet
+                             : 0;
+            boolean open = ImGui.treeNodeEx(event.name(), flags);
+            ImGui.tableNextColumn();
+            ImGui.text(String.format("%12.2fms", event.duration() / 1000000.0));
+            ImGui.tableNextColumn();
+            if (!leaf && open) {
+                renderEventTree(event.id());
+                ImGui.treePop();
+            }
+        }
+    }
+}

--- a/core/src/bms/player/beatoraja/select/BarManager.java
+++ b/core/src/bms/player/beatoraja/select/BarManager.java
@@ -93,7 +93,11 @@ public class BarManager {
 	void init() {
 		TableDataAccessor tdaccessor = new TableDataAccessor(select.resource.getConfig().getTablepath());
 
-		TableData[] unsortedtables = tdaccessor.readAll();
+        TableData[] unsortedtables;
+        try (var perf = PerformanceMetrics.get().Event("Saved table load")) {
+            unsortedtables = tdaccessor.readAll();
+        }
+
 		final List<TableData> sortedtables = new ArrayList<TableData>(unsortedtables.length);
 		
 		for(String url : select.resource.getConfig().getTableURL()) {

--- a/core/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/core/src/bms/player/beatoraja/select/MusicSelector.java
@@ -186,7 +186,9 @@ public final class MusicSelector extends MainState {
 		input.setMidiConfig(pc.getMidiConfig());
 		manager.updateBar();
 
-		loadSkin(SkinType.MUSIC_SELECT);
+        try (var perf = PerformanceMetrics.get().Event("Load skin: Select")) {
+            loadSkin(SkinType.MUSIC_SELECT);
+        }
 
 		// search text field
 		Rectangle searchRegion = ((MusicSelectSkin) getSkin()).getSearchTextRegion();

--- a/core/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/core/src/bms/player/beatoraja/select/MusicSelector.java
@@ -186,9 +186,7 @@ public final class MusicSelector extends MainState {
 		input.setMidiConfig(pc.getMidiConfig());
 		manager.updateBar();
 
-        try (var perf = PerformanceMetrics.get().Event("Load skin: Select")) {
-            loadSkin(SkinType.MUSIC_SELECT);
-        }
+        loadSkin(SkinType.MUSIC_SELECT);
 
 		// search text field
 		Rectangle searchRegion = ((MusicSelectSkin) getSkin()).getSearchTextRegion();

--- a/core/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/core/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -17,6 +17,7 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
+import bms.player.beatoraja.PerformanceMetrics;
 
 /**
  * .fnt ファイルをソースとして持つスキン用テキスト
@@ -152,6 +153,12 @@ public class SkinTextBitmap extends SkinText {
 				for (int i = 0; i < _fontData.imagePaths.length; ++i) {
 					_regions.add(new TextureRegion(SkinLoader.getTexture(_fontData.imagePaths[i], usecim, useMipMaps)));
 				}
+                try (var perf = PerformanceMetrics.get().Event(String.format("Font image load: %s", _fontPath.getFileName()))) {
+                    _regions = new Array<>(_fontData.imagePaths.length);
+                    for (int i = 0; i < _fontData.imagePaths.length; ++i) {
+                        _regions.add(new TextureRegion(SkinLoader.getTexture(_fontData.imagePaths[i], usecim, useMipMaps)));
+                    }
+                }
 
 				_font = new BitmapFont(_fontData, _regions, true);
 

--- a/core/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/core/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -146,14 +146,12 @@ public class SkinTextBitmap extends SkinText {
 			float _pageWidth = 0;
 			float _pageHeight = 0;
 
-			try {
-				_fontData = new BitmapFont.BitmapFontData(new FileHandle(_fontPath.toFile()), false);
+			try (var perf = PerformanceMetrics.get().Event(String.format("Font load: %s", _fontPath.getFileName()))){
+                try (var perf_ = PerformanceMetrics.get().Event(String.format("description parse", _fontPath.getFileName()))) {
+                    _fontData = new BitmapFont.BitmapFontData(new FileHandle(_fontPath.toFile()), false);
+                }
 
-				_regions = new Array<>(_fontData.imagePaths.length);
-				for (int i = 0; i < _fontData.imagePaths.length; ++i) {
-					_regions.add(new TextureRegion(SkinLoader.getTexture(_fontData.imagePaths[i], usecim, useMipMaps)));
-				}
-                try (var perf = PerformanceMetrics.get().Event(String.format("Font image load: %s", _fontPath.getFileName()))) {
+                try (var perf_ = PerformanceMetrics.get().Event(String.format("image load", _fontPath.getFileName()))) {
                     _regions = new Array<>(_fontData.imagePaths.length);
                     for (int i = 0; i < _fontData.imagePaths.length; ++i) {
                         _regions.add(new TextureRegion(SkinLoader.getTexture(_fontData.imagePaths[i], usecim, useMipMaps)));

--- a/core/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
+++ b/core/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
@@ -257,7 +257,7 @@ public class JSONSkinLoader extends SkinLoader {
 
 	protected Skin loadJsonSkin(SkinHeader header, JsonSkin.Skin sk, SkinType type, SkinConfig.Property property, Path p){
 		Skin skin = null;
-		try {
+		try (var perf = PerformanceMetrics.get().Event("Load JSON skin")) {
 			Resolution src = HD;
 			for(Resolution r : Resolution.values()) {
 				if(sk.w == r.width && sk.h == r.height) {

--- a/core/src/bms/player/beatoraja/skin/json/JsonPlaySkinObjectLoader.java
+++ b/core/src/bms/player/beatoraja/skin/json/JsonPlaySkinObjectLoader.java
@@ -14,6 +14,7 @@ import com.badlogic.gdx.math.Rectangle;
 import bms.player.beatoraja.play.*;
 import bms.player.beatoraja.skin.*;
 import bms.player.beatoraja.skin.SkinObject.SkinOffset;
+import bms.player.beatoraja.PerformanceMetrics;
 
 public class JsonPlaySkinObjectLoader extends JsonSkinObjectLoader<PlaySkin> {
 
@@ -32,6 +33,8 @@ public class JsonPlaySkinObjectLoader extends JsonSkinObjectLoader<PlaySkin> {
 		if(obj != null) {
 			return obj;
 		}
+
+        try (var perf = PerformanceMetrics.get().Event("Play object: " + dst.id)) {
 		
 		// note (playskin only)
 		if(sk.note != null && dst.id.equals(sk.note.id)) {
@@ -316,5 +319,6 @@ public class JsonPlaySkinObjectLoader extends JsonSkinObjectLoader<PlaySkin> {
 		}
 
 		return obj;
+        }
 	}
 }

--- a/core/src/bms/player/beatoraja/skin/json/JsonSelectSkinObjectLoader.java
+++ b/core/src/bms/player/beatoraja/skin/json/JsonSelectSkinObjectLoader.java
@@ -10,6 +10,7 @@ import bms.player.beatoraja.select.SkinBar;
 import bms.player.beatoraja.select.SkinDistributionGraph;
 import bms.player.beatoraja.skin.*;
 import bms.player.beatoraja.skin.property.TimerProperty;
+import bms.player.beatoraja.PerformanceMetrics;
 
 /**
  * JSONセレクトスキンオブジェクトローダー
@@ -33,6 +34,8 @@ public class JsonSelectSkinObjectLoader extends JsonSkinObjectLoader<MusicSelect
 		if(obj != null) {
 			return obj;
 		}
+
+        try (var perf = PerformanceMetrics.get().Event("Select object: " + dst.id)) {
 		
 		if (sk.songlist != null && dst.id.equals(sk.songlist.id)) {
 			SkinBar barobj = new SkinBar(0);
@@ -240,5 +243,6 @@ public class JsonSelectSkinObjectLoader extends JsonSkinObjectLoader<MusicSelect
 		}
 		
 		return null;
+        }
 	}
 }

--- a/core/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
+++ b/core/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
@@ -7,6 +7,7 @@ import bms.player.beatoraja.skin.*;
 import bms.player.beatoraja.skin.json.JSONSkinLoader;
 import bms.player.beatoraja.skin.json.JsonSkin;
 import bms.player.beatoraja.skin.property.*;
+import bms.player.beatoraja.PerformanceMetrics;
 
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
@@ -73,12 +74,15 @@ public class LuaSkinLoader extends JSONSkinLoader {
 				}
 			}
 
-			lua.exportSkinProperty(header, property, (String path) -> {
-				return getPath(p.getParent().toString() + "/" + path, filemap).getPath();
-			});
-			LuaValue value = lua.execFile(p);
-			sk = fromLuaValue(JsonSkin.Skin.class, value);
-			skin = loadJsonSkin(header, sk, type, property, p);
+            try (var perf = PerformanceMetrics.get().Event("Lua skin exec")) {
+                lua.exportSkinProperty(header, property, (String path) -> {
+                    return getPath(p.getParent().toString() + "/" + path, filemap).getPath();
+                });
+
+                LuaValue value = lua.execFile(p);
+                sk = fromLuaValue(JsonSkin.Skin.class, value);
+            }
+            skin = loadJsonSkin(header, sk, type, property, p);
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
This PR adds `PerformanceMetrics.java`, a helper interface for measuring execution time of selected code blocks, and `PerformanceMonitor.java`, a mod menu window that presents the results.

<img width="456" height="277" alt="image" src="https://github.com/user-attachments/assets/ae1abbc7-81a5-4c9b-b86b-13f81ed8495d" />

PerformanceMetrics comes with two methods:
`Event` for measuring one-time or rarely executed sections; these measurements can freely nest and will display as such in the monitor.
(to be used as a variable initializer in a `try-with` block - usage example from `BarManager.java`):
``` java
try (var perf = PerformanceMetrics.get().Event("Saved table load")) {
        unsortedtables = tdaccessor.readAll();
}
```
`Watch` for code that runs several times; these measurements are displayed as aggregate statistics instead of individual results. They're also slightly more performant than events.  (`MainLoader.java`):
```java
try (var perf = PerformanceMetrics.get().Watch("render")) {
    main.render();
}
````

Potential future work would be adding live charts for plotting the 'watch' measurements; for the moment I gave up on that due to ImGui library limitations and uncertainty about practicality.
