### PR TITLE
Refactor logging mechanism into slf4j

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -170,6 +170,7 @@ dependencies {
     implementation(libs.ebur128java)
 
     implementation(libs.javawebsocket)
+    implementation(libs.bundles.slf4j)
 
     // non-gradle managed file dependencies. jportaudio not on maven. "custom" scares me.
     implementation(":jportaudio")

--- a/core/src/bms/player/beatoraja/BMSResource.java
+++ b/core/src/bms/player/beatoraja/BMSResource.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja;
 
 import java.nio.file.Path;
 import java.util.ArrayDeque;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.model.BMSModel;
 import bms.player.beatoraja.audio.AudioDriver;
@@ -17,6 +18,7 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
  * @author exch
  */
 public class BMSResource {
+	private static final Logger logger = LoggerFactory.getLogger(BMSResource.class);
 
  	/**
 	 * 選曲中のBMS
@@ -75,7 +77,7 @@ public class BMSResource {
 				pix.dispose();
 			}
 		} catch(Throwable e) {
-			Logger.getGlobal().warning(e.getMessage());
+			logger.warn(e.getMessage());
 		}
 
 		if(backbmp != null) {
@@ -89,7 +91,7 @@ public class BMSResource {
 				pix.dispose();
 			}
 		} catch(Throwable e) {
-			Logger.getGlobal().warning(e.getMessage());
+			logger.warn(e.getMessage());
 		}
 
 		this.model = model;
@@ -109,7 +111,7 @@ public class BMSResource {
 					bga.setModel(bgamodel);
 					bgaon = bgamodel != null;
 				} catch (Throwable e) {
-					Logger.getGlobal().severe(e.getClass().getName() + " : " + e.getMessage());
+					logger.error("{} : {}", e.getClass().getName(), e.getMessage());
 					e.printStackTrace();
 				}
 			});
@@ -120,7 +122,7 @@ public class BMSResource {
 					audio.abort();
 					audio.setModel(model);
 				} catch (Throwable e) {
-					Logger.getGlobal().severe(e.getClass().getName() + " : " + e.getMessage());
+					logger.error("{} : {}", e.getClass().getName(), e.getMessage());
 					e.printStackTrace();
 				}
 			});

--- a/core/src/bms/player/beatoraja/Config.java
+++ b/core/src/bms/player/beatoraja/Config.java
@@ -7,7 +7,8 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.text.ParseException;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.system.RobustFile;
 import java.util.Map;
@@ -27,6 +28,7 @@ import com.badlogic.gdx.utils.SerializationException;
  * @author exch
  */
 public class Config implements Validatable {
+	private static final Logger logger = LoggerFactory.getLogger(Config.class);
 	
 	/**
 	 * 旧コンフィグパス。そのうち削除
@@ -917,9 +919,9 @@ public class Config implements Validatable {
 		try {
             Path configBackupPath = configpath.resolveSibling("config_sys_backup.json");
 			Files.copy(configpath, configBackupPath, StandardCopyOption.REPLACE_EXISTING);
-			Logger.getGlobal().info("Backup config written to " + configBackupPath);
+			logger.info("Backup config written to {}", configBackupPath);
 		} catch (IOException e) {
-			Logger.getGlobal().severe("Failed to write backup config file: " + e.getLocalizedMessage());
+			logger.error("Failed to write backup config file: {}", e.getLocalizedMessage());
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -5,7 +5,14 @@ import java.net.URL;
 import java.nio.file.*;
 import java.util.*;
 import java.util.logging.FileHandler;
-import java.util.logging.Logger;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+
+import de.damios.guacamole.gdx.log.LoggerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.JOptionPane;
 
@@ -34,6 +41,7 @@ import bms.player.beatoraja.song.SQLiteSongDatabaseAccessor;
 import bms.player.beatoraja.song.SongData;
 import bms.player.beatoraja.song.SongDatabaseAccessor;
 import bms.player.beatoraja.song.SongUtils;
+import org.slf4j.jul.JULServiceProvider;
 
 /**
  * 起動用クラス
@@ -41,6 +49,7 @@ import bms.player.beatoraja.song.SongUtils;
  * @author exch
  */
 public class MainLoader extends Application {
+	private static final Logger logger = LoggerFactory.getLogger(MainLoader.class);
 
 	private static final boolean ALLOWS_32BIT_JAVA = false;
 
@@ -59,9 +68,9 @@ public class MainLoader extends Application {
 			System.exit(1);
 		}
 
-		Logger logger = Logger.getGlobal();
+		java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("");
 		try {
-			logger.addHandler(new FileHandler("beatoraja_log.xml"));
+			rootLogger.addHandler(new FileHandler("beatoraja_log.xml"));
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}
@@ -185,7 +194,7 @@ public class MainLoader extends Application {
 				}
 				gdxDisplayMode = d;
 				if (gdxDisplayMode == null) {
-					Logger.getGlobal().warning(String.format("Current resolution(%dx%d) is not compatible with current monitor, full-screen mode might be malfunctioning", w, h));
+					logger.warn("Current resolution({}x{}) is not compatible with current monitor, full-screen mode might be malfunctioning", w, h);
 					gdxDisplayMode = targetMonitor == null ? Lwjgl3ApplicationConfiguration.getDisplayMode() : Lwjgl3ApplicationConfiguration.getDisplayMode(targetMonitor);
 				}
             } else {
@@ -243,8 +252,8 @@ public class MainLoader extends Application {
 				}
 
 				public void create() {
-                    Logger.getGlobal().info("Starting " + Version.versionLong);
-                    Logger.getGlobal().info ("[Build info] Build date: " + Version.getBuildDate() + ", Commit: " + Version.getGitCommitHash());
+					logger.info("Starting {}", Version.versionLong);
+					logger.info("[Build info] Build date: {}, Commit: {}", Version.getBuildDate(), Version.getGitCommitHash());
 					main.create();
 					if (displaymode == Config.DisplayMode.FULLSCREEN) {
 						Gdx.graphics.setFullscreenMode(finalGdxDisplayMode);
@@ -254,7 +263,7 @@ public class MainLoader extends Application {
 			//System.exit(0);
 		} catch (Throwable e) {
 			e.printStackTrace();
-			Logger.getGlobal().severe(e.getClass().getName() + " : " + e.getMessage());
+			logger.error("{} : {}", e.getClass().getName(), e.getMessage());
 		}
 		System.exit(0);
 	}
@@ -274,7 +283,7 @@ public class MainLoader extends Application {
 				Class.forName("org.sqlite.JDBC");
 				songdb = new SQLiteSongDatabaseAccessor(config.getSongpath(), config.getBmsroot());
 			} catch (ClassNotFoundException | PlayerConfigException e) {
-				Logger.getGlobal().severe("Failed to access score database: " + e.getLocalizedMessage());
+				logger.error("Failed to access score database: {}", e.getLocalizedMessage());
 			}
         }
 		return songdb;
@@ -339,10 +348,10 @@ public class MainLoader extends Application {
 				bmsinfo.exit();
 			});
 			primaryStage.show();
-//			Logger.getGlobal().info("初期化時間(ms) : " + (System.currentTimeMillis() - t));
+//			logger.info("初期化時間(ms) : " + (System.currentTimeMillis() - t));
 
 		} catch (IOException e) {
-			Logger.getGlobal().severe(e.getMessage());
+			logger.error(e.getMessage());
 			e.printStackTrace();
 		}
 	}
@@ -388,7 +397,7 @@ public class MainLoader extends Application {
                     dlurl = "https://github.com/seraxis/lr2oraja-endlessdream/releases/tag/pre-release";
                 }
 			} catch (Exception e) {
-				Logger.getGlobal().warning("最新版URL取得時例外:" + e.getMessage());
+				logger.warn("最新版URL取得時例外:{}", e.getMessage());
 				message = "バージョン情報を取得できませんでした";
 			}
 		}

--- a/core/src/bms/player/beatoraja/MessageRenderer.java
+++ b/core/src/bms/player/beatoraja/MessageRenderer.java
@@ -1,6 +1,7 @@
 package bms.player.beatoraja;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
@@ -21,6 +22,7 @@ import bms.player.beatoraja.select.MusicSelector;
  * @author exch
  */
 public class MessageRenderer implements Disposable  {
+	private static final Logger logger = LoggerFactory.getLogger(MessageRenderer.class);
 
 	private FreeTypeFontGenerator generator;
 	private final Array<Message> messages = new Array<Message>();
@@ -29,7 +31,7 @@ public class MessageRenderer implements Disposable  {
 		try {
 			generator = new FreeTypeFontGenerator(Gdx.files.internal(fontpath));				
 		} catch (GdxRuntimeException e) {
-			Logger.getGlobal().severe("Message Font読み込み失敗");
+			logger.error("Message Font読み込み失敗");
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/PixmapResourcePool.java
+++ b/core/src/bms/player/beatoraja/PixmapResourcePool.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.imageio.ImageIO;
 
@@ -16,6 +17,7 @@ import com.badlogic.gdx.graphics.PixmapIO;
  * @author exch
  */
 public class PixmapResourcePool extends ResourcePool<String, Pixmap> {
+	private static Logger logger = LoggerFactory.getLogger(PixmapResourcePool.class);
 
 	public PixmapResourcePool() {
 		super(1);
@@ -65,10 +67,10 @@ public class PixmapResourcePool extends ResourcePool<String, Pixmap> {
 				tex = new Pixmap(Gdx.files.internal(path));				
 			}
 		} catch (Throwable e) {
-			Logger.getGlobal().warning("BGAファイル読み込み失敗。" + e.getMessage());
+			logger.warn("BGAファイル読み込み失敗。{}", e.getMessage());
 		}
 		if (tex == null) {
-			Logger.getGlobal().warning("BGAファイル読み込み再試行:" + path);
+			logger.warn("BGAファイル読み込み再試行:{}", path);
 			try {
 				// TODO 一部のbmsはImageIO.readで失敗する(e.g. past glow)。別の画像デコーダーが必要
 				BufferedImage bi = ImageIO.read(f);
@@ -80,7 +82,7 @@ public class PixmapResourcePool extends ResourcePool<String, Pixmap> {
 					}
 				}
 			} catch (Throwable e) {
-				Logger.getGlobal().warning("BGAファイル読み込み失敗。" + e.getMessage());
+				logger.warn("BGAファイル読み込み失敗。{}", e.getMessage());
 				e.printStackTrace();
 			}
 		}

--- a/core/src/bms/player/beatoraja/PlayDataAccessor.java
+++ b/core/src/bms/player/beatoraja/PlayDataAccessor.java
@@ -5,7 +5,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -32,6 +33,7 @@ import com.badlogic.gdx.utils.StringBuilder;
  * @author exch
  */
 public final class PlayDataAccessor {
+	private static final Logger logger = LoggerFactory.getLogger(PlayDataAccessor.class);
 
 	// TODO スコアハッシュを付与するかどうかの判定(前のスコアハッシュの正当性を確認できなかった時)
 	// TODO BATTLEは別ハッシュで登録したい}			
@@ -296,7 +298,7 @@ public final class PlayDataAccessor {
 			}
 		}
 		updatePlayerData(newscore, time);
-		Logger.getGlobal().info("スコアデータベース更新完了 ");
+		logger.info("スコアデータベース更新完了 ");
 	}
 	
 	public ScoreData readScoreData(String hash, boolean ln, int lnmode, int option,
@@ -431,7 +433,7 @@ public final class PlayDataAccessor {
 			scorelogdb.setScoreLog(log);
 		}
 
-		Logger.getGlobal().info("スコアデータベース更新完了 ");
+		logger.info("スコアデータベース更新完了 ");
 
 	}
 
@@ -664,7 +666,7 @@ public final class PlayDataAccessor {
 			fw.write(json.prettyPrint(rd));
 			fw.flush();
 			fw.close();
-			Logger.getGlobal().info("コースリプレイを保存:" + path);
+			logger.info("コースリプレイを保存:{}", path);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/core/src/bms/player/beatoraja/PlayerConfig.java
+++ b/core/src/bms/player/beatoraja/PlayerConfig.java
@@ -4,7 +4,8 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.text.ParseException;
 
 import bms.player.beatoraja.system.RobustFile;
@@ -28,6 +29,7 @@ import com.badlogic.gdx.utils.SerializationException;
  * @author exch
  */
 public final class PlayerConfig {
+	private static final Logger logger = LoggerFactory.getLogger(PlayerConfig.class);
 
 	/**
 	 * 旧コンフィグパス。そのうち削除
@@ -443,7 +445,7 @@ public final class PlayerConfig {
 	public PlayModeConfig getMode10() {
 		if(mode10 == null || mode10.getController().length < 2) {
 			mode10 = new PlayModeConfig(Mode.BEAT_10K);
-			Logger.getGlobal().warning("mode10のPlayConfigを再構成");
+			logger.warn("mode10のPlayConfigを再構成");
 		}
 		return mode10;
 	}
@@ -455,7 +457,7 @@ public final class PlayerConfig {
 	public PlayModeConfig getMode14() {
 		if(mode14 == null || mode14.getController().length < 2) {
 			mode14 = new PlayModeConfig(Mode.BEAT_14K);
-			Logger.getGlobal().warning("mode14のPlayConfigを再構成");
+			logger.warn("mode14のPlayConfigを再構成");
 		}
 		return mode14;
 	}
@@ -483,7 +485,7 @@ public final class PlayerConfig {
 	public PlayModeConfig getMode24double() {
 		if(mode24double == null || mode24double.getController().length < 2) {
 			mode24double = new PlayModeConfig(Mode.KEYBOARD_24K_DOUBLE);
-			Logger.getGlobal().warning("mode24doubleのPlayConfigを再構成");
+			logger.warn("mode24doubleのPlayConfigを再構成");
 		}
 		return mode24double;
 	}
@@ -528,7 +530,7 @@ public final class PlayerConfig {
 	public SkinConfig[] getSkin() {
 		if(skin.length <= SkinType.getMaxSkinTypeID()) {
 			skin = Arrays.copyOf(skin, SkinType.getMaxSkinTypeID() + 1);
-			Logger.getGlobal().warning("skinを再構成");
+			logger.warn("skinを再構成");
 		}
 		return skin;
 	}
@@ -925,7 +927,7 @@ public final class PlayerConfig {
                 try {
                     Files.copy(parentPlayerScoreDBPath, Paths.get(config.getPlayerpath() + "/player1/score.db"));
                 } catch (IOException e) {
-					Logger.getGlobal().severe(String.format("Failed to copy playerscore.db to %s: %s", config.getPlayerpath(), e.getLocalizedMessage()));
+					logger.error("Failed to copy playerscore.db to {}: {}", config.getPlayerpath(), e.getLocalizedMessage());
                 }
             }
 
@@ -942,7 +944,7 @@ public final class PlayerConfig {
         try {
             Files.createDirectory(path);
         } catch (IOException e) {
-            Logger.getGlobal().severe(String.format("Failed to create directory at %s: %s", path, e.getLocalizedMessage()));
+            logger.error("Failed to create directory at {}: {}", path, e.getLocalizedMessage());
         }
     }
 
@@ -961,7 +963,7 @@ public final class PlayerConfig {
 				Files.copy(p, player1ReplayDir.resolve(p.getFileName()));
 			}
 		} catch(Throwable e) {
-			Logger.getGlobal().warning("Error while copying replays: " + e.getLocalizedMessage());
+			logger.warn("Error while copying replays: {}", e.getLocalizedMessage());
 		}
 	}
 
@@ -1059,9 +1061,9 @@ public final class PlayerConfig {
 		try {
 			Path configBackupPath = Paths.get(playerpath + "/" + playerid + "/config_backup.json");
 			Files.copy(path, configBackupPath, StandardCopyOption.REPLACE_EXISTING);
-			Logger.getGlobal().info("Backup config written to " + configBackupPath);
+			logger.info("Backup config written to {}", configBackupPath);
 		} catch (IOException e) {
-			Logger.getGlobal().severe("Failed to write backup config file: " + e.getLocalizedMessage());
+			logger.error("Failed to write backup config file: {}", e.getLocalizedMessage());
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/PlayerResource.java
+++ b/core/src/bms/player/beatoraja/PlayerResource.java
@@ -19,7 +19,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.concurrent.Future;
 
 /**
@@ -28,6 +29,7 @@ import java.util.concurrent.Future;
  * @author exch
  */
 public final class PlayerResource {
+	private static final Logger logger = LoggerFactory.getLogger(PlayerResource.class);
 	
 	/**
 	 * 選曲中のBMS
@@ -169,7 +171,7 @@ public final class PlayerResource {
 		replay = new ReplayData();
 		model = loadBMSModel(f, pconfig.getLnmode());
 		if (model == null) {
-			Logger.getGlobal().warning("楽曲が存在しないか、解析時にエラーが発生しました:" + f.toString());
+			logger.warn("楽曲が存在しないか、解析時にエラーが発生しました:{}", f.toString());
 			return false;
 		}
 		if (model.getAllTimeLines().length == 0) {

--- a/core/src/bms/player/beatoraja/RivalDataAccessor.java
+++ b/core/src/bms/player/beatoraja/RivalDataAccessor.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja;
 
 import java.io.File;
 import java.nio.file.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Stream;
 
 import com.badlogic.gdx.utils.Array;
@@ -19,6 +20,7 @@ import bms.player.beatoraja.song.SongData;
  * @author exch
  */
 public final class RivalDataAccessor {
+	private static final Logger logger = LoggerFactory.getLogger(RivalDataAccessor.class);
 
 	/**
 	 * ライバル情報
@@ -68,9 +70,9 @@ public final class RivalDataAccessor {
 						ScoreDataImporter scoreimport = new ScoreDataImporter(new ScoreDatabaseAccessor(main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + File.separatorChar + "score.db"));
 						scoreimport.importScores(convert(scores.getData()), main.getIRStatus()[0].config.getIrname());
 
-						Logger.getGlobal().info("IRからのスコアインポート完了");
+						logger.info("IRからのスコアインポート完了");
 					} else {
-						Logger.getGlobal().warning("IRからのスコアインポート失敗 : " + scores.getMessage());
+						logger.warn("IRからのスコアインポート失敗 : {}", scores.getMessage());
 					}					
 				} catch (Throwable e) {
 					e.printStackTrace();
@@ -117,9 +119,9 @@ public final class RivalDataAccessor {
 								IRResponse<IRScoreData[]> scores = main.getIRStatus()[0].connection.getPlayData(irplayer, null);
 								if(scores.isSucceeded()) {
 									scoredb.setScoreData(convert(scores.getData()));
-									Logger.getGlobal().info("IRからのライバルスコア取得完了 : " + rival.getName());
+									logger.info("IRからのライバルスコア取得完了 : {}", rival.getName());
 								} else {
-									Logger.getGlobal().warning("IRからのライバルスコア取得失敗 : " + scores.getMessage());
+									logger.warn("IRからのライバルスコア取得失敗 : {}", scores.getMessage());
 								}
 							}).start();
 						}
@@ -159,7 +161,7 @@ public final class RivalDataAccessor {
 											},songs, lnmode);
 										}
 									});
-									Logger.getGlobal().info("ローカルに保存されているライバルスコア取得完了 : " + info.getName());
+									logger.info("ローカルに保存されているライバルスコア取得完了 : {}", info.getName());
 								}
 							}
 						}
@@ -179,7 +181,7 @@ public final class RivalDataAccessor {
 					e.printStackTrace();
 				}
 			} else {
-				Logger.getGlobal().warning("IRからのライバル取得失敗 : " + response.getMessage());
+				logger.warn("IRからのライバル取得失敗 : {}", response.getMessage());
 			}
 		}
 	}

--- a/core/src/bms/player/beatoraja/ScoreDataLogDatabaseAccessor.java
+++ b/core/src/bms/player/beatoraja/ScoreDataLogDatabaseAccessor.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja;
 
 import java.sql.*;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
@@ -17,6 +18,7 @@ import org.sqlite.SQLiteConfig.SynchronousMode;
  * @author omi
  */
 public class ScoreDataLogDatabaseAccessor extends SQLiteDatabaseAccessor {
+	private static final Logger logger = LoggerFactory.getLogger(ScoreDataLogDatabaseAccessor.class);
 
 	private SQLiteDataSource ds;
 	private final ResultSetHandler<List<ScoreData>> scoreHandler = new BeanListHandler<ScoreData>(ScoreData.class);
@@ -84,7 +86,7 @@ public class ScoreDataLogDatabaseAccessor extends SQLiteDatabaseAccessor {
 			}
 			con.commit();
 		} catch (Exception e) {
-			Logger.getGlobal().severe("スコア更新時の例外:" + e.getMessage());
+			logger.error("スコア更新時の例外:" + e.getMessage());
 		}
 	}
 }

--- a/core/src/bms/player/beatoraja/ScoreDatabaseAccessor.java
+++ b/core/src/bms/player/beatoraja/ScoreDatabaseAccessor.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja;
 
 import java.sql.*;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
@@ -20,6 +21,7 @@ import org.sqlite.SQLiteConfig.SynchronousMode;
  * @author exch
  */
 public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
+	private static final Logger logger = LoggerFactory.getLogger(ScoreDatabaseAccessor.class);
 
 	private final QueryRunner qr;
 	
@@ -101,7 +103,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 				this.insert(qr, "player", new PlayerData());
 			}
 		} catch (SQLException e) {
-			Logger.getGlobal().severe("スコアデータベース初期化中の例外:" + e.getMessage());
+			logger.error("スコアデータベース初期化中の例外:{}", e.getMessage());
 		}
 	}
 	
@@ -112,7 +114,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 				return info.get(0);
 			}
 		} catch (Exception e) {
-			Logger.getGlobal().severe("スコア取得時の例外:" + e.getMessage());
+			logger.error("スコア取得時の例外:{}", e.getMessage());
 		}
 		return null;
 	}
