### PR TITLE
Add optional fallback default path for assets

### DIFF
--- a/core/src/bms/player/beatoraja/SystemSoundManager.java
+++ b/core/src/bms/player/beatoraja/SystemSoundManager.java
@@ -104,7 +104,7 @@ public class SystemSoundManager {
 		if(p != null) {
 			paths.addAll(AudioDriver.getPaths(p.resolve(type.path).toString()));			
 		}
-		paths.addAll(AudioDriver.getPaths(Paths.get("defaultsound").resolve(type.path).toString()));
+		paths.addAll(AudioDriver.getPaths(Config.resolvePath("defaultsound/" + type.path)));
 		return paths.toArray(Path.class);
 	}
 	

--- a/core/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
+++ b/core/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
@@ -1,6 +1,7 @@
 package bms.player.beatoraja.audio;
 
 import bms.model.*;
+import bms.player.beatoraja.Config;
 import bms.player.beatoraja.ResourcePool;
 
 import java.nio.file.InvalidPathException;
@@ -307,7 +308,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 				if (wavid < wavcount) {
 					p = dpath.resolve(wavlist[wavid]).toAbsolutePath();
 				} else {
-					p = Paths.get("defaultsound/landmine.wav").toAbsolutePath();
+					p = Paths.get(Config.resolvePath("defaultsound/landmine.wav")).toAbsolutePath();
 				}
 				for (Note note : waventry.getValue()) {
 					// 音切りあり・なし両方のデータが必要になるケースがある

--- a/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
+++ b/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
@@ -1,5 +1,6 @@
 package bms.player.beatoraja.modmenu;
 
+import bms.player.beatoraja.Config;
 import bms.player.beatoraja.controller.Lwjgl3ControllerManager;
 
 import com.badlogic.gdx.Gdx;
@@ -191,7 +192,7 @@ public class ImGuiRenderer {
 
     private static byte[] loadFromResources(String name) {
         try {
-            return Files.readAllBytes(Gdx.files.internal(name).file().toPath());
+            return Files.readAllBytes(Gdx.files.internal(Config.resolvePath(name)).file().toPath());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/bms/player/beatoraja/select/BarManager.java
+++ b/core/src/bms/player/beatoraja/select/BarManager.java
@@ -241,7 +241,7 @@ public class BarManager {
 		try {
 			Json json = new Json();
 			CommandFolder[] cf = json.fromJson(CommandFolder[].class,
-					new BufferedInputStream(Files.newInputStream(Paths.get("folder/default.json"))));
+					new BufferedInputStream(Files.newInputStream(Paths.get(Config.resolvePath("folder/default.json")))));
 			Stream.of(cf).forEach(folder -> l.add(createCommandBar(select, folder)));
 		} catch (Throwable e) {
 			e.printStackTrace();
@@ -250,7 +250,7 @@ public class BarManager {
 		try {
 			ObjectMapper objectMapper = new ObjectMapper();
 			randomFolderList = objectMapper.readValue(
-					new BufferedInputStream(Files.newInputStream(Paths.get("random/default.json"))),
+					new BufferedInputStream(Files.newInputStream(Paths.get(Config.resolvePath("random/default.json")))),
 					new TypeReference<List<RandomFolder>>() {
 					});
 		} catch (Throwable e) {

--- a/core/src/bms/player/beatoraja/skin/SkinLoader.java
+++ b/core/src/bms/player/beatoraja/skin/SkinLoader.java
@@ -52,19 +52,20 @@ public abstract class SkinLoader {
     public static Skin load(MainState state, SkinType skinType, SkinConfig sc) {
         final PlayerResource resource = state.resource;
         try {
-            if (sc.getPath().endsWith(".json")) {
+            String resolvedPath = Config.resolvePath(sc.getPath());
+            if (resolvedPath.endsWith(".json")) {
                 JSONSkinLoader sl = new JSONSkinLoader(state, resource.getConfig());
-                Skin skin = sl.loadSkin(Paths.get(sc.getPath()), skinType, sc.getProperties());
+                Skin skin = sl.loadSkin(Paths.get(resolvedPath), skinType, sc.getProperties());
                 SkinLoader.resource.disposeOld();
                 return skin;
-            } else if (sc.getPath().endsWith(".luaskin")) {
+            } else if (resolvedPath.endsWith(".luaskin")) {
                 LuaSkinLoader loader = new LuaSkinLoader(state, resource.getConfig());
-                Skin skin = loader.loadSkin(Paths.get(sc.getPath()), skinType, sc.getProperties());
+                Skin skin = loader.loadSkin(Paths.get(resolvedPath), skinType, sc.getProperties());
                 SkinLoader.resource.disposeOld();
                 return skin;
             } else {
                 LR2SkinHeaderLoader loader = new LR2SkinHeaderLoader(resource.getConfig());
-                SkinHeader header = loader.loadSkin(Paths.get(sc.getPath()), state, sc.getProperties());
+                SkinHeader header = loader.loadSkin(Paths.get(resolvedPath), state, sc.getProperties());
                 LR2SkinCSVLoader dloader = LR2SkinCSVLoader.getSkinLoader(skinType,  header.getResolution(), resource.getConfig());
                 header.setSourceResolution(dloader.src);
                 header.setDestinationResolution(dloader.dst);
@@ -86,6 +87,7 @@ public abstract class SkinLoader {
     }
 
     public static File getPath(String imagepath, ObjectMap<String, String> filemap) {
+        imagepath = Config.resolvePath(imagepath);
         File imagefile = new File(imagepath);
         for (String key : filemap.keys()) {
             if (imagepath.startsWith(key)) {

--- a/core/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/core/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -812,7 +812,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 	}
 
 	private static void addJudgeDetail(Skin skin, int[] values, float srcw, float dstw, float srch, float dsth, int side) {
-		Texture tex = new Texture("skin/default/judgedetail.png");
+		Texture tex = new Texture(Config.resolvePath("skin/default/judgedetail.png"));
 
 		final float dw = dstw / 1280f;
 		final float dh = dsth / 720f;
@@ -975,7 +975,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 	}
 
 	private void makeDefaultLines(int index, int h, int r, int g, int b) {
-		Texture tex = new Texture("skin/default/system.png");
+		Texture tex = new Texture(Config.resolvePath("skin/default/system.png"));
 		int[] values = parseInt(linevalues[index % 2]);
 		SkinImage li = new SkinImage(new TextureRegion(tex, 0, 0, 1,1));
 		lines[index] = li;

--- a/core/src/bms/player/beatoraja/skin/lr2/LR2SelectSkinLoader.java
+++ b/core/src/bms/player/beatoraja/skin/lr2/LR2SelectSkinLoader.java
@@ -512,7 +512,7 @@ public class LR2SelectSkinLoader extends LR2SkinCSVLoader<MusicSelectSkin> {
 				if (values[2] < fontlist.size && fontlist.get(values[2]) != null) {
 					bartext = new SkinTextImage(fontlist.get(values[2]));
 				} else {
-					bartext = new SkinTextFont("skin/default/VL-Gothic-Regular.ttf", 0, 48, 2);
+					bartext = new SkinTextFont(Config.resolvePath("skin/default/VL-Gothic-Regular.ttf"), 0, 48, 2);
 				}
 				bartext.setAlign(values[4]);
 				skinbar.setText(values[1], bartext);

--- a/core/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/core/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -290,7 +290,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 				if (values[2] < fontlist.size && fontlist.get(values[2]) != null) {
 					text = new SkinTextImage(fontlist.get(values[2]), values[3]);
 				} else {
-					text = new SkinTextFont("skin/default/VL-Gothic-Regular.ttf", 0, 48, 2);
+					text = new SkinTextFont(Config.resolvePath("skin/default/VL-Gothic-Regular.ttf"), 0, 48, 2);
 				}
 				text.setAlign(values[4]);
 				text.setEditable(values[5] != 0);


### PR DESCRIPTION
Introduces a new optional environment variable: `BEATORAJA_INSTALL_DIR`

If a default asset does not exist in the working directory - e.g. `skin/default`, `font/VL-Gothic-Regular.ttf` - the game will attempt to find it from the `BEATORAJA_INSTALL_DIR` directory instead

This should help with packaging on Linux, where the contents of [assets](https://github.com/seraxis/lr2oraja-endlessdream/tree/main/assets) could be installed to a read-only location such as `/usr/share/beatorja`. The game could then be launched and used from a completely empty working directory

Tested on Windows and Linux so far. Only altered the places I thought were necessary, so I might've missed something