### PR TITLE
Local score is always displayed as rank zero

### DIFF
--- a/core/src/bms/player/beatoraja/select/bar/LeaderBoardBar.java
+++ b/core/src/bms/player/beatoraja/select/bar/LeaderBoardBar.java
@@ -98,10 +98,9 @@ public class LeaderBoardBar extends DirectoryBar {
 		FunctionBar[] bars = new FunctionBar[leaderboard.length + 1];
 		int id = 0;
 		boolean inserted = false;
-        FunctionBar playerBar = createFunctionBar(id, LeaderboardEntry.newEntryPrimaryIR(localScore), true);
         if (leaderboard.length == 0 || localScore.getExscore() > leaderboard[0].getIrScore().getExscore()) {
             id++;
-			bars[0] = playerBar;
+			bars[0] = createFunctionBar(id, LeaderboardEntry.newEntryPrimaryIR(localScore), true);
 			inserted = true;
 		}
         for (int i = 0; i < leaderboard.length; i++) {
@@ -111,13 +110,13 @@ public class LeaderBoardBar extends DirectoryBar {
 			id++;
             if (!inserted && score.getExscore() > localScore.getExscore() &&
                 (i == leaderboard.length - 1 || leaderboard[i + 1].getIrScore().getExscore() <= localScore.getExscore())) {
-                bars[id] = playerBar;
+                bars[id] = createFunctionBar(id + 1, LeaderboardEntry.newEntryPrimaryIR(localScore), true);
 				id++;
 				inserted = true;
 			}
 		}
 		if (!inserted) {
-			bars[id] = playerBar;
+			bars[id] = createFunctionBar(id, LeaderboardEntry.newEntryPrimaryIR(localScore), true);
 		}
 		return bars;
 	}


### PR DESCRIPTION
Fix an issue that introduced by the refactor from #131, the local score would always be displayed as rank zero.
After:
<img width="2560" height="1496" alt="image" src="https://github.com/user-attachments/assets/980ba6df-7a22-4a40-b634-39b3ddbbf340" />
