### PR TITLE
Add a notification when next score won't be sent to IR service

### DIFF
--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -474,6 +474,9 @@ public class BMSPlayer extends MainState {
 		if (!score) {
 			ImGuiNotify.warning("Score nullifying options enabled. Next play will not be saved");
 		}
+		if (forceNoIRSend) {
+			ImGuiNotify.error("Special mod options enabled. Next play will not be submitted to IR");
+		}
 		Logger.getGlobal().info("アシストレベル : " + assist + " - スコア保存 : " + score + " - no IR submit : " + forceNoIRSend);
 
 		resource.setUpdateScore(score);


### PR DESCRIPTION
This pr fixes a small issue that should be resolved in #122: notify user if next play won't be sent to IR.
