### PR TITLE
Don't submit scores to IR services for osu maps

### DIFF
--- a/core/src/bms/player/beatoraja/PlayerResource.java
+++ b/core/src/bms/player/beatoraja/PlayerResource.java
@@ -131,6 +131,7 @@ public final class PlayerResource {
 	private String tablefull;
 	private boolean freqOn;
 	private String freqString;
+	private boolean forceNoIRSend;
 	// Full list of difficult tables that contains current song
 	private List<String> reverseLookup = new ArrayList<>();
 
@@ -214,6 +215,9 @@ public final class PlayerResource {
 		BMSModel model = decoder.decode(info);
 		if (model == null) {
 			return null;
+		}
+		if (decoder instanceof OSUDecoder) {
+			model.setFromOSU(true);
 		}
 
 		marginTime = BMSModelUtils.setStartNoteTime(model, 1000);
@@ -624,7 +628,15 @@ public final class PlayerResource {
 	public void setFreqString(String freqString) {
 		this.freqString = freqString;
 	}
-	
+
+	public boolean isForceNoIRSend() {
+		return forceNoIRSend;
+	}
+
+	public void setForceNoIRSend(boolean forceNoIRSend) {
+		this.forceNoIRSend = forceNoIRSend;
+	}
+
 	public Future<BMSLoudnessAnalyzer.AnalysisResult> getAnalysisTask() {
 		return analysisTask;
 	}

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -191,6 +191,12 @@ public class BMSPlayer extends MainState {
 		}
 
 		boolean score = true;
+		boolean forceNoIRSend = false;
+
+		// Don't send score on osu maps to IR services
+		if (model.isFromOSU()) {
+			forceNoIRSend = true;
+		}
 
 		// RANDOM構文処理
 		if (model.getRandom() != null && model.getRandom().length > 0) {
@@ -227,6 +233,9 @@ public class BMSPlayer extends MainState {
 			if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
 				main.getAudioProcessor().setGlobalPitch(freq / 100f);
 			}
+
+			// Whenever using freq mode, score is forced to not send to IR service
+			forceNoIRSend = true;
 
 			// "Persist" some states in resource
 			resource.setFreqOn(true);
@@ -420,10 +429,11 @@ public class BMSPlayer extends MainState {
 			gaugelog[i] = new FloatArray(playtime / 500 + 2);
 		}
 
-		Logger.getGlobal().info("アシストレベル : " + assist + " - スコア保存 : " + score);
+		Logger.getGlobal().info("アシストレベル : " + assist + " - スコア保存 : " + score + " - no IR submit : " + forceNoIRSend);
 
 		resource.setUpdateScore(score);
 		resource.setUpdateCourseScore(resource.isUpdateCourseScore() && score);
+		resource.setForceNoIRSend(forceNoIRSend);
 		final int difficulty = resource.getSongdata() != null ? resource.getSongdata().getDifficulty() : 0;
 		resource.getSongdata().setBMSModel(model);
 		resource.getSongdata().setDifficulty(difficulty);

--- a/core/src/bms/player/beatoraja/result/CourseResult.java
+++ b/core/src/bms/player/beatoraja/result/CourseResult.java
@@ -93,7 +93,7 @@ public class CourseResult extends AbstractResult {
 			final int lnmode = uln ? config.getLnmode() : 0;
 			
         	for(IRStatus irc : ir) {
-    			boolean send = resource.isUpdateCourseScore() && resource.getCourseData().isRelease();
+    			boolean send = resource.isUpdateCourseScore() && !resource.isForceNoIRSend() && resource.getCourseData().isRelease();
     			switch(irc.config.getIrsend()) {
     			case IRConfig.IR_SEND_ALWAYS:
     				break;

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -82,7 +82,7 @@ public class MusicResult extends AbstractResult {
 			state = STATE_IR_PROCESSING;
 			
         	for(IRStatus irc : ir) {
-    			boolean send = resource.isUpdateScore();
+    			boolean send = resource.isUpdateScore() && !resource.isForceNoIRSend();
     			switch(irc.config.getIrsend()) {
     			case IRConfig.IR_SEND_ALWAYS:
     				break;


### PR DESCRIPTION
This pr aims to stop the score submission to IR services for osu maps by recording whether the song data is parsed by `OSUDecoder` and creating a new field `forceNoIRSend` in `PlayerResource` to explicitly stop the IR submission.

Note: This pr also flags the `forceNoIRSend` when using `freq` mod, it implements the same request compared to [here](https://github.com/seraxis/lr2oraja-endlessdream/commit/e9ea033afc3047d7b6108fc7c10bb575606b0584#diff-65c7b23b23534563acbf1a0f2391b0ce428766289591794d8ca62758c496bd89R454-R457). Currently this pr doesn't remove the code to set score as `NO_PLAY` to keep the behavior consistent. But this pr might be a better way to stop user submitting `freq` mod scores.