### PR TITLE
Fix for improperly closed connection in SQLiteSongDatabaseAccessor

### DIFF
--- a/core/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
+++ b/core/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
@@ -206,31 +206,35 @@ public class SQLiteSongDatabaseAccessor extends SQLiteDatabaseAccessor implement
 	}
 
 	public SongData[] getSongDatas(String sql, String score, String scorelog, String info) {
-		try (Statement stmt = qr.getDataSource().getConnection().createStatement()) {
-			stmt.execute("ATTACH DATABASE '" + score + "' as scoredb");
-			stmt.execute("ATTACH DATABASE '" + scorelog + "' as scorelogdb");
-			List<SongData> m;
+      	try (Connection conn = qr.getDataSource().getConnection()) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("ATTACH DATABASE '" + score + "' as scoredb");
+                stmt.execute("ATTACH DATABASE '" + scorelog + "' as scorelogdb");
+                List<SongData> m = new ArrayList<>();
 
-			if(info != null) {
-				stmt.execute("ATTACH DATABASE '" + info + "' as infodb");
-				String s = "SELECT DISTINCT md5, song.sha256 AS sha256, title, subtitle, genre, artist, subartist,path,folder,stagefile,banner,backbmp,parent,level,difficulty,"
-						+ "maxbpm,minbpm,song.mode AS mode, judge, feature, content, song.date AS date, favorite, song.notes AS notes, adddate, preview, length, charthash"
-						+ " FROM song INNER JOIN (information LEFT OUTER JOIN (score LEFT OUTER JOIN scorelog ON score.sha256 = scorelog.sha256) ON information.sha256 = score.sha256) "
-						+ "ON song.sha256 = information.sha256 WHERE " + sql;
-				ResultSet rs = stmt.executeQuery(s);
-				m = songhandler.handle(rs);
-//				System.out.println(s + " -> result : " + m.size());
-				stmt.execute("DETACH DATABASE infodb");
-			} else {
-				String s = "SELECT DISTINCT md5, song.sha256 AS sha256, title, subtitle, genre, artist, subartist,path,folder,stagefile,banner,backbmp,parent,level,difficulty,"
-						+ "maxbpm,minbpm,song.mode AS mode, judge, feature, content, song.date AS date, favorite, song.notes AS notes, adddate, preview, length, charthash"
-						+ " FROM song LEFT OUTER JOIN (score LEFT OUTER JOIN scorelog ON score.sha256 = scorelog.sha256) ON song.sha256 = score.sha256 WHERE " + sql;
-				ResultSet rs = stmt.executeQuery(s);
-				m = songhandler.handle(rs);
-			}
-			stmt.execute("DETACH DATABASE scorelogdb");				
-			stmt.execute("DETACH DATABASE scoredb");
-			return Validatable.removeInvalidElements(m).toArray(new SongData[0]);
+                if(info != null) {
+                    stmt.execute("ATTACH DATABASE '" + info + "' as infodb");
+                    String s = "SELECT DISTINCT md5, song.sha256 AS sha256, title, subtitle, genre, artist, subartist,path,folder,stagefile,banner,backbmp,parent,level,difficulty,"
+                            + "maxbpm,minbpm,song.mode AS mode, judge, feature, content, song.date AS date, favorite, song.notes AS notes, adddate, preview, length, charthash"
+                            + " FROM song INNER JOIN (information LEFT OUTER JOIN (score LEFT OUTER JOIN scorelog ON score.sha256 = scorelog.sha256) ON information.sha256 = score.sha256) "
+                            + "ON song.sha256 = information.sha256 WHERE " + sql;
+                    ResultSet rs = stmt.executeQuery(s);
+                    m = songhandler.handle(rs);
+    				// System.out.println(s + " -> result : " + m.size());
+                    stmt.execute("DETACH DATABASE infodb");
+                } else {
+                    String s = "SELECT DISTINCT md5, song.sha256 AS sha256, title, subtitle, genre, artist, subartist,path,folder,stagefile,banner,backbmp,parent,level,difficulty,"
+                            + "maxbpm,minbpm,song.mode AS mode, judge, feature, content, song.date AS date, favorite, song.notes AS notes, adddate, preview, length, charthash"
+                            + " FROM song LEFT OUTER JOIN (score LEFT OUTER JOIN scorelog ON score.sha256 = scorelog.sha256) ON song.sha256 = score.sha256 WHERE " + sql;
+                    ResultSet rs = stmt.executeQuery(s);
+                    m = songhandler.handle(rs);
+                }
+                stmt.execute("DETACH DATABASE scorelogdb");
+                stmt.execute("DETACH DATABASE scoredb");
+                return Validatable.removeInvalidElements(m).toArray(new SongData[0]);
+            } catch(Throwable e) {
+                e.printStackTrace();
+            }
 		} catch(Throwable e) {
 			e.printStackTrace();			
 		}


### PR DESCRIPTION
While investigating the memory leak in #148, I ended up finding an unrelated issue in `SQLiteSongDatabaseAccessor`. The 4-argument version of `getSongDatas` (as far as I could tell, used in calculating lamps for some types of music select bars) did not `close()` its `Connection`, leading to a surprisingly large memory leak - I believe it could add up to as much as a gigabyte over a long session with lots of movement between folders.

The difference this fix makes can be observed by inserting `System.gc()` somewhere (for example in `getSongDatas`), and repeatedly going in and out of a folder at the top level of music select. I tested on linux.