@@ -123,7 +125,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 			insert(qr, "info", info);
 //			qr.update("insert into info " + "(id, name, rank) " + "values(?,?,?);", info.getId(), info.getName(), info.getRank());
 		} catch (Exception e) {
-			Logger.getGlobal().severe("スコア取得時の例外:" + e.getMessage());
+			logger.error("スコア取得時の例外:{}", e.getMessage());
 		}
 	}
 
@@ -141,7 +143,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 				result = sc;
 			}
 		} catch (Exception e) {
-			Logger.getGlobal().severe("スコア取得時の例外:" + e.getMessage());
+			logger.error("スコア取得時の例外:{}", e.getMessage());
 		}
 		return result;
 	}
@@ -196,7 +198,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 				}
 			}
 		} catch (Exception e) {
-			Logger.getGlobal().severe("スコア取得時の例外:" + e.getMessage());
+			logger.error("スコア取得時の例外:{}", e.getMessage());
 		}		
 	}
 
@@ -205,7 +207,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 		try {
 			score = Validatable.removeInvalidElements(qr.query("SELECT * FROM score WHERE " + sql, scoreHandler));
 		} catch (Exception e) {
-			Logger.getGlobal().severe("スコア取得時の例外:" + e.getMessage());
+			logger.error("スコア取得時の例外:{}", e.getMessage());
 		}
 		return score;
 
@@ -223,7 +225,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 			}
 			con.commit();
 		} catch (Exception e) {
-			Logger.getGlobal().severe("スコア更新時の例外:" + e.getMessage());
+			logger.error("スコア更新時の例外:{}", e.getMessage());
 		}
 	}
 
@@ -243,7 +245,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 			}
 			con.commit();
 		} catch (Exception e) {
-			Logger.getGlobal().severe("スコア更新時の例外:" + e.getMessage());
+			logger.error("スコア更新時の例外:{}", e.getMessage());
 		}
 	}
 
@@ -276,7 +278,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 					.query("SELECT * FROM player ORDER BY date DESC" + (count > 0 ? " limit " + count : ""), playerHandler);
 			result = pd.toArray(new PlayerData[0]);
 		} catch (Exception e) {
-			Logger.getGlobal().severe("プレイヤーデータ取得時の例外:" + e.getMessage());
+			logger.error("プレイヤーデータ取得時の例外:{}", e.getMessage());
 		}
 		return result != null ? result : new PlayerData[0];
 	}
@@ -299,7 +301,7 @@ public class ScoreDatabaseAccessor extends SQLiteDatabaseAccessor {
 			this.insert(qr, con, "player", pd);
 			con.commit();
 		} catch (Exception e) {
-			Logger.getGlobal().severe("スコア更新時の例外:" + e.getMessage());
+			logger.error("スコア更新時の例外:{}", e.getMessage());
 		}
 	}
 	

--- a/core/src/bms/player/beatoraja/SystemSoundManager.java
+++ b/core/src/bms/player/beatoraja/SystemSoundManager.java
@@ -4,7 +4,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Stream;
 
 import com.badlogic.gdx.utils.Array;
@@ -18,7 +19,8 @@ import bms.player.beatoraja.audio.AudioDriver;
  * @author exch
  */
 public class SystemSoundManager {
-	
+	private static final Logger logger = LoggerFactory.getLogger(SystemSoundManager.class);
+
 	private final MainController main;
 	/**
 	 * 検出されたBGMセットのディレクトリパス
@@ -48,7 +50,7 @@ public class SystemSoundManager {
 		if(config.getSoundpath() != null && config.getSoundpath().length() > 0) {
 			scan(Paths.get(config.getSoundpath()).toAbsolutePath(), sounds, "clear.wav");
 		}
-		Logger.getGlobal().info("検出されたBGM Set : " + bgms.size + " Sound Set : " + sounds.size);
+		logger.info("検出されたBGM Set : {} Sound Set : {}", bgms.size, sounds.size);
 	}
 
 	public void shuffle() {
@@ -58,7 +60,7 @@ public class SystemSoundManager {
 		if(sounds.size > 0) {
 			currentSoundPath = sounds.get((int) (Math.random() * sounds.size));
 		}
-		Logger.getGlobal().info("BGM Set : " + currentBGMPath + " Sound Set : " + currentSoundPath);
+		logger.info("BGM Set : {} Sound Set : {}", currentBGMPath, currentSoundPath);
 		
 		for(SoundType sound : SoundType.values()) {
 			for(Path p :getSoundPaths(sound)) {

--- a/core/src/bms/player/beatoraja/TableDataAccessor.java
+++ b/core/src/bms/player/beatoraja/TableDataAccessor.java
@@ -5,7 +5,8 @@ import java.nio.file.*;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -22,6 +23,7 @@ import bms.table.*;
  * @author exch
  */
 public class TableDataAccessor {
+	private static final Logger logger = LoggerFactory.getLogger(TableDataAccessor.class);
 	
 	private final String tabledir;
 
@@ -216,7 +218,7 @@ public class TableDataAccessor {
 				return td;
 			} catch (Throwable e) {
 				e.printStackTrace();
-				Logger.getGlobal().warning("難易度表 - "+url+" の読み込み失敗。");
+				logger.warn("難易度表 - "+url+" の読み込み失敗。");
 			}
 			return null;
 		}

--- a/core/src/bms/player/beatoraja/Version.java
+++ b/core/src/bms/player/beatoraja/Version.java
@@ -6,9 +6,11 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Properties;
 import java.util.TimeZone;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Version {
+    private static Logger logger = LoggerFactory.getLogger(Version.class);
     public static final int VERSION_MAJOR = 0;
     public static final int VERSION_MINOR = 3;
     public static final int VERSION_PATCH = 2;
@@ -97,7 +99,7 @@ public class Version {
             sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
             return sdf.parse(buildDate);
         } catch (Exception e) {
-            Logger.getGlobal().severe("Failed to parse build time: " + e.getMessage());
+			logger.error("Failed to parse build time: {}", e.getMessage());
             return null;
         }
     }
@@ -121,7 +123,7 @@ public class Version {
             buildMetaInfo.load(Version.class.getClassLoader().getResourceAsStream("resources/build.properties"));
         } catch (Exception e) {
             e.printStackTrace();
-            Logger.getGlobal().severe("Failed to load build meta info");
+            logger.error("Failed to load build meta info");
         }
     }
 }

--- a/core/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
+++ b/core/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
@@ -8,7 +8,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.badlogic.gdx.utils.*;
 
@@ -21,6 +22,7 @@ import com.badlogic.gdx.utils.*;
  *            音源データ
  */
 public abstract class AbstractAudioDriver<T> implements AudioDriver {
+	private static final Logger logger = LoggerFactory.getLogger(AbstractAudioDriver.class);
 
 	/**
 	 * 効果音マップ
@@ -180,7 +182,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 				sound = sound.audio != null ? sound : null;
 				soundmap.put(p, sound);
 			} catch (Exception e) {
-				Logger.getGlobal().warning("音源読み込み失敗。" + e.getMessage());
+				logger.warn("音源読み込み失敗。{}", e.getMessage());
 			}
 		}		
 		return sound;
@@ -242,7 +244,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 	 * @param model
 	 */
 	public synchronized void setModel(BMSModel model) {
-		Logger.getGlobal().info("音源ファイル読み込み開始。");
+		logger.info("音源ファイル読み込み開始。");
 		String[] wavlist = model.getWavList();
 		final int wavcount = wavlist.length;
 		boolean use_defaultsound = false;
@@ -340,12 +342,12 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 					}
 				}
 			} catch (InvalidPathException e) {
-				Logger.getGlobal().warning(e.getMessage());
+				logger.warn(e.getMessage());
 			}
 			progress.incrementAndGet();
 		});
 
-		Logger.getGlobal().info("音源ファイル読み込み完了。音源数:" + wavmap.length);
+		logger.info("音源ファイル読み込み完了。音源数:{}", wavmap.length);
 		for (int i = 0; i < wavmap.length; i++) {
 			if (slicesound[i] != null) {
 				this.slicesound[i] = slicesound[i].toArray(SliceWav.class);
@@ -356,7 +358,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 
 		final int prevsize = cache.size();
 		cache.disposeOld();
-		Logger.getGlobal().info("AudioCache容量 : " + cache.size() + " 開放 : " + (prevsize - cache.size()));
+		logger.info("AudioCache容量 : {} 開放 : {}", cache.size(), prevsize - cache.size());
 
 		progress.set(noteMapSize);
 	}
@@ -611,7 +613,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
                     // " start:" + note.getStarttime() +
                     // " duration:" + note.getDuration());
                 } catch (Throwable e) {
-                    Logger.getGlobal().warning("音源(wav)ファイルスライシング失敗。" + e.getMessage());
+					logger.warn("音源(wav)ファイルスライシング失敗。{}", e.getMessage());
                     e.printStackTrace();
                 }
             }
@@ -621,14 +623,14 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 
 		@Override
 		protected T load(AudioKey key) {
-		    Logger.getGlobal().fine("音源ファイルを読み込む中：" + key.path);
+			logger.trace("音源ファイルを読み込む中：{}", key.path);
 
 		    T sound = key.start == 0 && key.duration == 0
                     ? getKeySound(Paths.get(key.path)) // 音切りなしのケース
                     : loadSlice(key);
 
 		    if (sound == null) {
-                Logger.getGlobal().warning("音源ファイル読み込み失敗：" + key.path);
+				logger.warn("音源ファイル読み込み失敗：{}", key.path);
             }
 			return sound;
 		}

--- a/core/src/bms/player/beatoraja/audio/BMSLoudnessAnalyzer.java
+++ b/core/src/bms/player/beatoraja/audio/BMSLoudnessAnalyzer.java
@@ -9,7 +9,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.PerformanceMetrics;
 import io.github.llm96.ebur128java.Channel;
@@ -18,6 +19,7 @@ import io.github.llm96.ebur128java.Mode;
 import io.github.llm96.ebur128java.State;
 
 public class BMSLoudnessAnalyzer {
+	private static final Logger logger = LoggerFactory.getLogger(BMSLoudnessAnalyzer.class);
 
 	private final ExecutorService executor;
 	private final boolean available;
@@ -67,7 +69,7 @@ public class BMSLoudnessAnalyzer {
 			try {
 				Files.createDirectories(cacheDir);
 			} catch (Exception e) {
-				Logger.getGlobal().warning("Failed to create cache directory: " + e.getMessage());
+				logger.warn("Failed to create cache directory: {}", e.getMessage());
 			}
 		}
 
@@ -93,7 +95,7 @@ public class BMSLoudnessAnalyzer {
 			testState.close();
 			return true;
 		} catch (Exception e) {
-			Logger.getGlobal().warning("libebur128 not available: " + e.getMessage());
+			logger.warn("libebur128 not available: {}", e.getMessage());
 			return false;
 		}
 	}
@@ -137,7 +139,7 @@ public class BMSLoudnessAnalyzer {
 				return new AnalysisResult(model, loudness);
 			}
 		} catch (Exception e) {
-			Logger.getGlobal().severe("Loudness analysis failed: " + e.getMessage());
+			logger.error("Loudness analysis failed: {}", e.getMessage());
 			e.printStackTrace();
 			return new AnalysisResult(model, "Analysis error: " + e.getMessage());
 		}
@@ -181,7 +183,7 @@ public class BMSLoudnessAnalyzer {
 				return Double.parseDouble(content);
 			}
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Failed to read cache for " + hash + ": " + e.getMessage());
+			logger.warn("Failed to read cache for {}: {}", hash, e.getMessage());
 		}
 		return null;
 	}
@@ -190,9 +192,9 @@ public class BMSLoudnessAnalyzer {
 		try {
 			Path cacheFile = cacheDir.resolve(hash + ".lufs");
 			Files.write(cacheFile, String.valueOf(loudness).getBytes());
-			Logger.getGlobal().info("Cached loudness for " + hash + ": " + loudness + " LUFS");
+			logger.info("Cached loudness for {}: {} LUFS", hash, loudness);
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Failed to write cache for " + hash + ": " + e.getMessage());
+			logger.warn("Failed to write cache for {}: {}", hash, e.getMessage());
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/audio/BytePCM.java
+++ b/core/src/bms/player/beatoraja/audio/BytePCM.java
@@ -142,7 +142,7 @@ public class BytePCM extends PCM<byte[]> {
 			}
 		}
 //		if(length != orglength) {
-//			Logger.getGlobal().info("終端の無音データ除外 - " + (orglength - length) + " samples");
+//			logger.info("終端の無音データ除外 - " + (orglength - length) + " samples");
 //		}
 		return length > 0 ? new BytePCM(channels, sampleRate, this.start + start, length, this.sample) : null;
 	}

