### PR TITLE
Store freq & override judge score in separate table

### DIFF
--- a/core/src/bms/player/beatoraja/PlayerResource.java
+++ b/core/src/bms/player/beatoraja/PlayerResource.java
@@ -128,7 +128,9 @@ public final class PlayerResource {
 	private String tablelevel = "";
 	private String tablefull;
 	private boolean freqOn;
+	private int freqValue;
 	private String freqString;
+	private int overrideJudgeRank;
 	// Full list of difficult tables that contains current song
 	private List<String> reverseLookup = new ArrayList<>();
 
@@ -612,5 +614,21 @@ public final class PlayerResource {
 
 	public void setFreqString(String freqString) {
 		this.freqString = freqString;
+	}
+
+	public int getFreqValue() {
+		return freqValue;
+	}
+
+	public void setFreqValue(int freqValue) {
+		this.freqValue = freqValue;
+	}
+
+	public int getOverrideJudgeRank() {
+		return overrideJudgeRank;
+	}
+
+	public void setOverrideJudgeRank(int overrideJudgeRank) {
+		this.overrideJudgeRank = overrideJudgeRank;
 	}
 }

--- a/core/src/bms/player/beatoraja/ScoreData.java
+++ b/core/src/bms/player/beatoraja/ScoreData.java
@@ -120,6 +120,14 @@ public class ScoreData implements Validatable {
 	 */
 	private int gauge;
 	/**
+	 * Rate percentage, e.g. 120 == 1.2x
+	 */
+	private int rate;
+	/**
+	 * Override judgement, -1 as didn't use
+	 */
+	private int overridejudge = -1;
+	/**
 	 * 入力デバイス
 	 */
 	private BMSPlayerInputDevice.Type deviceType;
@@ -235,6 +243,18 @@ public class ScoreData implements Validatable {
 	}
 	public void setLms(int lms) {
 		this.lms = lms;
+	}
+	public int getRate() {
+		return rate;
+	}
+	public void setRate(int rate) {
+		this.rate = rate;
+	}
+	public int getOverridejudge() {
+		return overridejudge;
+	}
+	public void setOverridejudge(int overridejudge) {
+		this.overridejudge = overridejudge;
 	}
 
 	public int getJudgeCount(int judge) {

--- a/core/src/bms/player/beatoraja/ScoreDataLogDatabaseAccessor.java
+++ b/core/src/bms/player/beatoraja/ScoreDataLogDatabaseAccessor.java
@@ -1,15 +1,16 @@
 package bms.player.beatoraja;
 
-import java.sql.*;
-import java.util.*;
-import java.util.logging.Logger;
-
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
 import org.apache.commons.dbutils.handlers.BeanListHandler;
 import org.sqlite.SQLiteConfig;
-import org.sqlite.SQLiteDataSource;
 import org.sqlite.SQLiteConfig.SynchronousMode;
+import org.sqlite.SQLiteDataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * スコアデータログデータベースアクセサ
@@ -24,7 +25,8 @@ public class ScoreDataLogDatabaseAccessor extends SQLiteDatabaseAccessor {
 	private final QueryRunner qr;
 
 	public ScoreDataLogDatabaseAccessor(String path) throws ClassNotFoundException {
-		super(	new Table("scoredatalog",
+		super(
+				new Table("scoredatalog",
 						new Column("sha256", "TEXT", 1, 1),
 						new Column("mode", "INTEGER",0,1),
 						new Column("clear", "INTEGER"),
@@ -54,7 +56,41 @@ public class ScoreDataLogDatabaseAccessor extends SQLiteDatabaseAccessor {
 						new Column("date", "INTEGER"),
 						new Column("state", "INTEGER"),
 						new Column("scorehash", "TEXT")
-						));
+				),
+				new Table(
+						"eddatalog",
+						new Column("sha256", "TEXT", 1, 0),
+						new Column("mode", "INTEGER"),
+						new Column("clear", "INTEGER"),
+						new Column("epg", "INTEGER"),
+						new Column("lpg", "INTEGER"),
+						new Column("egr", "INTEGER"),
+						new Column("lgr", "INTEGER"),
+						new Column("egd", "INTEGER"),
+						new Column("lgd", "INTEGER"),
+						new Column("ebd", "INTEGER"),
+						new Column("lbd", "INTEGER"),
+						new Column("epr", "INTEGER"),
+						new Column("lpr", "INTEGER"),
+						new Column("ems", "INTEGER"),
+						new Column("lms", "INTEGER"),
+						new Column("notes", "INTEGER"),
+						new Column("combo", "INTEGER"),
+						new Column("minbp", "INTEGER"),
+						new Column("avgjudge", "INTEGER", 1, 0, String.valueOf(Integer.MAX_VALUE)),
+						new Column("playcount", "INTEGER"),
+						new Column("clearcount", "INTEGER"),
+						new Column("trophy", "TEXT"),
+						new Column("ghost", "TEXT"),
+						new Column("option", "INTEGER"),
+						new Column("seed", "INTEGER"),
+						new Column("random", "INTEGER"),
+						new Column("date", "INTEGER"),
+						new Column("state", "INTEGER"),
+						new Column("scorehash", "TEXT"),
+						new Column("rate", "INTEGER"),
+						new Column("overridejudge", "INTEGER")
+				));
 
 		Class.forName("org.sqlite.JDBC");
 		SQLiteConfig conf = new SQLiteConfig();
@@ -81,6 +117,7 @@ public class ScoreDataLogDatabaseAccessor extends SQLiteDatabaseAccessor {
 			con.setAutoCommit(false);
 			for (ScoreData score : scores) {
 				this.insert(qr, con, "scoredatalog", score);
+				this.insert(qr, con, "eddatalog", score);
 			}
 			con.commit();
 		} catch (Exception e) {

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -221,6 +221,7 @@ public class BMSPlayer extends MainState {
 
 			// "Persist" some states in resource
 			resource.setFreqOn(true);
+			resource.setFreqValue(freq);
 			resource.setFreqString(FreqTrainerMenu.getFreqString());
 		}
 		if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY) {
@@ -249,7 +250,10 @@ public class BMSPlayer extends MainState {
 					assist = Math.max(assist, 2);
 					score = false;
 				}
+				resource.setOverrideJudgeRank(JudgeTrainer.getJudgeRank());
 				model.setJudgerank(overridingJudgeWindowRate);
+			} else {
+				resource.setOverrideJudgeRank(-1);
 			}
 
 			Array<PatternModifier> mods = new Array<PatternModifier>();
@@ -915,6 +919,10 @@ public class BMSPlayer extends MainState {
 				}
 			}
 		}
+		if (resource.isFreqOn()) {
+			score.setRate(resource.getFreqValue());
+		}
+		score.setOverridejudge(resource.getOverrideJudgeRank());
 		score.setClear(clear.id);
 		score.setGauge(gauge.isTypeChanged() ? -1 : gauge.getType());
 		score.setOption(playinfo.randomoption + (model.getMode().player == 2


### PR DESCRIPTION
This is a proposal of how we store the scores have endless dream's features like freq/override judge. This pr creates a similar table `eddatalog` in `scoredatalog.db`, but:

- Removes the primary key, which causes `scoredatalog.db` file doesn't save each play record
- Adds two new fields `rate` and `overridejudge`

Needs further discussion:

- Should we transfer the old data from table `scoredatalog`?
- How should we treat `score.db` and `scorelog.db`?