### PR TITLE
fix for incorrect behaviour when searching with 0 results

### DIFF
--- a/core/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
+++ b/core/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
@@ -100,8 +100,8 @@ public class KeyBoardInputProcesseor extends BMSPlayerInputDevice implements Inp
 	public void poll(final long microtime) {
 		// NOTE: For further dev came here, it's better to wrap this variable instead of
 		// accessing imgui menu's field directly
-		boolean acceptInput = !textmode && !SkinWidgetManager.focus;
-		if (acceptInput) {
+        boolean acceptInput = !SkinWidgetManager.focus;
+		if (acceptInput && !textmode) {
 			for (int i = 0; i < keys.length; i++) {
 				if(keys[i] < 0) {
 					continue;


### PR DESCRIPTION
The behaviour implemented in `3090e308` where opening the skin widget debugger (#79) blocks keyboard input created an issue where, when searching for something that gives no results, hitting return would incorrectly select the currently hovered folder or song. I fix.