--- a/core/src/bms/player/beatoraja/audio/FloatPCM.java
+++ b/core/src/bms/player/beatoraja/audio/FloatPCM.java
@@ -148,7 +148,7 @@ public class FloatPCM extends PCM<float[]> {
 			}
 		}
 //		if(length != orglength) {
-//			Logger.getGlobal().info("終端の無音データ除外 - " + (orglength - length) + " samples");
+//			logger.info("終端の無音データ除外 - " + (orglength - length) + " samples");
 //		}
 		return length > 0 ? new FloatPCM(channels, sampleRate, this.start + start, length, this.sample) : null;
 	}

--- a/core/src/bms/player/beatoraja/audio/GdxSoundDriver.java
+++ b/core/src/bms/player/beatoraja/audio/GdxSoundDriver.java
@@ -5,7 +5,8 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.*;
 import java.util.Locale;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.Config;
 import com.badlogic.gdx.Gdx;
@@ -20,6 +21,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * @author exch
  */
 public class GdxSoundDriver extends AbstractAudioDriver<Sound> {
+	private static final Logger logger = LoggerFactory.getLogger(GdxSoundDriver.class);
 
 	private SoundMixer mixer;
 
@@ -72,7 +74,7 @@ public class GdxSoundDriver extends AbstractAudioDriver<Sound> {
 		try {
 			return Gdx.audio.newSound(handle);
 		} catch (GdxRuntimeException e) {
-			Logger.getGlobal().warning("音源ファイル読み込み失敗" + e.getMessage());
+			logger.warn("音源ファイル読み込み失敗" + e.getMessage());
 		}
 		return null;
 	}

--- a/core/src/bms/player/beatoraja/audio/PCM.java
+++ b/core/src/bms/player/beatoraja/audio/PCM.java
@@ -5,7 +5,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.jflac.FLACDecoder;
 import org.jflac.metadata.StreamInfo;
@@ -27,6 +28,7 @@ import javazoom.jl.decoder.OutputBuffer;
  * @author exch
  */
 public abstract class PCM<T> {
+	private static final Logger logger = LoggerFactory.getLogger(PCM.class);
 
 	protected static final boolean USE_UNSAFE = false;
 
@@ -91,7 +93,7 @@ public abstract class PCM<T> {
 			if(pcm.validate()) {
 				return pcm;
 			} else {
-				Logger.getGlobal().warning("音源の読み込みに失敗しました - file : " + p);
+				logger.warn("音源の読み込みに失敗しました - file : {}", p);
 				return null;
 			}
 		} catch (IOException e) {
@@ -203,9 +205,9 @@ public abstract class PCM<T> {
 						sampleRate = input.sampleRate;
 						bitsPerSample = 16;
 						blockAlign = input.blockAlign;
-//						Logger.getGlobal().info("channels: " + channels);
-//						Logger.getGlobal().info("sample rate: " + sampleRate);
-//						Logger.getGlobal().info("block align" + blockAlign);
+//						logger.info("channels: " + channels);
+//						logger.info("sample rate: " + sampleRate);
+//						logger.info("block align" + blockAlign);
 
 						OptimizedByteArrayOutputStream inputByteStream = new OptimizedByteArrayOutputStream(input.dataRemaining);
 						StreamUtils.copyStream(input, inputByteStream);
@@ -215,7 +217,7 @@ public abstract class PCM<T> {
 						pcm = decoder.decode(inputByteBuffer);
 
 
-						Logger.getGlobal().info("Filename: " + p );
+						logger.info("Filename: {}", p);
 						break;
 					}
 					// IMA-ADPCM Decoder
@@ -232,9 +234,9 @@ public abstract class PCM<T> {
 						ByteBuffer input_test = ByteBuffer.wrap(output2.getBuffer()).order(ByteOrder.LITTLE_ENDIAN);
 						pcm.limit(output2.size());
 						if (wavinput == input_test) {
-							Logger.getGlobal().info("They are the same");
+							logger.info("They are the same");
 						} else {
-							Logger.getGlobal().info("They are the different");
+							logger.info("They are the different");
 						}
 						OptimizedByteArrayOutputStream output = new OptimizedByteArrayOutputStream(input.dataRemaining);
 						StreamUtils.copyStream(input, output);
@@ -304,7 +306,7 @@ public abstract class PCM<T> {
 						throw new IOException(p.toString() + " unsupported WAV format ID : " + input.type);					
 					}
 				} catch (Throwable e) {
-					Logger.getGlobal().warning("WAV処理中の例外 - file : " + p + " error : "+ e.getMessage() + e);
+					logger.warn("WAV処理中の例外 - file : {} error : {}{}", p, e.getMessage(), e.toString());
 				}
 			} else if (name.endsWith(".ogg")) {
 				// ogg
@@ -408,7 +410,7 @@ public abstract class PCM<T> {
 				}
 			}
 //			if(bytes != orgbytes) {
-//				Logger.getGlobal().info("終端の無音データ除外 - " + p.getFileName().toString() + " : " + (orgbytes - bytes) + " bytes");
+//				logger.info("終端の無音データ除外 - " + p.getFileName().toString() + " : " + (orgbytes - bytes) + " bytes");
 //			}
 			if(bytes < channels * bitsPerSample / 8) {
 				throw new IOException(p.toString() + " : 0 samples");			

--- a/core/src/bms/player/beatoraja/audio/ShortDirectPCM.java
+++ b/core/src/bms/player/beatoraja/audio/ShortDirectPCM.java
@@ -152,7 +152,7 @@ public class ShortDirectPCM extends PCM<ByteBuffer> {
 			}
 		}
 //		if(length != orglength) {
-//			Logger.getGlobal().info("終端の無音データ除外 - " + (orglength - length) + " samples");
+//			logger.info("終端の無音データ除外 - " + (orglength - length) + " samples");
 //		}
 		return length > 0 ? new ShortDirectPCM(channels, sampleRate, this.start + start, length, this.sample) : null;
 	}

--- a/core/src/bms/player/beatoraja/audio/ShortPCM.java
+++ b/core/src/bms/player/beatoraja/audio/ShortPCM.java
@@ -149,7 +149,7 @@ public class ShortPCM extends PCM<short[]> {
 			}
 		}
 //		if(length != orglength) {
-//			Logger.getGlobal().info("終端の無音データ除外 - " + (orglength - length) + " samples");
+//			logger.info("終端の無音データ除外 - " + (orglength - length) + " samples");
 //		}
 		return length > 0 ? new ShortPCM(channels, sampleRate, this.start + start, length, this.sample) : null;
 	}

