### PR TITLE
Fix video flashes on macos

### DIFF
--- a/core/src/resources/whatsnew.html
+++ b/core/src/resources/whatsnew.html
@@ -127,7 +127,6 @@
         <ul>
         <li>[Linux] Certain skin fonts may only load partially due to incorrect letter case in their filenames. Can be manually resolved by renaming the offending files.</li>
         <li>[Linux] When loading configuration files created on Windows, skin settings will fail to transfer. Fix by replacing backslashes with forward slashes in the skin paths in saved skin settings in <code>config.json</code> and <code>config_play.json</code> in the player folder.</li>
-        <li>[macOS] Videos in skins sometimes “flash”</li>
         <li>Skin Widget Manager works abnormally when editing sliders or scrollbars</li>
         </ul>
     </body>


### PR DESCRIPTION
This pr intends to fix the issue that background video from skins sometimes flashes.
Example(without this pr):

https://github.com/user-attachments/assets/b6174b21-2818-466c-a077-04e2d057e1fa

As stated in #47, somehow the frame image grabbed by ffmpeg is ordering as `BGR` instead of `RGB`. The old way to fix this is by manipulating the pixel data one-by-one. This fixed the issue for playing the bga weirdly. But it introduces another issue: when there's a frame drop, the data somehow still be `BGR` (as the video shows) and causes "flashes". This issue can be reproduced by freezing the timer too.

> I guess some race conditions happened when there's a time gap. When quickly switching between folders, there's a small pause. By inserting logs we can find that the gap between two calls of `bms.player.beatoraja.play.bga.FFmpegProcessor#getFrame` is normally less than 10. But with a pause it can be longer than 1000. And flashes happening at the same time.

After some documentation discovery, I found that grabber actually has a way to specify its pixel format form, which is not only much elegant and can fix the two issues:


https://github.com/user-attachments/assets/fa24ccf5-a201-487a-b084-71941bb25def



Currently, this line is still wrapped as macos only to prevent unforeseeable issues.

