### PR TITLE
Auto switch http download source when package is missing

### DIFF
--- a/core/src/bms/player/beatoraja/Config.java
+++ b/core/src/bms/player/beatoraja/Config.java
@@ -188,6 +188,7 @@ public class Config implements Validatable {
 	private String overrideDownloadURL = "";
 	private String downloadDirectory = DEFAULT_DOWNLOAD_DIRECTORY;
 	public static final String DEFAULT_DOWNLOAD_DIRECTORY = "http_download";
+	private boolean autoSwitchHttpDownloadSource = true;
 
 	private int irSendCount = 5;
 
@@ -826,7 +827,15 @@ public class Config implements Validatable {
 		}
 	}
 
-    public boolean validate() {
+	public boolean isAutoSwitchHttpDownloadSource() {
+		return autoSwitchHttpDownloadSource;
+	}
+
+	public void setAutoSwitchHttpDownloadSource(boolean autoSwitchHttpDownloadSource) {
+		this.autoSwitchHttpDownloadSource = autoSwitchHttpDownloadSource;
+	}
+
+	public boolean validate() {
 		displaymode = (displaymode != null) ? displaymode : DisplayMode.WINDOW;
 		resolution = (resolution != null) ? resolution : Resolution.HD;
 

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -508,8 +508,7 @@ public class MainController {
 		}
 
 		if (config.isEnableHttp()) {
-			HttpDownloadSource httpDownloadSource = HttpDownloadProcessor.DOWNLOAD_SOURCES.get(config.getDownloadSource()).build(config);
-			httpDownloadProcessor = new HttpDownloadProcessor(this, httpDownloadSource, config.getDownloadDirectory());
+			httpDownloadProcessor = new HttpDownloadProcessor(this, config);
 			DownloadTaskState.initialize(httpDownloadProcessor);
 			DownloadTaskMenu.setProcessor(httpDownloadProcessor);
 		}

--- a/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
+++ b/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
@@ -419,6 +419,7 @@
 
                     <CheckBox fx:id="enableHttp" mnemonicParsing="false" prefHeight="18.0" text="%ENABLE_HTTP" />
                     <ComboBox fx:id="httpDownloadSource" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                    <CheckBox fx:id="autoSwitchHttpDownloadSource" mnemonicParsing="false" prefHeight="18.0" text="%AUTO_SWITCH_HTTP_DOWNLOAD_SOURCE" />
                     <GridPane hgap="10" vgap="5">
                         <children>
                             <Label text="Default Http Server URL" prefHeight="25.0" GridPane.rowIndex="0" GridPane.columnIndex="0" />

--- a/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
+++ b/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
@@ -2,7 +2,6 @@ package bms.player.beatoraja.launcher;
 
 import java.awt.Desktop;
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -16,29 +15,20 @@ import bms.player.beatoraja.exceptions.PlayerConfigException;
 import bms.player.beatoraja.external.ScoreDataImporter;
 
 import bms.tool.mdprocessor.HttpDownloadProcessor;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import javafx.animation.AnimationTimer;
-import javafx.beans.binding.Bindings;
-import org.apache.commons.lang3.compare.ComparableUtils;
 
 import bms.model.Mode;
 import bms.player.beatoraja.*;
 import bms.player.beatoraja.play.JudgeAlgorithm;
-import bms.player.beatoraja.play.TargetProperty;
 import bms.player.beatoraja.song.*;
 import javafx.application.Platform;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
 import javafx.event.ActionEvent;
 import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
-import javafx.scene.AccessibleAttribute;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
-import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -264,6 +254,8 @@ public class PlayConfigurationView implements Initializable {
 	@FXML
 	private ComboBox<String> httpDownloadSource;
 	@FXML
+	private CheckBox autoSwitchHttpDownloadSource;
+	@FXML
 	private TextField defaultDownloadURL;
 	@FXML
 	private TextField overrideDownloadURL;
@@ -350,7 +342,7 @@ public class PlayConfigurationView implements Initializable {
 		initComboBox(autosavereplay3, autosaves);
 		initComboBox(autosavereplay4, autosaves);
 
-		httpDownloadSource.getItems().setAll(HttpDownloadProcessor.DOWNLOAD_SOURCES.keySet());
+		httpDownloadSource.getItems().setAll(HttpDownloadProcessor.DOWNLOAD_SOURCE_METAS.keySet());
 		notesdisplaytiming.setValueFactoryValues(PlayerConfig.JUDGETIMING_MIN, PlayerConfig.JUDGETIMING_MAX, 0, 1);
 		resourceController.init(this);
 		discordController.init(this);
@@ -483,6 +475,7 @@ public class PlayConfigurationView implements Initializable {
 
 		enableHttp.setSelected(config.isEnableHttp());
 		httpDownloadSource.setValue(config.getDownloadSource());
+		autoSwitchHttpDownloadSource.setSelected(config.isAutoSwitchHttpDownloadSource());
 		defaultDownloadURL.setText(config.getDefaultDownloadURL());
 		overrideDownloadURL.setText(config.getOverrideDownloadURL());
 
@@ -631,6 +624,7 @@ public class PlayConfigurationView implements Initializable {
 
 		config.setEnableHttp(enableHttp.isSelected());
 		config.setDownloadSource(httpDownloadSource.getValue());
+		config.setAutoSwitchHttpDownloadSource(autoSwitchHttpDownloadSource.isSelected());
 		config.setOverrideDownloadURL(overrideDownloadURL.getText());
 
 		config.setClipboardWhenScreenshot(clipboardScreenshot.isSelected());

--- a/core/src/bms/tool/mdprocessor/DownloadRequest.java
+++ b/core/src/bms/tool/mdprocessor/DownloadRequest.java
@@ -1,0 +1,35 @@
+package bms.tool.mdprocessor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * DownloadRequest is a simple data object that records the context data during the process of downloading a package.
+ */
+public class DownloadRequest {
+	private String md5;
+	private String name;
+	private Set<String> triedSources;
+
+	public DownloadRequest(String md5, String name) {
+		this.md5 = md5;
+		this.name = name;
+		this.triedSources = new HashSet<>();
+	}
+
+	public void markTried(HttpDownloadSource downloadSource) {
+		this.triedSources.add(downloadSource.getName());
+	}
+
+	public boolean hasTried(String downloadSource) {
+		return this.triedSources.contains(downloadSource);
+	}
+
+	public String getMd5() {
+		return md5;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/core/src/bms/tool/mdprocessor/DownloadTask.java
+++ b/core/src/bms/tool/mdprocessor/DownloadTask.java
@@ -5,20 +5,18 @@ import java.nio.file.Path;
 public class DownloadTask {
     final private int id;
     final private String url;
-    final private String name;
-    final private String hash;
 
+    private DownloadRequest request;
     private DownloadTaskStatus downloadTaskStatus;
     private long downloadSize;
     private long contentLength;
     private String errorMessage;
     private volatile long timeFinished;
 
-    public DownloadTask(int id, String url, String name, String hash) {
+    public DownloadTask(int id, String url, DownloadRequest request) {
         this.id = id;
         this.url = url;
-        this.name = name;
-        this.hash = hash;
+        this.request = request;
         this.downloadTaskStatus = DownloadTaskStatus.Prepare;
     }
 
@@ -31,7 +29,7 @@ public class DownloadTask {
     }
 
     public String getHash() {
-        return hash;
+        return request.getMd5();
     }
 
     public DownloadTaskStatus getDownloadTaskStatus() {
@@ -70,7 +68,7 @@ public class DownloadTask {
     }
 
     public String getName() {
-        return name;
+        return request.getName();
     }
 
     public long getTimeFinished() {

--- a/core/src/bms/tool/mdprocessor/HttpDownloadProcessor.java
+++ b/core/src/bms/tool/mdprocessor/HttpDownloadProcessor.java
@@ -1,10 +1,13 @@
 package bms.tool.mdprocessor;
 
+import bms.player.beatoraja.Config;
 import bms.player.beatoraja.MainController;
 import bms.player.beatoraja.modmenu.ImGuiNotify;
-import com.badlogic.gdx.graphics.Color;
 import org.apache.commons.compress.archivers.sevenz.SevenZArchiveEntry;
 import org.apache.commons.compress.archivers.sevenz.SevenZFile;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -12,16 +15,12 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * In-game download processor. In charge of:
@@ -38,20 +37,21 @@ import java.util.regex.Pattern;
  */
 public class HttpDownloadProcessor {
     private static final Logger logger = LoggerFactory.getLogger(HttpDownloadProcessor.class);
-    public static final Map<String, HttpDownloadSourceMeta> DOWNLOAD_SOURCES = new HashMap<>();
+
+    public static final Map<String, HttpDownloadSourceMeta> DOWNLOAD_SOURCE_METAS = new HashMap<>();
     public static final int MAXIMUM_DOWNLOAD_COUNT = 5;
-    private String downloadDirectory;
+    private final String downloadDirectory;
 
     static {
         // Ginger
         HttpDownloadSourceMeta gingerDownloadSourceMeta = GingerDownloadSource.META;
-        DOWNLOAD_SOURCES.put(gingerDownloadSourceMeta.getName(), gingerDownloadSourceMeta);
+        DOWNLOAD_SOURCE_METAS.put(gingerDownloadSourceMeta.getName(), gingerDownloadSourceMeta);
         // Wriggle
         HttpDownloadSourceMeta wriggleDownloadSourceMeta = WriggleDownloadSource.META;
-        DOWNLOAD_SOURCES.put(wriggleDownloadSourceMeta.getName(), wriggleDownloadSourceMeta);
+        DOWNLOAD_SOURCE_METAS.put(wriggleDownloadSourceMeta.getName(), wriggleDownloadSourceMeta);
         // Konmai
         HttpDownloadSourceMeta konmaiDownloadSourceMeta = KonmaiDownloadSource.META;
-        DOWNLOAD_SOURCES.put(konmaiDownloadSourceMeta.getName(), konmaiDownloadSourceMeta);
+        DOWNLOAD_SOURCE_METAS.put(konmaiDownloadSourceMeta.getName(), konmaiDownloadSourceMeta);
     }
 
     // id => task
@@ -63,12 +63,22 @@ public class HttpDownloadProcessor {
     private final ExecutorService submitter = Executors.newSingleThreadExecutor();
     // A reference to the main controller, only used for updating folder and rendering the message
     private final MainController main;
-    private final HttpDownloadSource httpDownloadSource;
+    private final HttpDownloadSource preferredDownloadSource;
+    private final boolean autoSwitchHttpDownloadSource;
+    // Download source instances
+    private Map<String, HttpDownloadSource> DOWNLOAD_SOURCES = new HashMap<>();
 
-    public HttpDownloadProcessor(MainController main, HttpDownloadSource httpDownloadSource, String downloadDirectory) {
+    public HttpDownloadProcessor(MainController main, Config config) {
         this.main = main;
-        this.httpDownloadSource = httpDownloadSource;
-        this.downloadDirectory = downloadDirectory;
+        DOWNLOAD_SOURCES = DOWNLOAD_SOURCE_METAS.entrySet()
+                .stream()
+                .map(entry -> Pair.of(entry.getKey(), entry.getValue().build(config)))
+                .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
+        this.preferredDownloadSource = DOWNLOAD_SOURCES.containsKey(config.getDownloadSource())
+                ? DOWNLOAD_SOURCES.get(config.getDownloadSource())
+                : DOWNLOAD_SOURCES.get(getDefaultDownloadSource().getName());
+        this.downloadDirectory = config.getDownloadDirectory();
+        this.autoSwitchHttpDownloadSource = config.isAutoSwitchHttpDownloadSource() && DOWNLOAD_SOURCE_METAS.size() != 1;
     }
 
     public static HttpDownloadSourceMeta getDefaultDownloadSource() {
@@ -85,20 +95,46 @@ public class HttpDownloadProcessor {
     public Map<Integer, DownloadTask> getAllTasks() { return tasks; }
 
     /**
-     * Submit a download task based on md5
-     *
-     * @param md5      missing sabun's md5
-     * @param taskName task name, normally sabun's name
+     * Submit a download request based on md5, and use the configured download source
      */
     public void submitMD5Task(String md5, String taskName) {
-        logger.info("[HttpDownloadProcessor] Trying to submit new download task[{}](based on md5: {})", taskName, md5);
-        String sourceName = httpDownloadSource.getName();
+        DownloadRequest req = new DownloadRequest(md5, taskName);
+        submitMD5Task(req, this.preferredDownloadSource);
+    }
+
+    /**
+     * Try submitting a download request with a specified download source
+     *
+     * @param request download request
+     * @param source specified download source, must be non-null
+     */
+    public void submitMD5Task(DownloadRequest request, HttpDownloadSource source) {
+        String sourceName = source.getName();
+        request.markTried(source);
+        logger.info(
+                "[HttpDownloadProcessor] Trying to submit new download task[{}](based on md5: {}, source: {})",
+                request.getName(), request.getMd5(), sourceName
+        );
         String downloadURL;
         try {
-            downloadURL = httpDownloadSource.getDownloadURLBasedOnMd5(md5);
+            downloadURL = source.getDownloadURLBasedOnMd5(request.getMd5());
         } catch (FileNotFoundException e) {
             logger.error("[HttpDownloadProcessor] Remote server[{}] reports no such data", sourceName);
             ImGuiNotify.error(String.format("Cannot find specified song from %s", sourceName));
+            if (autoSwitchHttpDownloadSource) {
+                Optional<HttpDownloadSource> any = DOWNLOAD_SOURCES.entrySet()
+                        .stream()
+                        .filter(entry -> !request.hasTried(entry.getKey()))
+                        .map(Map.Entry::getValue)
+                        .findAny();
+                if (any.isPresent()) {
+                    logger.info("[HttpDownloadProcessor] Trying another download source: {}", any.get().getName());
+                    submitMD5Task(request, any.get());
+                } else {
+                    logger.info("[HttpDownloadProcessor] All download sources doesn't have this chart");
+                    ImGuiNotify.error("All download sources doesn't have this chart");
+                }
+            }
             return;
         } catch (RuntimeException e) {
             e.printStackTrace();
@@ -120,9 +156,9 @@ public class HttpDownloadProcessor {
                     return null;
                 }
                 int taskId = idGenerator.addAndGet(1);
-                DownloadTask downloadTask = new DownloadTask(taskId, downloadURL, taskName, md5);
+                DownloadTask downloadTask = new DownloadTask(taskId, downloadURL, request);
                 tasks.put(taskId, downloadTask);
-                ImGuiNotify.info(String.format("New download task[%s] submitted", taskName));
+                ImGuiNotify.info(String.format("New download task[%s] submitted", downloadTask.getName()));
                 return downloadTask;
             }
         });
@@ -167,7 +203,7 @@ public class HttpDownloadProcessor {
                 result = downloadFileFromURL(downloadTask, String.format("%s.7z", hash));
             } catch (Exception e) {
                 e.printStackTrace();
-                ImGuiNotify.error(String.format("Failed downloading from %s due to %s", httpDownloadSource.getName(), e.getMessage()));
+                ImGuiNotify.error(String.format("Failed downloading from %s due to %s", preferredDownloadSource.getName(), e.getMessage()));
             }
             if (result == null) {
                 // Download failed, skip the remaining steps
@@ -229,7 +265,7 @@ public class HttpDownloadProcessor {
             int responseCode = conn.getResponseCode();
             if (responseCode != HttpURLConnection.HTTP_OK) {
                 if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
-                    throw new FileNotFoundException("Package not found at " + httpDownloadSource.getName());
+                    throw new FileNotFoundException("Package not found at " + preferredDownloadSource.getName());
                 }
                 throw new IllegalStateException("Unexpected http response code: " + responseCode);
             }

--- a/core/src/resources/UIResources.properties
+++ b/core/src/resources/UIResources.properties
@@ -150,6 +150,7 @@ TWITTER_CONSUMER_KEY=Consumer Key
 TWITTER_CONSUMER_SECRET=Consumer Secret
 ENABLE_IPFS=Enable automatic download of BMS by IPFS
 ENABLE_HTTP=Enable automatic download of BMS by HTTP
+AUTO_SWITCH_HTTP_DOWNLOAD_SOURCE=Auto switch download source when package is missing
 MOUSE_SCRATCH=Mouse Scratch
 MOUSE_SCRATCH_TIME_THRESHOLD=Mouse Scratch Threshold (ms)
 MOUSE_SCRATCH_DISTANCE=Mouse Scratch Distance


### PR DESCRIPTION
Waiting wriggle changes the endpoint behavior

There're two cases that we know a package is missing from server:

- Building the actual download link. Konmai requires us to query a meta data endpoint first to know the actual download link. If it returns 404 or a json string with err message then we know this package is not present on konmai.
- Downloading file from the actual download link and server responds 404 back. This is currently happening when using wriggle as the download source because it's meta query endpoint doesn't return the actual download link back. The link is constructed by using a specific pattern currently.

Handle the second case is kinda hard because it's an async task. So currently this pr is waiting wriggle to change the endpoint behavior to match what konmai does.