--- a/core/src/bms/player/beatoraja/config/KeyConfiguration.java
+++ b/core/src/bms/player/beatoraja/config/KeyConfiguration.java
@@ -26,7 +26,8 @@ import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator.FreeTypeFont
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import space.earlygrey.shapedrawer.ShapeDrawer;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * キーコンフィグ画面
@@ -34,6 +35,7 @@ import java.util.logging.Logger;
  * @author exch
  */
 public class KeyConfiguration extends MainState {
+	private static final Logger logger = LoggerFactory.getLogger(KeyConfiguration.class);
 
 	// TODO スキンベースへ移行
 
@@ -116,7 +118,7 @@ public class KeyConfiguration extends MainState {
 			titlefont = generator.generateFont(parameter);
 			generator.dispose();
 		} catch (GdxRuntimeException e) {
-			Logger.getGlobal().severe("Font読み込み失敗");
+			logger.error("Font読み込み失敗");
 		}
 
 		input = main.getInputProcessor();

--- a/core/src/bms/player/beatoraja/config/SkinConfiguration.java
+++ b/core/src/bms/player/beatoraja/config/SkinConfiguration.java
@@ -18,7 +18,8 @@ import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Stream;
 
 /**
@@ -27,6 +28,7 @@ import java.util.stream.Stream;
  * @author excln
  */
 public class SkinConfiguration extends MainState {
+	private static final Logger logger = LoggerFactory.getLogger(SkinConfiguration.class);
 
 	private SkinConfigurationSkin skin;
 	private SkinType type;
@@ -169,7 +171,7 @@ public class SkinConfiguration extends MainState {
 
 	private void setOtherSkin(int indexDiff) {
 		if (availableSkins.isEmpty()) {
-			Logger.getGlobal().warning("利用可能なスキンがありません");
+			logger.warn("利用可能なスキンがありません");
 			return;
 		}
 

--- a/core/src/bms/player/beatoraja/external/BMSSearchAccessor.java
+++ b/core/src/bms/player/beatoraja/external/BMSSearchAccessor.java
@@ -4,7 +4,10 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
+
+import bms.player.beatoraja.config.SkinConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.song.SongData;
 import com.badlogic.gdx.utils.Json;
@@ -18,6 +21,7 @@ import bms.player.beatoraja.TableData.TableFolder;
  * @author exch
  */
 public class BMSSearchAccessor extends TableDataAccessor.TableAccessor {
+	private static final Logger logger = LoggerFactory.getLogger(BMSSearchAccessor.class);
 	private static String API_STRING = "https://api.bmssearch.net/v1/bmses/search?orderBy=PUBLISHED&orderDirection=DESC&limit=20";
 
 	private String tabledir;
@@ -69,9 +73,9 @@ public class BMSSearchAccessor extends TableDataAccessor.TableAccessor {
 			tdenew.setSong(songs.toArray(new SongData[songs.size()]));
 			td.setFolder(new TableFolder[] { tdenew });
 			td.setName("BMS Search");
-			Logger.getGlobal().info("BMS Search取得完了");
+			logger.info("BMS Search取得完了");
 		} catch (Throwable e) {
-			Logger.getGlobal().severe("BMS Search更新中の例外:" + e.getMessage());
+			logger.error("BMS Search更新中の例外:{}", e.getMessage());
 		}
 		return td;
 	}

--- a/core/src/bms/player/beatoraja/external/DiscordListener.java
+++ b/core/src/bms/player/beatoraja/external/DiscordListener.java
@@ -10,9 +10,11 @@ import bms.player.beatoraja.result.MusicResult;
 import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.external.DiscordRPC.RichPresence;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DiscordListener implements MainStateListener {
+	private static final Logger logger = LoggerFactory.getLogger(DiscordListener.class);
 
 	private static final String APPLICATION_ID = "1054234988167561277";
 
@@ -22,10 +24,10 @@ public class DiscordListener implements MainStateListener {
 		try {
 			richPresence = new RichPresence(APPLICATION_ID);
 			richPresence.connect();
-			Logger.getGlobal().info("Discord RPC Ready!");
+			logger.info("Discord RPC Ready!");
 		} catch (Exception e) {
 			richPresence = null;
-			Logger.getGlobal().warning("Failed to initialize Discord RPC: " + e.getMessage());
+			logger.warn("Failed to initialize Discord RPC: {}", e.getMessage());
 		}
 	}
 	
@@ -54,7 +56,7 @@ public class DiscordListener implements MainStateListener {
 			
 			richPresence.update(data);
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Failed to update Discord Rich Presence: " + e.getMessage());
+			logger.warn("Failed to update Discord Rich Presence: {}", e.getMessage());
 		}
 	}
 	

--- a/core/src/bms/player/beatoraja/external/DiscordRPC/UnixIPCConnection.java
+++ b/core/src/bms/player/beatoraja/external/DiscordRPC/UnixIPCConnection.java
@@ -6,9 +6,11 @@ import java.net.UnixDomainSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Path;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class UnixIPCConnection implements IPCConnection {
+    private static final Logger logger = LoggerFactory.getLogger(UnixIPCConnection.class);
     private SocketChannel socket;
 
     @Override
@@ -49,7 +51,7 @@ class UnixIPCConnection implements IPCConnection {
             try {
                 socket.close();
             } catch (IOException e) {
-                Logger.getGlobal().warning("Failed to close Unix socket: " + e.getMessage());
+				logger.warn("Failed to close Unix socket: {}", e.getMessage());
             }
         }
     }

--- a/core/src/bms/player/beatoraja/external/ScoreDataImporter.java
+++ b/core/src/bms/player/beatoraja/external/ScoreDataImporter.java
@@ -12,9 +12,11 @@ import java.sql.DriverManager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ScoreDataImporter {
+    private static final Logger logger = LoggerFactory.getLogger(ScoreDataImporter.class);
 
     private ScoreDatabaseAccessor scoredb;
 
@@ -54,7 +56,7 @@ public class ScoreDataImporter {
             
             this.importScores(result.toArray(new ScoreData[result.size()]), "LR2");
         } catch (Exception e) {
-            Logger.getGlobal().severe("スコア移行時の例外:" + e.getMessage());
+			logger.error("スコア移行時の例外:{}", e.getMessage());
         }
     }
 
@@ -78,6 +80,6 @@ public class ScoreDataImporter {
         }
         
         scoredb.setScoreData(result.toArray(new ScoreData[result.size()]));
-		Logger.getGlobal().info("スコアインポート完了 - インポート数 : " + result.size());
+		logger.info("スコアインポート完了 - インポート数 : {}", result.size());
     }
 }

--- a/core/src/bms/player/beatoraja/external/ScreenShotFileExporter.java
+++ b/core/src/bms/player/beatoraja/external/ScreenShotFileExporter.java
@@ -34,12 +34,14 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 
 import static bms.player.beatoraja.skin.SkinProperty.*;
 
 public class ScreenShotFileExporter implements ScreenShotExporter {
+    private static final Logger logger = LoggerFactory.getLogger(ScreenShotFileExporter.class);
 
     @Override
     public boolean send(MainState currentState, byte[] pixels) {
@@ -87,7 +89,7 @@ public class ScreenShotFileExporter implements ScreenShotExporter {
             String path = "screenshot/" + sdf.format(Calendar.getInstance().getTime()) + stateName + ".png";
             BufferUtils.copy(pixels, 0, pixmap.getPixels(), pixels.length);
             PixmapIO.writePNG(new FileHandle(path), pixmap);
-            Logger.getGlobal().info("スクリーンショット保存:" + path);
+            logger.info("スクリーンショット保存:" + path);
             pixmap.dispose();
             ImGuiNotify.info(String.format("Screen shot saved: %s", path), 2000);
 
@@ -121,7 +123,7 @@ public class ScreenShotFileExporter implements ScreenShotExporter {
             Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
             ImageTransferable imageTransferable = new ImageTransferable(output);
             clipboard.setContents(imageTransferable, null);
-            Logger.getGlobal().info("スクリーンショット保存: Clipboard");
+            logger.info("スクリーンショット保存: Clipboard");
             ImGuiNotify.info("Screen shot saved : Clipboard", 2000);
         } catch (Exception e) {
             e.printStackTrace();

--- a/core/src/bms/player/beatoraja/external/ScreenShotTwitterExporter.java
+++ b/core/src/bms/player/beatoraja/external/ScreenShotTwitterExporter.java
@@ -8,7 +8,8 @@ import static bms.player.beatoraja.skin.SkinProperty.STRING_TABLE_NAME;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.modmenu.ImGuiNotify;
 import com.badlogic.gdx.Gdx;
@@ -35,6 +36,7 @@ import twitter4j.UploadedMedia;
 import twitter4j.conf.ConfigurationBuilder;
 
 public class ScreenShotTwitterExporter implements ScreenShotExporter {
+	private static final Logger logger = LoggerFactory.getLogger(ScreenShotTwitterExporter.class);
 
 	private String consumerKey;
 	private String consumerSecret;
@@ -113,11 +115,11 @@ public class ScreenShotTwitterExporter implements ScreenShotExporter {
 
 			// Upload Media and Post
 			UploadedMedia mediastatus = twitter.uploadMedia("from beatoraja", byteArrayInputStream);
-			Logger.getGlobal().info("Twitter Media Upload:" + mediastatus.toString());
+			logger.info("Twitter Media Upload:{}", mediastatus.toString());
 			StatusUpdate update = new StatusUpdate(text);
 			update.setMediaIds(new long[]{mediastatus.getMediaId()});
 			Status status = twitter.updateStatus(update);
-			Logger.getGlobal().info("Twitter Post:" + status.toString());
+			logger.info("Twitter Post:{}", status.toString());
 			pixmap.dispose();
 	        ImGuiNotify.info(String.format("Twitter Upload: %s", text), 2000);
 			return true;

--- a/core/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
+++ b/core/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
@@ -4,7 +4,8 @@ import bms.player.beatoraja.*;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Stream;
 
 import bms.player.beatoraja.PlayModeConfig.*;
@@ -21,6 +22,7 @@ import com.badlogic.gdx.utils.Array;
  * @author exch
  */
 public class BMSPlayerInputProcessor {
+	private static final Logger logger = LoggerFactory.getLogger(BMSPlayerInputProcessor.class);
 	
 	private boolean enable = true;
 
@@ -40,7 +42,7 @@ public class BMSPlayerInputProcessor {
 
 		Array<BMControllerInputProcessor> bminput = new Array<BMControllerInputProcessor>();
 		for (Controller controller : Controllers.getControllers()) {
-			Logger.getGlobal().info("コントローラーを検出 : " + controller.getName());
+			logger.info("コントローラーを検出 : " + controller.getName());
 			// FIXME:前回終了時のModeからコントローラ設定を復元
 			ControllerConfig controllerConfig = Stream.of(player.getMode7().getController())
 				.filter(m -> {

--- a/core/src/bms/player/beatoraja/ir/IRConnectionManager.java
+++ b/core/src/bms/player/beatoraja/ir/IRConnectionManager.java
@@ -9,7 +9,8 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * IRConnectionの管理用クラス
@@ -17,6 +18,7 @@ import java.util.logging.Logger;
  * @author exch
  */
 public class IRConnectionManager {
+	private static final Logger logger = LoggerFactory.getLogger(IRConnectionManager.class);
 	
 	/**
 	 * 検出されたIRConnection
@@ -113,7 +115,7 @@ public class IRConnectionManager {
 							}
 						}
 					} catch(Throwable e) {
-						Logger.getGlobal().warning("Jarファイル読み込み失敗 - " + url.toString() + " : " + e.getMessage());
+						logger.warn("Jarファイル読み込み失敗 - " + url.toString() + " : " + e.getMessage());
 					}
 				}
 				if (url.getProtocol().equals("file")) {

--- a/core/src/bms/player/beatoraja/ir/RankingData.java
+++ b/core/src/bms/player/beatoraja/ir/RankingData.java
@@ -1,7 +1,8 @@
 package bms.player.beatoraja.ir;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.*;
 import bms.player.beatoraja.MainController.IRStatus;
@@ -13,6 +14,7 @@ import bms.player.beatoraja.song.SongData;
  * @author exch
  */
 public class RankingData {
+	private static final Logger logger = LoggerFactory.getLogger(RankingData.class);
 	/**
 	 * 選択されている楽曲の現在のIR順位
 	 */
@@ -71,10 +73,10 @@ public class RankingData {
 	        }
 	        if(response.isSucceeded()) {
 	        	updateScore(response.getData(), mainstate.getScoreDataProperty().getScoreData());
-	            Logger.getGlobal().fine("IRからのスコア取得成功 : " + response.getMessage());
+				logger.trace("IRからのスコア取得成功 : {}", response.getMessage());
 				state = FINISH;
 	        } else {
-	            Logger.getGlobal().warning("IRからのスコア取得失敗 : " + response.getMessage());
+				logger.warn("IRからのスコア取得失敗 : {}", response.getMessage());
 				state = FAIL;
 	        }
 	        lastUpdateTime = System.currentTimeMillis();

--- a/core/src/bms/player/beatoraja/launcher/AudioConfigurationView.java
+++ b/core/src/bms/player/beatoraja/launcher/AudioConfigurationView.java
@@ -4,7 +4,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.portaudio.DeviceInfo;
 
@@ -22,6 +23,7 @@ import javafx.scene.control.Slider;
 import javafx.scene.control.Spinner;
 
 public class AudioConfigurationView implements Initializable {
+	private static final Logger logger = LoggerFactory.getLogger(AudioConfigurationView.class);
 
 	@FXML
 	private ComboBox<DriverType> audio;
@@ -133,7 +135,7 @@ public class AudioConfigurationView implements Initializable {
 				audiosim.setDisable(false);
 //				PortAudio.terminate();
 			} catch(Throwable e) {
-				Logger.getGlobal().severe("PortAudioは選択できません : " + e.getMessage());
+				logger.error("PortAudioは選択できません : {}", e.getMessage());
 				audio.setValue(DriverType.OpenAL);
 			}
 			break;

--- a/core/src/bms/player/beatoraja/launcher/IRConfigurationView.java
+++ b/core/src/bms/player/beatoraja/launcher/IRConfigurationView.java
@@ -4,7 +4,8 @@ import java.awt.Desktop;
 import java.net.URI;
 import java.net.URL;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.IRConfig;
 import bms.player.beatoraja.PlayerConfig;
@@ -20,6 +21,7 @@ import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
 
 public class IRConfigurationView implements Initializable {
+	private static final Logger logger = LoggerFactory.getLogger(IRConfigurationView.class);
 	
 	@FXML
 	private Button primarybutton;
@@ -122,7 +124,7 @@ public class IRConfigurationView implements Initializable {
                 uri = new URI(homeurl);
                 desktop.browse(uri);
             } catch (Exception e) {
-                Logger.getGlobal().warning("最新版URLアクセス時例外:" + e.getMessage());
+				logger.warn("最新版URLアクセス時例外:{}", e.getMessage());
             }
         });
 		

--- a/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
+++ b/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
@@ -8,8 +8,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.*;
 import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 import bms.player.beatoraja.exceptions.PlayerConfigException;
 import bms.player.beatoraja.external.ScoreDataImporter;
@@ -57,6 +58,7 @@ import twitter4j.conf.ConfigurationBuilder;
  * @author exch
  */
 public class PlayConfigurationView implements Initializable {
+	private static final Logger logger = LoggerFactory.getLogger(PlayConfigurationView.class);
     // TODO スキンプレビュー機能
 
 	@FXML
@@ -355,7 +357,7 @@ public class PlayConfigurationView implements Initializable {
 		obsController.init(this);
 
 		checkNewVersion();
-		Logger.getGlobal().info("初期化時間(ms) : " + (System.currentTimeMillis() - t));
+		logger.info("初期化時間(ms) : " + (System.currentTimeMillis() - t));
 	}
 
     @FXML
@@ -427,7 +429,7 @@ public class PlayConfigurationView implements Initializable {
                                     desktop.browse(uri);
                                 }
                                 catch (Exception e) {
-                                    Logger.getGlobal().warning("最新版URLアクセス時例外:" + e.getMessage());
+                                    logger.warn("最新版URLアクセス時例外:" + e.getMessage());
                                 }
                             });
 						}
@@ -528,7 +530,7 @@ public class PlayConfigurationView implements Initializable {
         try {
             player = PlayerConfig.readPlayerConfig(config.getPlayerpath(), players.getValue());
         } catch (PlayerConfigException e) {
-            Logger.getGlobal().warning("Player config failed to load: " + e.getLocalizedMessage());
+            logger.warn("Player config failed to load: " + e.getLocalizedMessage());
 			player = PlayerConfig.validatePlayerConfig("player1", new PlayerConfig());
         }
         playername.setText(player.getName());
@@ -908,9 +910,9 @@ public class PlayConfigurationView implements Initializable {
                 SongDatabaseAccessor songdb = MainLoader.getScoreDatabaseAccessor();
                 SongInformationAccessor infodb = config.isUseSongInfo() ?
                         new SongInformationAccessor(Paths.get("songinfo.db").toString()) : null;
-                Logger.getGlobal().info("song.db更新開始");
-                songdb.updateSongDatas(updatepath, config.getBmsroot(), updateAll, infodb, songDatabaseUpdateListener);
-                Logger.getGlobal().info("song.db更新完了");
+                logger.info("song.db更新開始");
+                songdb.updateSongDatas(updatepath, config.getBmsroot(), updateAll, infodb);
+                logger.info("song.db更新完了");
                 songUpdated = true;
 
 				// Once again, JavaFX UI code must be run inside a Platform context. Hide progress bar and resume

--- a/core/src/bms/player/beatoraja/launcher/StreamEditorView.java
+++ b/core/src/bms/player/beatoraja/launcher/StreamEditorView.java
@@ -5,7 +5,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.portaudio.DeviceInfo;
 

--- a/core/src/bms/player/beatoraja/launcher/TrainerView.java
+++ b/core/src/bms/player/beatoraja/launcher/TrainerView.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja.launcher;
 
 
 import java.util.Arrays;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.PlayerConfig;
 import bms.player.beatoraja.modmenu.RandomTrainer;
@@ -12,6 +13,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextField;
 
 public class TrainerView {
+	private static final Logger logger = LoggerFactory.getLogger(TrainerView.class);
 	
 	@FXML
 	private CheckBox traineractive;
@@ -58,7 +60,7 @@ public class TrainerView {
 	public void setRandom() {
 		RandomTrainer randomtrainer = new RandomTrainer();
 		if (this.laneorder == null) {
-			Logger.getGlobal().warning("RandomTrainer: Lane field empty");
+			logger.warn("RandomTrainer: Lane field empty");
 			return;
 		}
 
@@ -70,13 +72,13 @@ public class TrainerView {
 		Arrays.sort(l);
 
 		if (l.length != 7) {
-			Logger.getGlobal().warning("RandomTrainer: Incorrect number of lanes specified");
+			logger.warn("RandomTrainer: Incorrect number of lanes specified");
 			return;
 		}
 
 		for (int i = 0; i < has_all.length; i++) {
 			if (l[i] != has_all[i]) {
-				Logger.getGlobal().warning("RandomTrainer: Lanes in incorrect format, falling back to nonran or last ran used");
+				logger.warn("RandomTrainer: Lanes in incorrect format, falling back to nonran or last ran used");
 				return;
 			}
 		}

--- a/core/src/bms/player/beatoraja/modmenu/RandomTrainer.java
+++ b/core/src/bms/player/beatoraja/modmenu/RandomTrainer.java
@@ -3,9 +3,11 @@ package bms.player.beatoraja.modmenu;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RandomTrainer {
+    private static final Logger logger = LoggerFactory.getLogger(RandomTrainer.class);
     private static String laneOrder = "1234567";
     private static ArrayList<Character> lanesToRandom = new ArrayList<>();
 
@@ -27,7 +29,7 @@ public class RandomTrainer {
                 randomSeedMap = (HashMap<Integer, Long>) ois.readObject();
                 ois.close();
             } catch (ClassNotFoundException | NullPointerException | IOException ex) {
-                Logger.getGlobal().severe("RandomTrainer: randomtrainer.dat corrupted or missing from jar");
+                logger.error("RandomTrainer: randomtrainer.dat corrupted or missing from jar");
                 ex.printStackTrace();
             }
         }

--- a/core/src/bms/player/beatoraja/obs/ObsListener.java
+++ b/core/src/bms/player/beatoraja/obs/ObsListener.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja.obs;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.Config;
 import bms.player.beatoraja.MainController;
@@ -12,6 +13,7 @@ import bms.player.beatoraja.MainStateListener;
 import bms.player.beatoraja.launcher.ObsConfigurationView;
 
 public class ObsListener implements MainStateListener {
+	private static final Logger logger = LoggerFactory.getLogger(ObsListener.class);
 
 	private final Config config;
 	private final ObsWsClient obsClient;
@@ -27,7 +29,7 @@ public class ObsListener implements MainStateListener {
 			client = new ObsWsClient(config);
 			client.connectAsync();
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Failed to initialize OBS client: " + e.getMessage());
+			logger.warn("Failed to initialize OBS client: {}", e.getMessage());
 		}
 		this.obsClient = client;
 	}
@@ -79,7 +81,7 @@ public class ObsListener implements MainStateListener {
 			try {
 				obsClient.requestStopRecord();
 			} catch (Exception e) {
-				Logger.getGlobal().warning("Failed to send early StopRecord: " + e.getMessage());
+				logger.warn("Failed to send early StopRecord: {}", e.getMessage());
 			}
 		}
 
@@ -98,7 +100,7 @@ public class ObsListener implements MainStateListener {
 						try {
 							obsClient.requestStopRecord();
 						} catch (Exception e) {
-							Logger.getGlobal().warning("Failed to stop recording: " + e.getMessage());
+							logger.warn("Failed to stop recording: {}", e.getMessage());
 						} finally {
 							synchronized (ObsListener.this) {
 								scheduledStopTask = null;
@@ -110,7 +112,7 @@ public class ObsListener implements MainStateListener {
 				}
 			}
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Failed to send OBS request: " + e.getMessage());
+			logger.warn("Failed to send OBS request: {}", e.getMessage());
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/obs/ObsWsClient.java
+++ b/core/src/bms/player/beatoraja/obs/ObsWsClient.java
@@ -16,7 +16,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
@@ -29,6 +30,7 @@ import bms.player.beatoraja.Config;
 import bms.player.beatoraja.modmenu.ImGuiNotify;
 
 public class ObsWsClient {
+	private static final Logger logger = LoggerFactory.getLogger(ObsWsClient.class);
 	private volatile WebSocketClient wsClient;
 	private volatile boolean isConnected = false;
 	private volatile boolean isIdentified = false;
@@ -118,7 +120,7 @@ public class ObsWsClient {
 				try {
 					JsonNode json = objectMapper.readTree(message);
 					if (!json.has("op")) {
-						Logger.getGlobal().warning("Received malformed JSON (no op): " + message);
+						logger.warn("Received malformed JSON (no op): {}", message);
 						return;
 					}
 
@@ -142,7 +144,7 @@ public class ObsWsClient {
 							break;
 					}
 				} catch (Exception e) {
-					Logger.getGlobal().warning("Error processing message: " + e.getMessage());
+					logger.warn("Error processing message: {}", e.getMessage());
 				}
 
 				if (customMessageHandler != null) {
@@ -168,7 +170,7 @@ public class ObsWsClient {
 			@Override
 			public void onError(Exception ex) {
 				if (ex != null && ex.getMessage() != null && !ex.getMessage().isEmpty()) {
-					Logger.getGlobal().warning("OBS WebSocket error: " + ex.getMessage());
+					logger.warn("OBS WebSocket error: {}", ex.getMessage());
 				}
 
 				if (onErrorHandler != null) {
@@ -189,12 +191,12 @@ public class ObsWsClient {
 
 			switch (eventType) {
 				case "ExitStarted":
-				Logger.getGlobal().info("OBS is shutting down");
+				logger.info("OBS is shutting down");
 					close();
 					break;
 				case "AuthenticationFailure":
 				case "AuthenticationFailed":
-					Logger.getGlobal().warning("OBS authentication failed!");
+					logger.warn("OBS authentication failed!");
 					autoReconnect = false;
 					close();
 					break;
@@ -259,7 +261,7 @@ public class ObsWsClient {
 					break;
 			}
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Error handling event: " + e.getMessage());
+			logger.warn("Error handling event: {}", e.getMessage());
 		}
 	}
 
@@ -273,7 +275,7 @@ public class ObsWsClient {
 
 			if (authRequired) {
 				if (password == null || password.isEmpty()) {
-					Logger.getGlobal().warning("Authentication required but no password provided");
+					logger.warn("Authentication required but no password provided");
 					autoReconnect = false;
 					close();
 					return;
@@ -298,7 +300,7 @@ public class ObsWsClient {
 
 			send(objectMapper.writeValueAsString(identify));
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Error sending Identify: " + e.getMessage());
+			logger.warn("Error sending Identify: {}", e.getMessage());
 			e.printStackTrace();
 		}
 	}
@@ -349,7 +351,7 @@ public class ObsWsClient {
 					break;
 			}
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Error handling request response: " + e.getMessage());
+			logger.warn("Error handling request response: {}", e.getMessage());
 		}
 	}
 
@@ -395,7 +397,7 @@ public class ObsWsClient {
 			}
 		} catch (Exception e) {
 			if (autoReconnect) {
-				Logger.getGlobal().warning("Initial connection failed: " + e.getMessage());
+				logger.warn("Initial connection failed: {}", e.getMessage());
 				scheduleReconnect();
 			} else {
 				throw e;
@@ -463,7 +465,7 @@ public class ObsWsClient {
 
 			send(objectMapper.writeValueAsString(request));
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Error setting scene: " + e.getMessage());
+			logger.warn("Error setting scene: {}", e.getMessage());
 		}
 	}
 
@@ -482,7 +484,7 @@ public class ObsWsClient {
 
 			send(objectMapper.writeValueAsString(request));
 		} catch (Exception e) {
-			Logger.getGlobal().warning("Error sending request: " + e.getMessage());
+			logger.warn("Error sending request: {}", e.getMessage());
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/pattern/LaneShuffleModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/LaneShuffleModifier.java
@@ -6,7 +6,8 @@ import java.util.*;
 
 import bms.player.beatoraja.modmenu.RandomTrainer;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.IntStream;
 
 import com.badlogic.gdx.utils.IntArray;
@@ -17,6 +18,7 @@ import com.badlogic.gdx.utils.IntArray;
  * @author exch
  */
 public abstract class LaneShuffleModifier extends PatternModifier {
+	private static final Logger logger = LoggerFactory.getLogger(LaneShuffleModifier.class);
 
 	/**
 	 * 各レーンの移動先
@@ -305,7 +307,7 @@ public abstract class LaneShuffleModifier extends PatternModifier {
 				kouhoPatternList = searchForNoMurioshiLaneCombinations(originalPatternList, keys);
 			}
 
-			Logger.getGlobal().info("無理押し無し譜面数 : "+(kouhoPatternList.size()));
+			logger.info("無理押し無し譜面数 : {}", kouhoPatternList.size());
 
 			int[] result = new int[9];
 			if (kouhoPatternList.size() > 0) {

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -10,7 +10,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.audio.BMSLoudnessAnalyzer;
 import bms.player.beatoraja.modmenu.FreqTrainerMenu;
@@ -36,6 +37,7 @@ import bms.player.beatoraja.skin.SkinType;
  * @author exch
  */
 public class BMSPlayer extends MainState {
+	private static final Logger logger = LoggerFactory.getLogger(BMSPlayer.class);
 
 	private BMSModel model;
 
@@ -158,7 +160,7 @@ public class BMSPlayer extends MainState {
 						}
 						replay = replays[0];
 					} else {
-						Logger.getGlobal().info("リプレイデータを読み込めなかったため、通常プレイモードに移行");
+						logger.info("リプレイデータを読み込めなかったため、通常プレイモードに移行");
 						autoplay = BMSPlayerMode.PLAY;
 						resource.setPlayMode(autoplay);
 					}
@@ -177,7 +179,7 @@ public class BMSPlayer extends MainState {
 					boolean isReplayPatternPlay = false;
 					if(main.getInputProcessor().getKeyState(1)) {
 						//保存された譜面オプション/Random Seedから譜面再現
-						Logger.getGlobal().info("リプレイ再現モード : 譜面");
+						logger.info("リプレイ再現モード : 譜面");
 						playinfo.randomoption = replay.randomoption;
 						playinfo.randomoptionseed = replay.randomoptionseed;
 						playinfo.randomoption2 = replay.randomoption2;
@@ -187,7 +189,7 @@ public class BMSPlayer extends MainState {
 						isReplayPatternPlay = true;
 					} else if(main.getInputProcessor().getKeyState(2)) {
 						//保存された譜面オプションログから譜面オプション再現
-						Logger.getGlobal().info("リプレイ再現モード : オプション");
+						logger.info("リプレイ再現モード : オプション");
 						playinfo.randomoption = replay.randomoption;
 						playinfo.randomoption2 = replay.randomoption2;
 						playinfo.doubleoption = replay.doubleoption;
@@ -195,7 +197,7 @@ public class BMSPlayer extends MainState {
 					}
 					if(main.getInputProcessor().getKeyState(4)) {
 						//保存されたHSオプションログからHSオプション再現
-						Logger.getGlobal().info("リプレイ再現モード : ハイスピード");
+						logger.info("リプレイ再現モード : ハイスピード");
 						HSReplay = replay;
 						isReplayPatternPlay = true;
 					}
@@ -205,7 +207,7 @@ public class BMSPlayer extends MainState {
 						resource.setPlayMode(autoplay);
 					}
 				} else {
-					Logger.getGlobal().info("リプレイデータを読み込めなかったため、通常プレイモードに移行");
+					logger.info("リプレイデータを読み込めなかったため、通常プレイモードに移行");
 					autoplay = BMSPlayerMode.PLAY;
 					resource.setPlayMode(autoplay);
 				}
@@ -236,7 +238,7 @@ public class BMSPlayer extends MainState {
 				BMSPlayerRule.validate(model);
 			}
 			playinfo.rand = model.getRandom();
-			Logger.getGlobal().info("譜面分岐 : " + Arrays.toString(playinfo.rand));
+			logger.info("譜面分岐 : {}", Arrays.toString(playinfo.rand));
 		}
 		// 通常プレイの場合は最後のノーツ、オートプレイの場合はBG/BGAを含めた最後のノーツ
 		playtime = (autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY ? model.getLastTime() : model.getLastNoteTime()) + TIME_MARGIN;
@@ -283,7 +285,7 @@ public class BMSPlayer extends MainState {
 				// the window rate to it and directly mark the model as BMSON type (see BMSPlayerRule::validate)
 				int overridingJudgeWindowRate = JudgeTrainer.getJudgeWindowRate(model.getMode());
 				int originalJudgeWindowRate = model.getJudgerank();
-				Logger.getGlobal().info(String.format("Overriding original judge window from %d to %d", originalJudgeWindowRate, overridingJudgeWindowRate));
+				logger.info("Overriding original judge window from {} to {}", originalJudgeWindowRate, overridingJudgeWindowRate);
 				if (originalJudgeWindowRate < overridingJudgeWindowRate) {
 					// Like expand judge treatment above if the original judge window is stricter than customized one
 					assist = Math.max(assist, 2);
@@ -341,7 +343,7 @@ public class BMSPlayer extends MainState {
 					}
 					assist = Math.max(assist, 1);
 					score = false;
-					Logger.getGlobal().info("譜面オプション : BATTLE (L-ASSIST)");
+					logger.info("譜面オプション : BATTLE (L-ASSIST)");
 				} else {
 					// SPでなければBATTLEは未適用
 					playinfo.doubleoption = 0;
@@ -349,24 +351,24 @@ public class BMSPlayer extends MainState {
 			}
 		}
 
-		Logger.getGlobal().info("譜面オプション設定");
+		logger.info("譜面オプション設定");
 		if (replay != null && replay.pattern != null) {
 			// リプレイ譜面再現(PatternModifyLog使用。旧verとの互換性維持用)
 			if(replay.sevenToNinePattern > 0 && model.getMode() == Mode.BEAT_7K) {
 				model.setMode(Mode.POPN_9K);
 			}
 			PatternModifier.modify(model, Arrays.asList(replay.pattern));
-			Logger.getGlobal().info("リプレイデータから譜面再現 : PatternModifyLog");
+			logger.info("リプレイデータから譜面再現 : PatternModifyLog");
 		} else if (autoplay.mode != BMSPlayerMode.Mode.PRACTICE) {
 
 			// リプレイデータからのoption/seed再現
 			ReplayData rd = null;
 			if(replay != null) {
 				rd = replay;
-				Logger.getGlobal().info("リプレイデータから譜面再現 : option/seed");
+				logger.info("リプレイデータから譜面再現 : option/seed");
 			} else if(resource.getReplayData().randomoptionseed != -1) {
 				rd = resource.getReplayData();
-				Logger.getGlobal().info("前回プレイ時の譜面再現");
+				logger.info("前回プレイ時の譜面再現");
 			}
 			if (rd != null) {
 				if(rd.sevenToNinePattern > 0 && model.getMode() == Mode.BEAT_7K) {
@@ -385,7 +387,7 @@ public class BMSPlayer extends MainState {
 				if (playinfo.doubleoption == 1) {
 					mods.add(new PlayerFlipModifier());
 				}
-				Logger.getGlobal().info("譜面オプション(DP) :  " + playinfo.doubleoption);
+				logger.info("譜面オプション(DP) :  {}", playinfo.doubleoption);
 
 				PatternModifier pm = PatternModifier.create(playinfo.randomoption2, 1, model.getMode(), config);
 				if(playinfo.randomoption2seed != -1) {
@@ -394,7 +396,7 @@ public class BMSPlayer extends MainState {
 					playinfo.randomoption2seed = pm.getSeed();
 				}
 				mods.add(pm);
-				Logger.getGlobal().info("譜面オプション(2P) :  " + playinfo.randomoption2 + ", Seed : " + playinfo.randomoption2seed);
+				logger.info("譜面オプション(2P) :  {}, Seed : {}", playinfo.randomoption2, playinfo.randomoption2seed);
 			}
 
 			// SP譜面オプション
@@ -405,18 +407,18 @@ public class BMSPlayer extends MainState {
                 if (ghostBattle.isPresent()) {
 					HashMap<Integer, Long> seedmap = RandomTrainer.getRandomSeedMap();
                     Integer pattern = ghostBattle.get().lanes();
-					Logger.getGlobal().info("Ghost battle - fixing lane pattern to " + pattern);
+					logger.info("Ghost battle - fixing lane pattern to {}", pattern);
 					pm.setSeed(seedmap.get(pattern));
                 }
                 else if (RandomTrainer.isActive() && model.getMode() == Mode.BEAT_7K && RandomTrainer.getRandomSeedMap() != null) {
 					HashMap<Integer, Long> seedmap = RandomTrainer.getRandomSeedMap();
-					Logger.getGlobal().info("RandomTrainer: Enabled, modifying random seed");
+					logger.info("RandomTrainer: Enabled, modifying random seed");
 					pm.setSeed(seedmap.get(Integer.parseInt(RandomTrainer.getLaneOrder())));
 				}
 				playinfo.randomoptionseed = pm.getSeed();
 			}
 			mods.add(pm);
-			Logger.getGlobal().info("譜面オプション(1P) :  " + playinfo.randomoption + ", Seed : " + playinfo.randomoptionseed);
+			logger.info("譜面オプション(1P) :  {}, Seed : {}", playinfo.randomoption, playinfo.randomoptionseed);
 
 			if (config.getSevenToNinePattern() >= 1 && model.getMode() == Mode.BEAT_7K) {
 				//7to9
@@ -429,7 +431,7 @@ public class BMSPlayer extends MainState {
 			for(PatternModifier mod : mods) {
 				mod.modify(model);
 				if(mod.getAssistLevel() != PatternModifier.AssistLevel.NONE) {
-					Logger.getGlobal().info("アシスト譜面オプションが選択されました");
+					logger.info("アシスト譜面オプションが選択されました");
 					assist = Math.max(assist, mod.getAssistLevel() == PatternModifier.AssistLevel.ASSIST ? 2 : 1);
 					score = false;
 				}
@@ -450,7 +452,7 @@ public class BMSPlayer extends MainState {
 			config.getPlayConfig(model.getMode()).setPlayconfig(HSReplay.config);
 		}
 
-		Logger.getGlobal().info("ゲージ設定");
+		logger.info("ゲージ設定");
 		if(replay != null) {
 			for(int count = (main.getInputProcessor().getKeyState(5) ? 1 : 0) + (main.getInputProcessor().getKeyState(3) ? 2 : 0);count > 0; count--) {
 				if (replay.gauge != GrooveGauge.HAZARD || replay.gauge != GrooveGauge.EXHARDCLASS) {
@@ -477,7 +479,7 @@ public class BMSPlayer extends MainState {
 		if (forceNoIRSend) {
 			ImGuiNotify.error("Special mod options enabled. Next play will not be submitted to IR");
 		}
-		Logger.getGlobal().info("アシストレベル : " + assist + " - スコア保存 : " + score + " - no IR submit : " + forceNoIRSend);
+		logger.info("アシストレベル : {} - スコア保存 : {} - no IR submit : {}", assist, score, forceNoIRSend);
 
 		resource.setUpdateScore(score);
 		resource.setUpdateCourseScore(resource.isUpdateCourseScore() && score);
@@ -543,7 +545,7 @@ public class BMSPlayer extends MainState {
 		bga = resource.getBGAManager();
 
 		ScoreData score = main.getPlayDataAccessor().readScoreData(model, config.getLnmode());
-		Logger.getGlobal().info("スコアデータベースからスコア取得");
+		logger.info("スコアデータベースからスコア取得");
 		if (score == null) {
 			score = new ScoreData();
 		}
@@ -621,19 +623,19 @@ public class BMSPlayer extends MainState {
 								if (result.success) {
 									float configVolume = main.getConfig().getAudioConfig().getKeyvolume();
 									adjustedVolume = result.calculateAdjustedVolume(configVolume);
-									Logger.getGlobal().info(String.format("Volume set to %.2f (%.2f LUFS)",
-										adjustedVolume, result.loudnessLUFS));
+									logger.info("Volume set to {} ({} LUFS)",
+										adjustedVolume, result.loudnessLUFS);
 								} else {
-									Logger.getGlobal().warning("Analysis failed: " + result.errorMessage);
+									logger.warn("Analysis failed: {}", result.errorMessage);
 									ImGuiNotify.warning("Loudness analysis failed");
 								}
 							} catch (TimeoutException e) {
 								ImGuiNotify.warning("Chart volume analysis timed out");
-								Logger.getGlobal().warning("Loudness analysis timed out after 15 seconds");
+								logger.warn("Loudness analysis timed out after 15 seconds");
 								analysisTask.cancel(true);
 							} catch (Exception e) {
 								ImGuiNotify.warning("Failed to analyze chart volume");
-								Logger.getGlobal().warning("Loudness analysis error: " + e.getMessage());
+								logger.warn("Loudness analysis error: {}", e.getMessage());
 							}
 						}
 					}
@@ -642,12 +644,11 @@ public class BMSPlayer extends MainState {
 					final long mem = Runtime.getRuntime().freeMemory();
 					System.gc();
 					final long cmem = Runtime.getRuntime().freeMemory();
-					Logger.getGlobal().info("current free memory : " + (cmem / (1024 * 1024)) + "MB , disposed : "
-							+ ((cmem - mem) / (1024 * 1024)) + "MB");
+					logger.info("current free memory : {}MB , disposed : {}MB", cmem / (1024 * 1024), (cmem - mem) / (1024 * 1024));
 					state = STATE_READY;
 					timer.setTimerOn(TIMER_READY);
 					play(PLAY_READY);
-					Logger.getGlobal().info("STATE_READYに移行");
+					logger.info("STATE_READYに移行");
 				}
 				if(!timer.isTimerOn(TIMER_PM_CHARA_1P_NEUTRAL) || !timer.isTimerOn(TIMER_PM_CHARA_2P_NEUTRAL)){
 					timer.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
@@ -702,7 +703,7 @@ public class BMSPlayer extends MainState {
 					PatternModifier.create(property.random, 0, model.getMode(), config).modify(model);
                     if (RandomTrainer.isActive() && model.getMode() == Mode.BEAT_7K && RandomTrainer.getRandomSeedMap() != null) {
                         HashMap<Integer, Long> seedmap = RandomTrainer.getRandomSeedMap();
-                        Logger.getGlobal().info("RandomTrainer: Enabled, modifying random seed");
+                        logger.info("RandomTrainer: Enabled, modifying random seed");
                         pm.setSeed(seedmap.get(Integer.parseInt(RandomTrainer.getLaneOrder())));
                     }
                     pm.modify(model);
@@ -718,7 +719,7 @@ public class BMSPlayer extends MainState {
 					state = STATE_READY;
 					timer.setTimerOn(TIMER_READY);
 					play(PLAY_READY);
-					Logger.getGlobal().info("STATE_READYに移行");
+					logger.info("STATE_READYに移行");
 				}
 			}
 			// practice終了
@@ -741,7 +742,7 @@ public class BMSPlayer extends MainState {
 					input.setKeyLogMarginTime(resource.getMarginTime());
 					keyinput.startJudge(model, replay != null ? replay.keylog : null, resource.getMarginTime());
 					keysound.startBGPlay(model, starttimeoffset * 1000);
-					Logger.getGlobal().info("STATE_PLAYに移行");
+					logger.info("STATE_PLAYに移行");
 				}
 			}
 			// プレイ
@@ -773,7 +774,7 @@ public class BMSPlayer extends MainState {
 					}
 					timer.setTimerOff(TIMER_PM_CHARA_DANCE);
 
-					Logger.getGlobal().info("STATE_FINISHEDに移行");
+					logger.info("STATE_FINISHEDに移行");
 				} else if(playtime - TIME_MARGIN < ptime) {
 					timer.switchTimer(TIMER_ENDOFNOTE_1P, true);
 				}
@@ -800,7 +801,7 @@ public class BMSPlayer extends MainState {
 							main.getAudioProcessor().stop((Note) null);
 						}
 						play(PLAY_STOP);
-						Logger.getGlobal().info("STATE_FAILEDに移行");
+						logger.info("STATE_FAILEDに移行");
 						break;
 					case PlayerConfig.GAUGEAUTOSHIFT_CONTINUE:
 						break;
@@ -824,13 +825,13 @@ public class BMSPlayer extends MainState {
                     main.getAudioProcessor().setGlobalPitch(1f);
 					if (!resource.isUpdateScore()) {
 						resource.getReplayData().randomoptionseed = -1;
-						Logger.getGlobal().info("アシストモード時は同じ譜面でリプレイできません");
+						logger.info("アシストモード時は同じ譜面でリプレイできません");
 					} else if (input.startPressed()) {
 						resource.getReplayData().randomoptionseed = -1;
-						Logger.getGlobal().info("オプションを変更せずリプレイ");
+						logger.info("オプションを変更せずリプレイ");
 					} else {
 						resource.setScoreData(createScoreData());
-						Logger.getGlobal().info("同じ譜面でリプレイ");
+						logger.info("同じ譜面でリプレイ");
 					}
 					saveConfig();
 					resource.reloadBMSFile();
@@ -894,7 +895,7 @@ public class BMSPlayer extends MainState {
 					if (autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
 						state = STATE_PRACTICE;
 					} else if (resource.getScoreData() != null) {
-						Logger.getGlobal().info("\"score\": " + resource.getScoreData());
+						logger.info("\"score\": {}", resource.getScoreData());
 						main.changeState(MainStateType.RESULT);
 					} else {
 						if (resource.mediaLoadFinished()) {
@@ -916,13 +917,13 @@ public class BMSPlayer extends MainState {
 					main.getAudioProcessor().setGlobalPitch(1f);
 					if (!resource.isUpdateScore()) {
 						resource.getReplayData().randomoptionseed = -1;
-						Logger.getGlobal().info("アシストモード時は同じ譜面でリプレイできません");
+						logger.info("アシストモード時は同じ譜面でリプレイできません");
 					} else if (input.startPressed()) {
 						resource.getReplayData().randomoptionseed = -1;
-						Logger.getGlobal().info("オプションを変更せずリプレイ");
+						logger.info("オプションを変更せずリプレイ");
 					} else {
 						resource.setScoreData(createScoreData());
-						Logger.getGlobal().info("同じ譜面でリプレイ");
+						logger.info("同じ譜面でリプレイ");
 					}
 					saveConfig();
 					resource.reloadBMSFile();
@@ -1131,7 +1132,7 @@ public class BMSPlayer extends MainState {
 				|| resource.getPlayMode().mode == BMSPlayerMode.Mode.AUTOPLAY)) {
 			state = STATE_FINISHED;
 			timer.setTimerOn(TIMER_FADEOUT);
-			Logger.getGlobal().info("STATE_FINISHEDに移行");
+			logger.info("STATE_FINISHEDに移行");
 		} else if(state == STATE_FINISHED && !timer.isTimerOn(TIMER_FADEOUT)) {
 			timer.setTimerOn(TIMER_FADEOUT);
 		} else if(state != STATE_FINISHED) {
@@ -1142,7 +1143,7 @@ public class BMSPlayer extends MainState {
 				main.getAudioProcessor().stop((Note) null);
 			}
 			play(PLAY_STOP);
-			Logger.getGlobal().info("STATE_FAILEDに移行");
+			logger.info("STATE_FAILEDに移行");
 		}
 	}
 
@@ -1151,7 +1152,7 @@ public class BMSPlayer extends MainState {
 		super.dispose();
 		lanerender.dispose();
 		practice.dispose();
-		Logger.getGlobal().info("システム描画のリソース解放");
+		logger.info("システム描画のリソース解放");
 	}
 
 	public PracticeConfiguration getPracticeConfiguration() {

--- a/core/src/bms/player/beatoraja/play/KeyInputProccessor.java
+++ b/core/src/bms/player/beatoraja/play/KeyInputProccessor.java
@@ -2,7 +2,9 @@ package bms.player.beatoraja.play;
 
 import static bms.player.beatoraja.skin.SkinProperty.*;
 
-import java.util.logging.Logger;
+import bms.player.beatoraja.modmenu.RandomTrainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.badlogic.gdx.math.MathUtils;
 
@@ -20,6 +22,7 @@ import bms.player.beatoraja.skin.SkinPropertyMapper;
  * @author exch
  */
 class KeyInputProccessor {
+	private static final Logger logger = LoggerFactory.getLogger(KeyInputProccessor.class);
 
 	private final BMSPlayer player;
 
@@ -234,7 +237,7 @@ class KeyInputProccessor {
 				input.resetAllKeyState();
 			}
 
-			Logger.getGlobal().info("入力パフォーマンス(max ms) : " + frametime);
+			logger.info("入力パフォーマンス(max ms) : {}", frametime);
 		}
 	}
 }

--- a/core/src/bms/player/beatoraja/play/KeySoundProcessor.java
+++ b/core/src/bms/player/beatoraja/play/KeySoundProcessor.java
@@ -12,7 +12,8 @@ import bms.model.TimeLine;
 import bms.player.beatoraja.Config;
 import bms.player.beatoraja.audio.AudioDriver;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * キー音処理用クラス

--- a/core/src/bms/player/beatoraja/play/LaneRenderer.java
+++ b/core/src/bms/player/beatoraja/play/LaneRenderer.java
@@ -1,7 +1,8 @@
 package bms.player.beatoraja.play;
 
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.*;
 import bms.player.beatoraja.play.SkinNote.SkinLane;
@@ -29,6 +30,7 @@ import static bms.player.beatoraja.skin.SkinProperty.*;
  * @author exch
  */
 public class LaneRenderer {
+	private static final Logger logger = LoggerFactory.getLogger(LaneRenderer.class);
 	
 	private float basehispeed;
 
@@ -76,7 +78,7 @@ public class LaneRenderer {
 			font = generator.generateFont(parameter);
 			generator.dispose();
 		} catch (GdxRuntimeException e) {
-			Logger.getGlobal().severe("Practice Font読み込み失敗");
+			logger.error("Practice Font読み込み失敗");
 		}
 
 		this.skin = (PlaySkin) main.getSkin();
@@ -112,7 +114,7 @@ public class LaneRenderer {
 			cscr = tl.getScroll();
 		}
 		this.timelines = tls.toArray(new TimeLine[tls.size()]);
-		// Logger.getGlobal().info("省略したTimeLine数:" +
+		// logger.info("省略したTimeLine数:" +
 		// (model.getAllTimeLines().length - timelines.length) + " / " +
 		// model.getAllTimeLines().length);
 
@@ -525,7 +527,7 @@ public class LaneRenderer {
 					} else if (note instanceof LongNote ln) {
 						if (!ln.isEnd() && ln.getPair().getMicroTime() >= microtime) {
 							// if (((LongNote) note).getEnd() == null) {
-							// Logger.getGlobal().warning(
+							// logger.warn(
 							// "LN終端がなく、モデルが正常に表示されません。LN開始時間:"
 							// + ((LongNote) note)
 							// .getStart()

--- a/core/src/bms/player/beatoraja/play/PracticeConfiguration.java
+++ b/core/src/bms/player/beatoraja/play/PracticeConfiguration.java
@@ -3,7 +3,8 @@ package bms.player.beatoraja.play;
 import java.io.*;
 import java.nio.file.*;
 import java.util.function.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.model.BMSModel;
 import bms.model.Mode;
@@ -32,7 +33,7 @@ import com.badlogic.gdx.utils.SerializationException;
  * @author exch
  */
 public final class PracticeConfiguration {
-
+	private static final Logger logger = LoggerFactory.getLogger(PracticeConfiguration.class);
 
 	private BitmapFont titlefont;
 
@@ -92,7 +93,7 @@ public final class PracticeConfiguration {
 			titlefont = generator.generateFont(parameter);
 			generator.dispose();
 		} catch (GdxRuntimeException e) {
-			Logger.getGlobal().warning("Practice Font読み込み失敗");
+			logger.warn("Practice Font読み込み失敗");
 		}
 		
 		for(int i = 0; i < graph.length; i++) {

--- a/core/src/bms/player/beatoraja/play/bga/BGAProcessor.java
+++ b/core/src/bms/player/beatoraja/play/bga/BGAProcessor.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja.play.bga;
 
 import java.nio.file.*;
 import java.util.Arrays;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.model.Layer.Sequence;
 import bms.model.*;
@@ -25,6 +26,7 @@ import com.badlogic.gdx.utils.Array;
  * @author exch
  */
 public class BGAProcessor {
+	private static final Logger logger = LoggerFactory.getLogger(BGAProcessor.class);
 	
 	// TODO イベントレイヤー対応(現状はミスレイヤーのみ)
 
@@ -176,7 +178,7 @@ public class BGAProcessor {
 						}
 					}
 				} catch (InvalidPathException e) {
-					Logger.getGlobal().warning(e.getMessage());
+					logger.warn(e.getMessage());
 				}
 
 				if (f != null) {
@@ -189,7 +191,7 @@ public class BGAProcessor {
 								isMovie = true;
 								break;
 							} catch (Throwable e) {
-								Logger.getGlobal().warning("BGAファイル読み込み失敗。" + e.getMessage());
+								logger.warn("BGAファイル読み込み失敗。{}", e.getMessage());
 								e.printStackTrace();
 							}
 						}
@@ -208,7 +210,7 @@ public class BGAProcessor {
 
 		disposeOld();
 
-		Logger.getGlobal().info("BGAファイル読み込み完了。BGA数:" + id);
+		logger.info("BGAファイル読み込み完了。BGA数:{}", id);
 		progress = 1;
 	}
 

--- a/core/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/core/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja.play.bga;
 
 import java.nio.file.Path;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.model.TimeLine;
 import bms.player.beatoraja.PixmapResourcePool;
@@ -16,6 +17,7 @@ import com.badlogic.gdx.graphics.Texture;
  * @author exch
  */
 public class BGImageProcessor {
+	private static final Logger logger = LoggerFactory.getLogger(BGImageProcessor.class);
 	
 	public static final String[] pic_extension = { "jpg", "jpeg", "gif", "bmp", "png", "tga" };
 	/**
@@ -96,8 +98,7 @@ public class BGImageProcessor {
 				count++;
 			}
 		}
-		Logger.getGlobal().info(
-				"BGAデータの事前Texture化 - BGAデータ数:" + count + " time(ms):" + (System.currentTimeMillis() - l));
+		logger.info("BGAデータの事前Texture化 - BGAデータ数:{} time(ms):{}", count, System.currentTimeMillis() - l);
 	}
 
 	public Texture getTexture(int id) {

--- a/core/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
+++ b/core/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
@@ -5,7 +5,8 @@ import java.lang.reflect.Method;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import org.bytedeco.javacv.FFmpegFrameGrabber;
@@ -20,12 +21,14 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import org.bytedeco.javacv.Java2DFrameConverter;
 
 import static org.bytedeco.ffmpeg.global.avutil.AV_PIX_FMT_RGB24;
+
 /**
  * ffmpegを使用した動画表示用クラス
  *
  * @author exch
  */
 public class FFmpegProcessor implements MovieProcessor {
+	private static final Logger logger = LoggerFactory.getLogger(FFmpegProcessor.class);
 	private enum ProcessorStatus {
 		TEXTURE_INACTIVE,
 		TEXTURE_ACTIVE,
@@ -160,11 +163,7 @@ public class FFmpegProcessor implements MovieProcessor {
 						e.printStackTrace();
 					}
 				}
-				Logger.getGlobal()
-						.info("movie decode - fps : " + grabber.getFrameRate() + " format : " + grabber.getFormat()
-								+ " size : " + grabber.getImageWidth() + " x " + grabber.getImageHeight()
-								+ " length (frame / time) : " + grabber.getLengthInFrames() + " / "
-								+ grabber.getLengthInTime());
+				logger.info("movie decode - fps : {} format : {} size : {} x {} length (frame / time) : {} / {}", grabber.getFrameRate(), grabber.getFormat(), grabber.getImageWidth(), grabber.getImageHeight(), grabber.getLengthInFrames(), grabber.getLengthInTime());
 
 				offset = grabber.getTimestamp();
 				Frame frame = null;
@@ -255,7 +254,7 @@ public class FFmpegProcessor implements MovieProcessor {
 				try {
 					grabber.stop();
 					grabber.close();
-					Logger.getGlobal().info("動画リソースの開放 : " + filepath);
+					logger.info("動画リソースの開放 : {}", filepath);
 				} catch (Throwable e) {
 					e.printStackTrace();
 				}

--- a/core/src/bms/player/beatoraja/result/CourseResult.java
+++ b/core/src/bms/player/beatoraja/result/CourseResult.java
@@ -5,7 +5,8 @@ import static bms.player.beatoraja.skin.SkinProperty.*;
 import static bms.player.beatoraja.SystemSoundManager.SoundType.*;
 
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.input.KeyCommand;
 import com.badlogic.gdx.utils.FloatArray;
@@ -25,6 +26,7 @@ import bms.player.beatoraja.skin.property.EventFactory.EventType;
  * @author exch
  */
 public class CourseResult extends AbstractResult {
+	private static final Logger logger = LoggerFactory.getLogger(CourseResult.class);
 
 	private List<IRSendStatus> irSendStatus = new ArrayList<IRSendStatus>();
 
@@ -128,7 +130,7 @@ public class CourseResult extends AbstractResult {
 							removeIrSendStatus.add(irc);
 						}
 					} catch (Exception e) {
-						Logger.getGlobal().warning("IR送信時の例外:" + e.getMessage());
+						logger.warn("IR送信時の例外:{}", e.getMessage());
 						e.printStackTrace();
 						// remove from queue
 						removeIrSendStatus.add(irc);
@@ -143,12 +145,12 @@ public class CourseResult extends AbstractResult {
 						if (response.isSucceeded()) {
 							ranking.updateScore(response.getData(), newscore.getExscore() > oldscore.getExscore() ? newscore : oldscore);
 							rankingOffset = ranking.getRank() > 10 ? ranking.getRank() - 5 : 0;
-							Logger.getGlobal().info("IRからのスコア取得成功 : " + response.getMessage());
+							logger.info("IRからのスコア取得成功 : {}", response.getMessage());
 						} else {
-							Logger.getGlobal().warning("IRからのスコア取得失敗 : " + response.getMessage());
+							logger.warn("IRからのスコア取得失敗 : {}", response.getMessage());
 						}
 					} catch (Exception e) {
-						Logger.getGlobal().warning("IRからのスコア取得時例外:" + e.getMessage());
+						logger.warn("IRからのスコア取得時例外:{}", e.getMessage());
 						e.printStackTrace();
 					}
 				}
@@ -274,7 +276,7 @@ public class CourseResult extends AbstractResult {
 				random, resource.getConstraint(), resource.isUpdateCourseScore());
 
 
-		Logger.getGlobal().info("スコアデータベース更新完了 ");
+		logger.info("スコアデータベース更新完了 ");
 	}
 
 	public int getJudgeCount(int judge, boolean fast) {
@@ -338,14 +340,14 @@ public class CourseResult extends AbstractResult {
 		}
 		
 		public boolean send() {
-			Logger.getGlobal().info("IRへスコア送信中 : " + course.getName());
+			logger.info("IRへスコア送信中 : {}", course.getName());
             IRResponse<Object> send1 = ir.sendCoursePlayData(new IRCourseData(course, lnmode), new bms.player.beatoraja.ir.IRScoreData(score));
             if(send1.isSucceeded()) {
-                Logger.getGlobal().info("IRスコア送信完了 : " + course.getName());
+				logger.info("IRスコア送信完了 : {}", course.getName());
                 retry = -255;
                 return true;
             } else {
-                Logger.getGlobal().warning("IRスコア送信失敗 : " + send1.getMessage());
+				logger.warn("IRスコア送信失敗 : {}", send1.getMessage());
                 retry++;
                 return false;
             }

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -6,7 +6,8 @@ import static bms.player.beatoraja.skin.SkinProperty.*;
 import static bms.player.beatoraja.SystemSoundManager.SoundType.*;
 
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.input.KeyCommand;
 import bms.player.beatoraja.input.KeyBoardInputProcesseor.ControlKeys;
@@ -31,6 +32,7 @@ import bms.player.beatoraja.song.SongData;
  * @author exch
  */
 public class MusicResult extends AbstractResult {
+	private static final Logger logger = LoggerFactory.getLogger(MusicResult.class);
 
 	private ResultKeyProperty property;
 
@@ -121,7 +123,7 @@ public class MusicResult extends AbstractResult {
 							removeIrSendStatus.add(irc);
 						}
 					} catch (Exception e) {
-						Logger.getGlobal().warning("IR送信時の例外:" + e.getMessage());
+						logger.warn("IR送信時の例外: {}", e.getMessage());
 						e.printStackTrace();
 						// remove from queue
 						removeIrSendStatus.add(irc);
@@ -136,12 +138,12 @@ public class MusicResult extends AbstractResult {
 						if(response.isSucceeded()) {
 							ranking.updateScore(response.getData(), newscore.getExscore() > oldscore.getExscore() ? newscore : oldscore);
 							rankingOffset = ranking.getRank() > 10 ? ranking.getRank() - 5 : 0;
-							Logger.getGlobal().info("IRからのスコア取得成功 : " + response.getMessage());
+							logger.info("IRからのスコア取得成功 : {}", response.getMessage());
 						} else {
-							Logger.getGlobal().warning("IRからのスコア取得失敗 : " + response.getMessage());
+							logger.warn("IRからのスコア取得失敗 : {}", response.getMessage());
 						}
 					} catch (Exception e) {
-						Logger.getGlobal().warning("IRからのスコア取得時例外:" + e.getMessage());
+						logger.warn("IRからのスコア取得時例外: {}", e.getMessage());
 						e.printStackTrace();
 					}
 				}
@@ -229,7 +231,7 @@ public class MusicResult extends AbstractResult {
 					}
 					if (resource.getPlayMode().mode == BMSPlayerMode.Mode.PLAY
 							&& key == ResultKeyProperty.ResultKey.REPLAY_DIFFERENT) {
-						Logger.getGlobal().info("オプションを変更せずリプレイ");
+						logger.info("オプションを変更せずリプレイ");
 						// オプションを変更せず同じ譜面でリプレイ
 						resource.getReplayData().randomoptionseed = -1;
 						resource.reloadBMSFile();
@@ -238,9 +240,9 @@ public class MusicResult extends AbstractResult {
 							&& key == ResultKeyProperty.ResultKey.REPLAY_SAME) {
 						// 同じ譜面でリプレイ
 						if(resource.isUpdateScore()) {
-							Logger.getGlobal().info("同じ譜面でリプレイ");							
+							logger.info("同じ譜面でリプレイ");
 						} else {
-							Logger.getGlobal().info("アシストモード時は同じ譜面でリプレイできません");
+							logger.info("アシストモード時は同じ譜面でリプレイできません");
 							resource.getReplayData().randomoptionseed = -1;
 						}
 						resource.reloadBMSFile();
@@ -456,7 +458,7 @@ public class MusicResult extends AbstractResult {
 			main.getPlayDataAccessor().writeScoreData(resource.getScoreData(), resource.getBMSModel(),
 					resource.getPlayerConfig().getLnmode(), resource.isUpdateScore());
 		} else {
-			Logger.getGlobal().info("プレイモードが" + resource.getPlayMode().mode.name() + "のため、スコア登録はされません");
+			logger.info("プレイモードが{}のため、スコア登録はされません", resource.getPlayMode().mode.name());
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/select/BarManager.java
+++ b/core/src/bms/player/beatoraja/select/BarManager.java
@@ -6,7 +6,8 @@ import java.io.BufferedInputStream;
 import java.lang.reflect.Method;
 import java.nio.file.*;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -38,6 +39,7 @@ import bms.player.beatoraja.song.SongInformationAccessor;
  * @author exch
  */
 public class BarManager {
+	private static final Logger logger = LoggerFactory.getLogger(BarManager.class);
 	
 	private final MusicSelector select;
 	/**
@@ -188,7 +190,7 @@ public class BarManager {
 					}
 				}
 			} else {
-				Logger.getGlobal().warning("IRからのテーブル取得失敗 : " + response.getMessage());
+				logger.warn("IRからのテーブル取得失敗 : {}", response.getMessage());
 			}
 		}
 
@@ -471,7 +473,7 @@ public class BarManager {
 		} else {
 			updateBar(null);
 		}
-		Logger.getGlobal().warning("楽曲がありません");
+		logger.warn("楽曲がありません");
 		return false;
 	}
 
@@ -823,7 +825,7 @@ public class BarManager {
 							songbar.setBanner(select.getBannerResource().get(bannerfile.toString()));
 						}
 					} catch (Exception e) {
-						Logger.getGlobal().warning("banner読み込み失敗 : " + song.getBanner());
+						logger.warn("banner読み込み失敗 : {}", song.getBanner());
 					}
 					try {
 						Path stagefilefile = Paths.get(song.getPath()).getParent().resolve(song.getStagefile());
@@ -832,7 +834,7 @@ public class BarManager {
 							songbar.setStagefile(select.getStagefileResource().get(stagefilefile.toString()));
 						}
 					} catch (Exception e) {
-						Logger.getGlobal().warning("stagefile読み込み失敗 : " + song.getStagefile());
+						logger.warn("stagefile読み込み失敗 : {}", song.getStagefile());
 					}
 				}
 				if (stop) {

--- a/core/src/bms/player/beatoraja/select/MusicSelectCommand.java
+++ b/core/src/bms/player/beatoraja/select/MusicSelectCommand.java
@@ -12,7 +12,8 @@ import javafx.scene.input.ClipboardContent;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 
 import static bms.player.beatoraja.SystemSoundManager.SoundType.FOLDER_OPEN;
@@ -115,7 +116,7 @@ public enum MusicSelectCommand {
                 }
 
                 if (!startdownload) {
-                    Logger.getGlobal().info("ダウンロードは開始されませんでした。");
+					LoggerFactory.getLogger(MusicSelectCommand.class).info("ダウンロードは開始されませんでした。");
                 }
                 break;
             }
@@ -126,10 +127,10 @@ public enum MusicSelectCommand {
 		if (current instanceof SongBar) {
 			final SongData song = ((SongBar) current).getSongData();
 			if (song == null) {
-				Logger.getGlobal().info("Not a valid song bar? Skipped...");
+				LoggerFactory.getLogger(MusicSelectCommand.class).info("Not a valid song bar? Skipped...");
 				return ;
 			}
-			Logger.getGlobal().info("Missing song md5: " + song.getMd5());
+			LoggerFactory.getLogger(MusicSelectCommand.class).info("Missing song md5: {}", song.getMd5());
 			if (song.getMd5() != null && !song.getMd5().isEmpty()) {
 				selector.main.getHttpDownloadProcessor().submitMD5Task(song.getMd5(), song.getTitle());
 			}

--- a/core/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/core/src/bms/player/beatoraja/select/MusicSelector.java
@@ -4,7 +4,8 @@ import static bms.player.beatoraja.skin.SkinProperty.*;
 import static bms.player.beatoraja.SystemSoundManager.SoundType.*;
 
 import java.nio.file.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -34,6 +35,7 @@ import imgui.ImGui;
  * @author exch
  */
 public final class MusicSelector extends MainState {
+	private static final Logger logger = LoggerFactory.getLogger(MusicSelector.class);
 
 	// TODO　ミラーランダム段位のスコア表示
 
@@ -143,7 +145,7 @@ public final class MusicSelector extends MainState {
 		this.rival = index != -1 ? rivals.getRivalInformation(index) : null;
 		rivalcache = index != -1 ? rivals.getRivalScoreDataCache(index) : null;
 		manager.updateBar();
-		Logger.getGlobal().info("Rival変更:" + (rival != null ? rival.getName() : "なし"));
+		logger.info("Rival変更:{}", rival != null ? rival.getName() : "なし");
 	}
 
 	public PlayerInformation getRival() {
@@ -445,20 +447,20 @@ public final class MusicSelector extends MainState {
 	private void readCourse(BMSPlayerMode mode) {
 		final GradeBar gradeBar = (GradeBar) manager.getSelected();
 		if (!gradeBar.existsAllSongs()) {
-			Logger.getGlobal().info("段位の楽曲が揃っていません");
+			logger.info("段位の楽曲が揃っていません");
 			return;
 		}
 
 		if (!_readCourse(mode, gradeBar)) {
 			ImGuiNotify.error("Failed to loading Course : Some of songs not found", 1200);
-			Logger.getGlobal().info("段位の楽曲が揃っていません");
+			logger.info("段位の楽曲が揃っていません");
 		}
 	}
 
 	private void readRandomCourse(BMSPlayerMode mode) {
 		final RandomCourseBar randomCourseBar = (RandomCourseBar) manager.getSelected();
 		if (!randomCourseBar.existsAllSongs()) {
-			Logger.getGlobal().info("ランダムコースの楽曲が揃っていません");
+			logger.info("ランダムコースの楽曲が揃っていません");
 			return;
 		}
 
@@ -466,7 +468,7 @@ public final class MusicSelector extends MainState {
 		final GradeBar gradeBar = new GradeBar(randomCourseBar.getCourseData().createCourseData());
 		if (!gradeBar.existsAllSongs()) {
 			ImGuiNotify.error("Failed to loading Random Course : Some of songs not found", 1200);
-			Logger.getGlobal().info("ランダムコースの楽曲が揃っていません");
+			logger.info("ランダムコースの楽曲が揃っていません");
 			return;
 		}
 
@@ -476,7 +478,7 @@ public final class MusicSelector extends MainState {
 			manager.setSelected(gradeBar);
 		} else {
 			ImGuiNotify.error("Failed to loading Random Course : Some of songs not found", 1200);
-			Logger.getGlobal().info("ランダムコースの楽曲が揃っていません");
+			logger.info("ランダムコースの楽曲が揃っていません");
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/select/PreviewMusicProcessor.java
+++ b/core/src/bms/player/beatoraja/select/PreviewMusicProcessor.java
@@ -5,7 +5,8 @@ import java.nio.file.Paths;
 import java.util.Deque;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.Config;
 import bms.player.beatoraja.Config.SongPreview;
@@ -18,6 +19,7 @@ import bms.player.beatoraja.song.SongData;
  * @author exch
  */
 public class PreviewMusicProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(PreviewMusicProcessor.class);
     /**
      * 音源読み込みタスク
      */
@@ -54,7 +56,7 @@ public class PreviewMusicProcessor {
             try {
                 previewPath = Paths.get(song.getPath()).getParent().resolve(song.getPreview()).toString();
             } catch (InvalidPathException e) {
-                Logger.getGlobal().warning(e.getMessage());
+                logger.warn(e.getMessage());
             }
         }
         commands.add(previewPath);

--- a/core/src/bms/player/beatoraja/select/SearchTextField.java
+++ b/core/src/bms/player/beatoraja/select/SearchTextField.java
@@ -5,7 +5,8 @@ import bms.player.beatoraja.SpriteBatchHelper;
 import bms.player.beatoraja.input.KeyBoardInputProcesseor.ControlKeys;
 import bms.player.beatoraja.select.bar.SearchWordBar;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
@@ -29,6 +30,7 @@ import com.badlogic.gdx.utils.viewport.FitViewport;
  * @author exch
  */
 public class SearchTextField extends Stage {
+	private static final Logger logger = LoggerFactory.getLogger(SearchTextField.class);
 	
 	// TOTO ユーザー定義のBitmapFontも使えるようにしたい
 	
@@ -146,7 +148,7 @@ public class SearchTextField extends Stage {
 			screen.addActor(search);
 			addActor(screen);
 		} catch (GdxRuntimeException e) {
-			Logger.getGlobal().warning("Search Text読み込み失敗");
+			logger.warn("Search Text読み込み失敗");
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/skin/BitmapFontBatchLoader.java
+++ b/core/src/bms/player/beatoraja/skin/BitmapFontBatchLoader.java
@@ -3,7 +3,8 @@ package bms.player.beatoraja.skin;
 import java.io.*;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.PixmapResourcePool;
 import bms.player.beatoraja.skin.json.JsonSkin;
@@ -26,6 +27,7 @@ import com.badlogic.gdx.utils.Array;
 // largely adopted from SkinTextBitmap.java
 
 public class BitmapFontBatchLoader {
+    private static final Logger logger = LoggerFactory.getLogger(BitmapFontBatchLoader.class);
     public BitmapFontBatchLoader(JsonSkin.Skin skin, Path skinPath, boolean usecim,
                                  boolean useMipMaps) {
         this.usecim = usecim;
@@ -40,8 +42,7 @@ public class BitmapFontBatchLoader {
                 fontPaths.put(path, font.type);
             }
             catch (IllegalArgumentException e) {
-                Logger.getGlobal().warning("Skin attempted to load a font with an invalid path: " +
-                                           e.getMessage());
+				logger.warn("Skin attempted to load a font with an invalid path: {}", e.getMessage());
             }
         }
     }
@@ -68,12 +69,12 @@ public class BitmapFontBatchLoader {
                     parsedFontData.put(fontData);
                 }
                 catch (InterruptedException e) {
-                    Logger.getGlobal().warning(e.getLocalizedMessage());
+                    logger.warn(e.getLocalizedMessage());
                     e.printStackTrace();
                 }
                 catch (Exception e) {
-                    Logger.getGlobal().warning("Failed to load bitmap font description: " + path);
-                    Logger.getGlobal().warning(e.getLocalizedMessage());
+					logger.warn("Failed to load bitmap font description: {}", path);
+                    logger.warn(e.getLocalizedMessage());
                 }
             }
             return true;
@@ -101,19 +102,18 @@ public class BitmapFontBatchLoader {
                                 loadedImages.put(imagePath);
                             }
                             else {
-                                Logger.getGlobal().warning("Failed to load bitmap font image: " +
-                                                           imagePath);
+								logger.warn("Failed to load bitmap font image: {}", imagePath);
                             }
                         }
                         catch (InterruptedException e) {
-                            Logger.getGlobal().warning(e.getLocalizedMessage());
+                            logger.warn(e.getLocalizedMessage());
                             e.printStackTrace();
                         }
                     });
                 }
             }
             catch (InterruptedException e) {
-                Logger.getGlobal().warning(e.getLocalizedMessage());
+                logger.warn(e.getLocalizedMessage());
                 e.printStackTrace();
             }
         }
@@ -131,7 +131,7 @@ public class BitmapFontBatchLoader {
                 loadedTextures.put(imagePath, new TextureRegion(texture));
             }
             catch (InterruptedException e) {
-                Logger.getGlobal().warning(e.getLocalizedMessage());
+                logger.warn(e.getLocalizedMessage());
                 e.printStackTrace();
             }
         }
@@ -170,7 +170,7 @@ public class BitmapFontBatchLoader {
                 fontCache.font = new BitmapFont(fontData, imageRegions, true);
             }
             catch (Exception e) {
-                Logger.getGlobal().warning(e.getLocalizedMessage());
+                logger.warn(e.getLocalizedMessage());
                 e.printStackTrace();
             }
             fontCache.fontData = fontData;
@@ -200,7 +200,7 @@ public class BitmapFontBatchLoader {
             return new fontSizes(size, scaleW, scaleH);
         }
         catch (Exception e) {
-            Logger.getGlobal().warning(e.getLocalizedMessage());
+            logger.warn(e.getLocalizedMessage());
             e.printStackTrace();
             return null;
         }

--- a/core/src/bms/player/beatoraja/skin/Skin.java
+++ b/core/src/bms/player/beatoraja/skin/Skin.java
@@ -30,7 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.lwjgl.opengl.GL11;
 
@@ -40,6 +41,7 @@ import org.lwjgl.opengl.GL11;
  * @author exch
  */
 public class Skin {
+	private static final Logger logger = LoggerFactory.getLogger(Skin.class);
 	
 	public final SkinHeader header;
 	/**
@@ -207,7 +209,7 @@ public class Skin {
 			}
 			
  		}
-		Logger.getGlobal().info("描画されないことが確定しているSkinObject削除 : " + removes.size + " / " + objects.size);
+		logger.info("描画されないことが確定しているSkinObject削除 : {} / {}", removes.size, objects.size);
 		objects.removeAll(removes, true);
 		objectarray = objects.toArray(SkinObject.class);
 		option.clear();

--- a/core/src/bms/player/beatoraja/skin/SkinTextFont.java
+++ b/core/src/bms/player/beatoraja/skin/SkinTextFont.java
@@ -3,7 +3,8 @@ package bms.player.beatoraja.skin;
 import bms.player.beatoraja.skin.property.StringProperty;
 import bms.player.beatoraja.skin.property.StringPropertyFactory;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
@@ -22,6 +23,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * @author exch
  */
 public class SkinTextFont extends SkinText {
+	private static final Logger logger = LoggerFactory.getLogger(SkinTextFont.class);
 
     /**
      * ビットマップフォント
@@ -48,7 +50,7 @@ public class SkinTextFont extends SkinText {
             parameter.size = size;
             setShadowOffset(new Vector2(shadow, shadow));    		
     	} catch (GdxRuntimeException e) {
-    		Logger.getGlobal().warning("Skin Font読み込み失敗");
+    		logger.warn("Skin Font読み込み失敗");
     	}
     }
     
@@ -71,7 +73,7 @@ public class SkinTextFont extends SkinText {
             layout = new GlyphLayout(font, "");
             preparedFonts = text;
         } catch (GdxRuntimeException e) {
-    		Logger.getGlobal().warning("Font準備失敗 : " + text + " - " + e.getMessage());
+			logger.warn("Font準備失敗 : {} - {}", text, e.getMessage());
     	}
     }    
 
@@ -90,7 +92,7 @@ public class SkinTextFont extends SkinText {
             font = generator.generateFont(parameter);
             layout = new GlyphLayout(font, "");        	
     	} catch (GdxRuntimeException e) {
-    		Logger.getGlobal().warning("Font準備失敗 : " + text + " - " + e.getMessage());
+			logger.warn("Font準備失敗 : {} - {}", text, e.getMessage());
     	}
 	}
 	

--- a/core/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
+++ b/core/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
@@ -6,7 +6,8 @@ import java.io.*;
 import java.nio.file.Path;
 import java.nio.charset.Charset;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.utils.*;
@@ -24,6 +25,7 @@ import bms.player.beatoraja.skin.lua.SkinLuaAccessor;
  * @author exch
  */
 public class JSONSkinLoader extends SkinLoader {
+	private static final Logger logger = LoggerFactory.getLogger(JSONSkinLoader.class);
 
 	protected Resolution dstr;
 	protected boolean usecim;
@@ -96,14 +98,14 @@ public class JSONSkinLoader extends SkinLoader {
                 sk = json.fromJson(JsonSkin.Skin.class, new FileReader(p.toFile()));
             }
 			catch (Exception e) {
-                Logger.getGlobal().warning("Error parsing json, retrying with Shift JIS: " + p);
+				logger.warn("Error parsing json, retrying with Shift JIS: {}", p);
                 var stream = new InputStreamReader(new FileInputStream(p.toFile()),
                                                    Charset.forName("Shift_JIS"));
                 sk = json.fromJson(JsonSkin.Skin.class, stream);
             }
             header = loadJsonSkinHeader(sk, p);
 		} catch (FileNotFoundException e) {
-			Logger.getGlobal().severe("JSONスキンファイルが見つかりません : " + p.toString());
+			logger.error("JSONスキンファイルが見つかりません : {}", p.toString());
 		}
 		return header;
 	}
@@ -249,7 +251,7 @@ public class JSONSkinLoader extends SkinLoader {
                 sk = json.fromJson(JsonSkin.Skin.class, new FileReader(p.toFile()));
             }
             catch (Exception e) {
-                Logger.getGlobal().warning("Error parsing json, retrying with Shift JIS: " + p);
+				logger.warn("Error parsing json, retrying with Shift JIS: {}", p);
                 var stream = new InputStreamReader(new FileInputStream(p.toFile()),
                                                    Charset.forName("Shift_JIS"));
                 sk = json.fromJson(JsonSkin.Skin.class, stream);
@@ -257,9 +259,9 @@ public class JSONSkinLoader extends SkinLoader {
 
             skin = loadJsonSkin(header, sk, type, property, p);
 		} catch (FileNotFoundException e) {
-			Logger.getGlobal().severe("JSONスキンファイルが見つかりません : " + p.toString());
+			logger.error("JSONスキンファイルが見つかりません : {}", p.toString());
 		} catch (Throwable e) {
-			Logger.getGlobal().severe("何らかの原因でJSONスキンファイルの読み込みに失敗しました");
+			logger.error("何らかの原因でJSONスキンファイルの読み込みに失敗しました");
 			e.printStackTrace();
 		}
 		return skin;
@@ -497,8 +499,8 @@ public class JSONSkinLoader extends SkinLoader {
 					 	isMovie = true;
 					 	break;
 					 } catch (Throwable e) {
-						Logger.getGlobal().warning("BGAファイル読み込み失敗。" + e.getMessage());
-					 	e.printStackTrace();
+						 logger.warn("BGAファイル読み込み失敗。{}", e.getMessage());
+						 e.printStackTrace();
 					 }
 				 }
 			 }

--- a/core/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/core/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -5,7 +5,8 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.BiConsumer;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Stream;
 
 import static bms.player.beatoraja.skin.SkinProperty.*;
@@ -34,6 +35,7 @@ import com.badlogic.gdx.utils.ObjectMap;
  * @author exch
  */
 public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
+	private static final Logger logger = LoggerFactory.getLogger(LR2SkinCSVLoader.class);
 
 	Array<Object> imagelist = new Array<Object>();
 	Array<SkinTextImage.SkinTextImageSource> fontlist = new Array<SkinTextImage.SkinTextImageSource>();
@@ -99,7 +101,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 								isMovie = true;
 								break;
 							} catch (Throwable e) {
-								Logger.getGlobal().warning("BGAファイル読み込み失敗。" + e.getMessage());
+								logger.warn("BGAファイル読み込み失敗。{}", e.getMessage());
 								e.printStackTrace();
 							}
 						}
@@ -109,8 +111,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 						imagelist.add(getTexture(imagefile.getPath(), usecim));
 					}
 				} else {
-					Logger.getGlobal()
-							.warning("IMAGE " + imagelist.size + " : ファイルが見つかりません : " + imagefile.getPath());
+					logger.warn("IMAGE {} : ファイルが見つかりません : {}", imagelist.size, imagefile.getPath());
 					imagelist.add(null);
 				}
 				// System.out
@@ -134,8 +135,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 					}
 
 				} else {
-					Logger.getGlobal()
-							.warning("IMAGE " + imagelist.size + " : ファイルが見つかりません : " + imagefile.getPath());
+					logger.warn("IMAGE {} : ファイルが見つかりません : {}", imagelist.size, imagefile.getPath());
 					fontlist.add(null);
 				}
 				// System.out
@@ -781,7 +781,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 		for (SkinObject obj : skin.getAllSkinObjects()) {
 			if (obj instanceof SkinImage && obj.getAllDestination().length == 0) {
 				skin.removeSkinObject(obj);
-				Logger.getGlobal().warning("NO_DESTINATION : " + obj);
+				logger.warn("NO_DESTINATION : {}", obj);
 			}
 		}
 	}
@@ -822,7 +822,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 			return getSourceImage((Texture) imagelist.get(values[2]), values[3], values[4], values[5], values[6],
 					values[7], values[8]);
 		}
-		Logger.getGlobal().warning("IMAGEが定義されてないか、読み込みに失敗しています : " + line);
+		logger.warn("IMAGEが定義されてないか、読み込みに失敗しています : {}", line);
 		return null;
 	}
 

--- a/core/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
+++ b/core/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
@@ -2,7 +2,8 @@ package bms.player.beatoraja.skin.lua;
 
 import java.nio.file.Path;
 import java.util.function.Function;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.luaj.vm2.*;
 import org.luaj.vm2.lib.*;
@@ -22,6 +23,7 @@ import bms.player.beatoraja.SkinConfig;
  * @author excln
  */
 public class SkinLuaAccessor {
+	private static final Logger logger = LoggerFactory.getLogger(SkinLuaAccessor.class);
 	
 	private final Globals globals;
 
@@ -50,7 +52,7 @@ public class SkinLuaAccessor {
 			final LuaValue lv = globals.load("return " + script);
 			return loadBooleanProperty(lv.checkfunction());
 		} catch (RuntimeException e) {
-			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
+			logger.warn("Lua解析時の例外 : {}", e.getMessage());
 		}
 		return null;
 	}
@@ -67,7 +69,7 @@ public class SkinLuaAccessor {
 				try {
 					return function.call().toboolean();
 				} catch (RuntimeException e) {
-					Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+					logger.warn("Lua実行時の例外 : {}", e.getMessage());
 					return false;
 				}
 			}
@@ -79,7 +81,7 @@ public class SkinLuaAccessor {
 			final LuaValue lv = globals.load("return " + script);
 			return loadIntegerProperty(lv.checkfunction());
 		} catch (RuntimeException e) {
-			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
+			logger.warn("Lua解析時の例外 : {}", e.getMessage());
 		}
 		return null;
 	}
@@ -91,7 +93,7 @@ public class SkinLuaAccessor {
 				try{
 					return function.call().toint();
 				} catch (RuntimeException e) {
-					Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+					logger.warn("Lua実行時の例外 : {}", e.getMessage());
 					return 0;
 				}
 			}
@@ -103,7 +105,7 @@ public class SkinLuaAccessor {
 			final LuaValue lv = globals.load("return " + script);
 			return loadFloatProperty(lv.checkfunction());
 		} catch (RuntimeException e) {
-			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
+			logger.warn("Lua解析時の例外 : {}", e.getMessage());
 		}
 		return null;
 	}
@@ -115,7 +117,7 @@ public class SkinLuaAccessor {
 				try{
 					return function.call().tofloat();
 				} catch (RuntimeException e) {
-					Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+					logger.warn("Lua実行時の例外 : {}", e.getMessage());
 					return 0f;
 				}
 			}
@@ -127,7 +129,7 @@ public class SkinLuaAccessor {
 			final LuaValue lv = globals.load("return " + script);
 			return loadStringProperty(lv.checkfunction());
 		} catch (RuntimeException e) {
-			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
+			logger.warn("Lua解析時の例外 : {}", e.getMessage());
 		}
 		return null;
 	}
@@ -139,7 +141,7 @@ public class SkinLuaAccessor {
 				try {
 					return function.call().tojstring();
 				} catch (RuntimeException e) {
-					Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
+					logger.warn("Lua実行時の例外：{}", e.getMessage());
 					return "";
 				}
 			}
@@ -168,7 +170,7 @@ public class SkinLuaAccessor {
 				return loadTimerProperty(lv.checkfunction());
 			}
 		} catch (RuntimeException e) {
-			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
+			logger.warn("Lua解析時の例外 : {}", e.getMessage());
 		}
 		return null;
 	}
@@ -186,7 +188,7 @@ public class SkinLuaAccessor {
 				try {
 					return timerFunction.call().tolong();
 				} catch (RuntimeException e) {
-					Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
+					logger.warn("Lua実行時の例外：{}", e.getMessage());
 					return Long.MIN_VALUE;
 				}
 			}
@@ -198,7 +200,7 @@ public class SkinLuaAccessor {
 			final LuaValue lv = globals.load(script);
 			return loadEvent(lv.checkfunction());
 		} catch (RuntimeException e) {
-			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
+			logger.warn("Lua解析時の例外 : {}", e.getMessage());
 		}
 		return null;
 	}
@@ -210,7 +212,7 @@ public class SkinLuaAccessor {
 				try{
 					function.call();
 				} catch (RuntimeException e) {
-					Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+					logger.warn("Lua実行時の例外 : {}", e.getMessage());
 				}
 			});
 		case 1:
@@ -218,7 +220,7 @@ public class SkinLuaAccessor {
 				try{
 					function.call(LuaNumber.valueOf(arg1));
 				} catch (RuntimeException e) {
-					Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+					logger.warn("Lua実行時の例外 : {}", e.getMessage());
 				}
 			});
 		case 2:
@@ -226,7 +228,7 @@ public class SkinLuaAccessor {
 				try{
 					function.call(LuaNumber.valueOf(arg1), LuaNumber.valueOf(arg2));
 				} catch (RuntimeException e) {
-					Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+					logger.warn("Lua実行時の例外 : {}", e.getMessage());
 				}
 			});
 		default:
@@ -239,7 +241,7 @@ public class SkinLuaAccessor {
 			final LuaValue lv = globals.load(script);
 			return loadFloatWriter(lv.checkfunction());
 		} catch (RuntimeException e) {
-			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
+			logger.warn("Lua解析時の例外 : {}", e.getMessage());
 		}
 		return null;
 	}
@@ -251,7 +253,7 @@ public class SkinLuaAccessor {
 				try{
 					function.call(LuaDouble.valueOf(value));
 				} catch (RuntimeException e) {
-					Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
+					logger.warn("Lua実行時の例外：{}", e.getMessage());
 				}
 			}
 		};

--- a/core/src/bms/player/beatoraja/song/SongInformation.java
+++ b/core/src/bms/player/beatoraja/song/SongInformation.java
@@ -7,7 +7,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * 楽曲詳細情報
@@ -15,6 +16,7 @@ import java.util.logging.Logger;
  * @author exch
  */
 public class SongInformation implements Validatable {
+	private static final Logger logger = LoggerFactory.getLogger(SongInformation.class);
 	
 	/**
 	 * 譜面のハッシュ値
@@ -207,7 +209,7 @@ public class SongInformation implements Validatable {
 		}
 		final int count = distribution.length() % (index.length * 2) == 0 ? distribution.length() / (index.length * 2) : 0;
 		if(count == 0) {
-			Logger.getGlobal().warning("distributionのString超が不正です");
+			logger.warn("distributionのString超が不正です");
 		}
 		distributionValues = new int[count][7];
 		for(int i = 0;i < count;i++) {
@@ -215,7 +217,7 @@ public class SongInformation implements Validatable {
 				try {
 					distributionValues[i][index[j]] = parseInt36(distribution, i * (index.length * 2) + j * 2);
 				} catch(NumberFormatException e) {
-					Logger.getGlobal().warning("distribution解析中の例外:" + e.getMessage());
+					logger.warn("distribution解析中の例外:{}", e.getMessage());
 				}
 			}
 		}

--- a/core/src/bms/player/beatoraja/song/SongInformationAccessor.java
+++ b/core/src/bms/player/beatoraja/song/SongInformationAccessor.java
@@ -4,7 +4,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.Validatable;
 import bms.player.beatoraja.SQLiteDatabaseAccessor;
@@ -25,6 +26,7 @@ import org.sqlite.SQLiteConfig.SynchronousMode;
  * @author exch
  */
 public class SongInformationAccessor extends SQLiteDatabaseAccessor {
+	private static final Logger logger = LoggerFactory.getLogger(SongInformationAccessor.class);
 
 	private final SQLiteDataSource ds;
 
@@ -63,7 +65,7 @@ public class SongInformationAccessor extends SQLiteDatabaseAccessor {
 		try {
 			validate(qr);
 		} catch (SQLException e) {
-			Logger.getGlobal().severe("楽曲データベース初期化中の例外:" + e.getMessage());
+			logger.error("楽曲データベース初期化中の例外:" + e.getMessage());
 		}
 	}
 

--- a/core/src/bms/player/beatoraja/stream/StreamController.java
+++ b/core/src/bms/player/beatoraja/stream/StreamController.java
@@ -3,7 +3,8 @@ package bms.player.beatoraja.stream;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import bms.player.beatoraja.MessageRenderer;
 import bms.player.beatoraja.select.MusicSelector;
@@ -14,6 +15,7 @@ import bms.player.beatoraja.stream.command.StreamRequestCommand;
  * beatoraja パイプで受け取った文字列処理
  */
 public class StreamController {
+    private static final Logger logger = LoggerFactory.getLogger(StreamController.class);
     StreamCommand[] commands;
     BufferedReader pipeBuffer;
     Thread polling;
@@ -45,7 +47,7 @@ public class StreamController {
                         if (line == null) {
                             break;
                         }
-                        Logger.getGlobal().info("受信:" + line);
+						logger.info("受信:{}", line);
                         execute(line);
                     } catch (Exception e) {
                         e.printStackTrace();
@@ -83,7 +85,7 @@ public class StreamController {
         for(int i = 0; i < commands.length; i++) {
             commands[i].dispose();
         }
-        Logger.getGlobal().info("パイプリソース破棄完了");
+        logger.info("パイプリソース破棄完了");
     }
 
     private void execute(String line) {

--- a/core/src/bms/player/beatoraja/system/RobustFile.java
+++ b/core/src/bms/player/beatoraja/system/RobustFile.java
@@ -12,9 +12,11 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.text.ParseException;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RobustFile {
+    private static final Logger logger = LoggerFactory.getLogger(RobustFile.class);
     // an interface for supplying a parsing function to the load methods
     // this function is expected to throw ParseException on any
     // encountered issues to trigger an attempt to restore from a backup
@@ -41,13 +43,13 @@ public class RobustFile {
         }
         catch (IOException e) {
             // could not read the original file - try the backup
-            Logger.getGlobal().severe(e.getMessage());
+            logger.error(e.getMessage());
             return loadBackup(file, parser);
         }
         catch (ParseException e) {
             // the read reported no errors but, for some reason, parsing the received
             // data failed (possible corruption) - log the problem, then restore from backup
-            Logger.getGlobal().severe(e.getMessage());
+            logger.error(e.getMessage());
             return loadBackup(file, parser);
         }
     }
@@ -70,7 +72,7 @@ public class RobustFile {
                                   e);
         }
         catch (ParseException e) {
-            Logger.getGlobal().severe(e.getMessage());
+            logger.error(e.getMessage());
             throw new IOException("File load failed.\nPath: " + original + "\nReason: " +
                                       e.getClass().getSimpleName() + "\n" + e.getMessage(),
                                   e);
@@ -101,8 +103,7 @@ public class RobustFile {
             Files.move(temporaryPath(file), file, REPLACE_EXISTING, ATOMIC_MOVE);
         }
         catch (AtomicMoveNotSupportedException e) {
-            Logger.getGlobal().warning("RobustFile.write: Could not perform an atomic move to " +
-                                       file);
+			logger.warn("RobustFile.write: Could not perform an atomic move to {}", file);
             Files.move(temporaryPath(file), file, REPLACE_EXISTING);
         }
 

--- a/core/src/bms/tool/mdprocessor/MusicDownloadProcessor.java
+++ b/core/src/bms/tool/mdprocessor/MusicDownloadProcessor.java
@@ -15,7 +15,8 @@ import java.nio.file.Paths;
 import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import static java.nio.file.StandardCopyOption.*;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -29,6 +30,7 @@ import org.apache.commons.compress.utils.IOUtils;
  * @author LNTakeshi
  */
 public class MusicDownloadProcessor {
+	private static final Logger logger = LoggerFactory.getLogger(MusicDownloadProcessor.class);
 
 	private Deque<IpfsInformation> commands = new ConcurrentLinkedDeque<IpfsInformation>();
 	private String ipfs = "";
@@ -143,10 +145,10 @@ public class MusicDownloadProcessor {
 							downloadipfs = new DownloadIpfsThread(ipfspath, path);
 							downloadipfs.start();
         					download = true;
-							Logger.getGlobal().info("BMS本体取得開始");
+							logger.info("BMS本体取得開始");
 						} else if (ipfspath != null && ipfspath.length() != 0 && diffpath != null
 								&& diffpath.length() != 0) {
-        					Logger.getGlobal().info(path+"は既に存在します（差分取得のみ）");
+							logger.info("{}は既に存在します（差分取得のみ）", path);
         					download = true;
         				}
         			}
@@ -169,7 +171,7 @@ public class MusicDownloadProcessor {
 								downloadipfs = new DownloadIpfsThread(diffpath, "ipfs" + File.separator + diffpath);
 								ipfspath = "";
 								downloadipfs.start();
-								Logger.getGlobal().info("差分取得開始");
+								logger.info("差分取得開始");
         					}
         				}else if(downloadpath == null){
         					Path p = Paths.get(path).toAbsolutePath();
@@ -183,7 +185,7 @@ public class MusicDownloadProcessor {
         	} catch (Exception e) {
         		e.printStackTrace();
         	}
-			Logger.getGlobal().info("IPFS Thread終了");
+			logger.info("IPFS Thread終了");
 			if (downloadipfs != null && downloadipfs.isAlive()) {
 				downloadipfs.interrupt();
 			}
@@ -221,7 +223,7 @@ public class MusicDownloadProcessor {
 				out = new FileOutputStream("ipfs/bms.tar.gz");
 			} catch (Exception e) {
 				if (url != null) {
-					Logger.getGlobal().info("URL:" + url.toString() + "に接続失敗。");
+					logger.info("URL:{}に接続失敗。", url.toString());
 				}
 			}
 			byte data[] = new byte[1024 * 512];

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ guacamole = "0.3.5"
 ebur128java = "1.2.6-2"
 jna = "5.13.0"
 websocket = "1.6.0"
+slf4j = "2.0.17"
 
 
 [libraries]
@@ -79,6 +80,8 @@ jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
 jna-platform = { group = "net.java.dev.jna", name = "jna-platform", version.ref = "jna" }
 
 javawebsocket = { group = "org.java-websocket", name = "Java-WebSocket", version.ref = "websocket" }
+slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+slf4j-jul = { group = "org.slf4j", name = "slf4j-jdk14", version.ref = "slf4j" }
 
 [bundles]
 libgdx = ["gdx-core", "gdx-backend", "gdx-freetype",  "gdx-controllers-core", "gdx-controllers-desktop"]
@@ -88,3 +91,4 @@ ffmpeg = ["javacv", "javacpp", "ffmpeg"]
 codecs = ["commons-codec", "jflac"]
 jackson = ["jackson-core", "jackson-databind", "jackson-annotations", "jackson-xml"]
 jna = ["jna", "jna-platform"]
+slf4j = ["slf4j", "slf4j-jul"]


### PR DESCRIPTION
> Although this pr is targeting `0.3.1` but it's an ongoing proposal that has no motivation to be merged into `0.3.1`

This is a proposal for adapting slf4j as the logging interface. Replacing the old string concat operations with the static strings. This can bring a little performance improvement.

> Why is concatenating string in logging message is bad?
> Because it would be executed no matter log level we currently at. Suppose you write a log message like `Logger.getGlobal().info("Error message:" + e.getMessage())` and the inner expression `"Error message:" + e.getMessage()` is evaluated even we're currently on `SEVERE` level. Using the parameterized api provided by slf4j can avoid this useless concatenation

