### PR TITLE
IR service's leaderboard doesn't show player's name

### DIFF
--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -382,7 +382,6 @@ public class MainController {
 		}
 		SongManagerMenu.injectMusicSelector(selector);
 		MiscSettingMenu.setMain(this);
-		LR2IRConnection.setMain(this);
 		decide = new MusicDecide(this);
 		result = new MusicResult(this);
 		gresult = new CourseResult(this);

--- a/core/src/bms/player/beatoraja/ir/LR2IRConnection.java
+++ b/core/src/bms/player/beatoraja/ir/LR2IRConnection.java
@@ -31,11 +31,6 @@ import java.util.List;
 public class LR2IRConnection {
 	private static final String IRUrl = "http://dream-pro.info/~lavalse/LR2IR/2";
 	private static ScoreDatabaseAccessor scoreDatabaseAccessor;
-	private static MainController main;
-
-	public static void setMain(MainController main) {
-		LR2IRConnection.main = main;
-	}
 
 	public static void setScoreDatabaseAccessor(ScoreDatabaseAccessor scoreDatabaseAccessor) {
 		LR2IRConnection.scoreDatabaseAccessor = scoreDatabaseAccessor;
@@ -112,7 +107,9 @@ public class LR2IRConnection {
 			IRScoreData[] scoreData = ranking.toBeatorajaScoreData(chart);
 			ScoreData localScore = scoreDatabaseAccessor.getScoreData(chart.sha256, chart.hasUndefinedLN ? chart.lntype : 0);
 			if (localScore != null) {
-				localScore.setPlayer(StringPropertyFactory.getStringProperty(StringPropertyFactory.StringType.player.name()).get(main.getCurrentState()));
+				// This is intentional behaivor, see IRScoreData's player definition
+				// and how we use this feature in LeaderBoardBar
+				localScore.setPlayer("");
 			}
 			return new Pair<>(localScore == null ? null : new IRScoreData(localScore), scoreData);
 		} catch (Exception e) {

--- a/core/src/bms/player/beatoraja/select/bar/LeaderBoardBar.java
+++ b/core/src/bms/player/beatoraja/select/bar/LeaderBoardBar.java
@@ -7,10 +7,12 @@ import bms.player.beatoraja.ir.IRScoreData;
 import bms.player.beatoraja.ir.LR2IRConnection;
 import bms.player.beatoraja.modmenu.ImGuiNotify;
 import bms.player.beatoraja.select.MusicSelector;
+import bms.player.beatoraja.skin.property.StringPropertyFactory;
 import bms.player.beatoraja.song.SongData;
 import javafx.util.Pair;
 
-import static bms.player.beatoraja.select.bar.FunctionBar.*;
+import static bms.player.beatoraja.select.bar.FunctionBar.STYLE_COURSE;
+import static bms.player.beatoraja.select.bar.FunctionBar.STYLE_TABLE;
 
 public class LeaderBoardBar extends DirectoryBar {
 	private final SongData songData;
@@ -58,12 +60,13 @@ public class LeaderBoardBar extends DirectoryBar {
 	 *
 	 * @param irScoreData ir scores, should be ordered by exscore. More specifically, the score has larger exscore
 	 *                    should be positioned before a smaller one
+	 * @implNote IRScoreData's player field would be an empty string when it represents the player's own score
 	 * @return bars
 	 */
 	public FunctionBar[] fromIRScoreData(IRScoreData[] irScoreData) {
 		FunctionBar[] bars = new FunctionBar[irScoreData.length];
 		for (int i = 0; i < irScoreData.length; i++) {
-			bars[i] = createFunctionBar(i + 1, irScoreData[i], false);
+			bars[i] = createFunctionBar(i + 1, irScoreData[i], irScoreData[i].player.isEmpty());
 		}
 		return bars;
 	}
@@ -117,9 +120,17 @@ public class LeaderBoardBar extends DirectoryBar {
 	private FunctionBar createFunctionBar(int rank, IRScoreData scoreData, boolean isSelfScore) {
 		FunctionBar irScoreBar = new FunctionBar((selector, self) -> {
 			// TODO: Hijack/Inherit random seed, like LR2IR gbattle
-		}, String.format("%d. %s", rank, scoreData.player), isSelfScore ? STYLE_COURSE : STYLE_TABLE);
+		},
+				String.format("%d. %s", rank, isSelfScore ? getCurrentPlayerName() : scoreData.player),
+				isSelfScore ? STYLE_COURSE : STYLE_TABLE
+		);
         irScoreBar.setScore(scoreData.convertToScoreData());
         irScoreBar.setLamp(scoreData.clear.id);
         return irScoreBar;
     }
+
+	private String getCurrentPlayerName() {
+		return StringPropertyFactory.getStringProperty(StringPropertyFactory.StringType.player.name())
+				.get(super.selector.main.getCurrentState());
+	}
 }


### PR DESCRIPTION
When querying leaderboard score from IR service, it returns an empty string as the name for current player's score. This is an intentional design from upstream. Therefore, in this commit, name is manually set to the player's own score.

Also this commit removes the `main` reference in `LR2IRConnection`, since we delayed the name set step to "build leaderboard's bars" phase.