### PR TITLE
Rework logging in Endless Dream

### DIFF
--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -4,9 +4,11 @@ import java.io.*;
 import java.net.URL;
 import java.nio.file.*;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
+import java.util.logging.SimpleFormatter;
 
 import de.damios.guacamole.gdx.log.LoggerService;
 import org.slf4j.Logger;
@@ -69,11 +71,8 @@ public class MainLoader extends Application {
 		}
 
 		java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("");
-		try {
-			rootLogger.addHandler(new FileHandler("beatoraja_log.xml"));
-		} catch (Throwable e) {
-			e.printStackTrace();
-		}
+        initialize_logging(rootLogger);
+
 
 		BMSPlayerMode auto = null;
 		for (String s : args) {
@@ -117,7 +116,41 @@ public class MainLoader extends Application {
 		}
 	}
 
-	public static void play(Path bmsPath, BMSPlayerMode playerMode, boolean forceExit, Config config, PlayerConfig player, boolean songUpdated) {
+    private static void initialize_logging(java.util.logging.Logger rootLogger) {
+        try {
+            Files.createDirectories(Paths.get("./logs/"));
+            FileHandler fileHandler = new FileHandler("./logs/endlessdream-%g.log", 0, 10);
+            // There is no function to set this directly on the formatter. This is very stupid
+            // Set log info to plain for printing system information
+            System.setProperty("java.util.logging.SimpleFormatter.format", "%5$s%n");
+            SimpleFormatter formatter = new SimpleFormatter();
+            fileHandler.setFormatter(formatter);
+            rootLogger.addHandler(fileHandler);
+
+            Consumer<String> logSystem = (key) -> {
+                String value = System.getProperty(key);
+                rootLogger.info(key + ": " + value);
+            };
+
+            rootLogger.info("--- System Information ---");
+            logSystem.accept("java.version");
+            logSystem.accept("java.vendor");
+            logSystem.accept("java.home");
+            logSystem.accept("os.name");
+            logSystem.accept("os.arch");
+            logSystem.accept("os.version");
+            rootLogger.info("--- End System Information ---");
+
+            // OpenJDK default
+            System.setProperty("java.util.logging.SimpleFormatter.format", "%1$tc %2$s%n%4$s: %5$s%6$s%n");
+            SimpleFormatter formatter2 = new SimpleFormatter();
+            fileHandler.setFormatter(formatter2);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void play(Path bmsPath, BMSPlayerMode playerMode, boolean forceExit, Config config, PlayerConfig player, boolean songUpdated) {
 		//configuratorStage.setIconified(true);
 		if(config == null) {
             try {


### PR DESCRIPTION
This is a tracking PR for reworking the logging in Endless Dream. This comment will be editted as requirements are discussed and updated.

## Background

The logging system inherited by upstream has several issues, and has been neglected for some time now. It is slow, most logging messages are in Japanese, and XML structured logging is verbose, not easily human readable, and has largely fallen out of favor.

## Requirements

Through internal discussion the following criteria should be met:
- There will be two log files: a user facing, and developer facing log file
- The developer log file must be in English
- The old Japanese logging messages should be preserved in a per-locale i18n user facing log
- stdout should be in the per-locale i18n format
- Existing errors should receive 4 digit error numbers to keep communication clear

## Open Questions

The following has yet to be addressed
- How could we route JVM crash messages in stdout into the log file?
- How should we communicate BMS parse errors to the user more effectively than is done now?
- Should we promote certain warnings/errors to popping up an imguinotify toast? if so which ones?

## Relevant PRs

#100
#177 (merged)