### PR TITLE
Update shadow plugin to 8.3.9

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,7 +3,7 @@ import java.nio.file.FileSystems
 plugins {
     id("java-library")
     id("application")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "8.3.9"
     id("org.endlessdream.extra.multiplatform-convention")
 }
 
@@ -31,7 +31,7 @@ application {
 }
 
 tasks {
-    // fat/uber-jar task provided by https://github.com/johnrengelman/shadow
+    // fat/uber-jar task provided by https://github.com/GradleUp/shadow
     shadowJar {
         val platformProp = System.getProperty("platform")
         val archProp = System.getProperty("arch")


### PR DESCRIPTION
Updates the shadow plugin to use the new ID and bumps the version to 8.3.9

> Previously this plugin was developed by johnrengelman and published under the ID com.github.johnrengelman.shadow before maintenance was transferred to the GradleUp organization to ensure future development [...]

> If you are still using the old plugin ID in your build script, we recommend to switch to the new plugin ID com.gradleup.shadow and update to the latest version to receive all the latest bug fixes and improvements.

As per the [compatibility matrix](https://github.com/GradleUp/shadow?tab=readme-ov-file#compatibility-matrix), 8.3.x was selected as it is the latest version which is still compatible with 8.4

Fixes the following error when attempting to build with newer versions of Gradle:

```
Build file '/home/llm96/Projects/test-gradle-native/core/build.gradle.kts' line: 3

An exception occurred applying plugin request [id: 'com.github.johnrengelman.shadow', version: '8.1.1']
> Failed to apply plugin class 'com.github.jengelman.gradle.plugins.shadow.ShadowApplicationPlugin'.
   > Could not set unknown property 'fileMode' for object of type org.gradle.api.internal.file.copy.CopySpecWrapper_Decorated.
```

Tested with Gradle 9.1.0 & wrapper (8.4) in repo. Compared .jar files before/after applying patch - both identical