### PR TITLE
Goto result scene button

### DIFF
--- a/core/src/bms/player/beatoraja/CourseDataResource.java
+++ b/core/src/bms/player/beatoraja/CourseDataResource.java
@@ -1,0 +1,64 @@
+package bms.player.beatoraja;
+
+import bms.player.beatoraja.song.SongData;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Holding all course data on disk
+ */
+public class CourseDataResource {
+	private final List<CourseData> courseDataList;
+	// Sha256 (sorted, concat) -> courseData
+	private final Map<String, CourseData> sha256CourseDataMap;
+	// Md5 (sorted, concat) -> courseData
+	private final Map<String, CourseData> md5CourseDataMap;
+
+	public CourseDataResource(List<CourseData> courseDataList) {
+		this.courseDataList = courseDataList;
+		this.sha256CourseDataMap = courseDataList.stream()
+				.filter(
+						cd -> Arrays.stream(cd.getSong())
+								.noneMatch(sd -> sd.getSha256() == null || sd.getSha256().isEmpty())
+				)
+				.collect(Collectors.toMap(
+						courseData -> {
+							SongData[] songs = courseData.getSong();
+							return Arrays.stream(songs)
+									.map(SongData::getSha256)
+									.sorted()
+									.collect(Collectors.joining());
+						}, Function.identity(), (a, b) -> a
+				));
+		this.md5CourseDataMap = courseDataList.stream()
+				.filter(
+						cd -> Arrays.stream(cd.getSong())
+								.noneMatch(sd -> sd.getMd5() == null || sd.getMd5().isEmpty())
+				)
+				.collect(Collectors.toMap(
+				courseData -> {
+					SongData[] songs = courseData.getSong();
+					return Arrays.stream(songs)
+							.map(SongData::getMd5)
+							.sorted()
+							.collect(Collectors.joining());
+				}, Function.identity(), (a, b) -> a
+		));
+	}
+
+	public List<CourseData> getCourseDataList() {
+		return courseDataList;
+	}
+
+	public Optional<CourseData> getCourseDataBySha256(List<String> sha256List) {
+		String sortedSha256s = sha256List.stream().sorted().collect(Collectors.joining());
+		return Optional.ofNullable(sha256CourseDataMap.get(sortedSha256s));
+	}
+
+	public Optional<CourseData> getCourseDataByMd5(List<String> md5List) {
+		String sortedMd5s = md5List.stream().sorted().collect(Collectors.joining());
+		return Optional.ofNullable(md5CourseDataMap.get(sortedMd5s));
+	}
+}

--- a/core/src/bms/player/beatoraja/PlayerResource.java
+++ b/core/src/bms/player/beatoraja/PlayerResource.java
@@ -324,6 +324,10 @@ public final class PlayerResource {
 		return course;
 	}
 
+	public void clearCourseBMSModels() {
+		course = null;
+	}
+
 	public void setAutoPlaySongs(Path[] paths, boolean loop) {
 		this.bmsPaths = paths;
 		this.loop = loop;

--- a/core/src/bms/player/beatoraja/result/CourseResult.java
+++ b/core/src/bms/player/beatoraja/result/CourseResult.java
@@ -167,6 +167,17 @@ public class CourseResult extends AbstractResult {
 		stop(getSound(COURSE_CLEAR) != null ? COURSE_CLEAR : RESULT_CLEAR);
 		stop(getSound(COURSE_FAIL) != null ? COURSE_FAIL : RESULT_FAIL);
 		stop(getSound(COURSE_CLOSE) != null ? COURSE_CLOSE : RESULT_CLOSE);
+		// NOTE: This line is preventing crash from specific executions:
+		// 1) Course result scene (by pressing goto course scene)
+		// 2) Return to music select scene
+		// 3) Music result scene (by pressing goto result scene)
+		// 4) Exiting from music result scene, the game itself will crash immediately
+		// This crash is because when trying to exist music result scene, the game will check if we're currently
+		// playing a course, this is by checking 'courseBMSModels' from resource is whether empty or not
+		// During the step (1), we have set course data into resource. And if we don't remove it manually here,
+		// it will be still exist at step 3. And the game would think we're playing a course and try to do some
+		// silly things that causes the game to crash.
+		resource.clearCourseBMSModels();
 	}
 
 	public void render() {

--- a/core/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/core/src/bms/player/beatoraja/select/MusicSelector.java
@@ -8,6 +8,8 @@ import java.nio.file.*;
 import bms.player.beatoraja.play.GrooveGauge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -741,6 +743,30 @@ public final class MusicSelector extends MainState {
 			main.changeState(MainState.MainStateType.RESULT);
 		} else {
 			ImGuiNotify.error("Failed to load BMS");
+		}
+	}
+
+	public void gotoCourseResultScene(CourseData courseData, ScoreData score, FloatArray[] gaugeLog) {
+		Path[] bmsPaths = Arrays.stream(courseData.getSong())
+				.map(sd -> Path.of(sd.getPath()))
+				.toArray(Path[]::new);
+		if (resource.setCourseBMSFiles(bmsPaths)) {
+			resource.setCourseData(courseData);
+			resource.setScoreData(score);
+			resource.setCourseScoreData(score);
+			resource.setBMSFile(bmsPaths[0], BMSPlayerMode.AUTOPLAY);
+			resource.setGrooveGauge(GrooveGauge.create(resource.getBMSModel(), score.getGauge(), resource));
+			if (gaugeLog == null) {
+				gaugeLog = new FloatArray[resource.getGrooveGauge().getGaugeTypeLength()];
+				for (int i = 0; i < resource.getGrooveGauge().getGaugeTypeLength(); i++) {
+					gaugeLog[i] = new FloatArray();
+					gaugeLog[i].add(0.0f);
+				}
+			}
+			resource.setGauge(gaugeLog);
+			main.changeState(MainStateType.COURSERESULT);
+		} else {
+			ImGuiNotify.error("Failed to load course");
 		}
 	}
 


### PR DESCRIPTION
<img width="2560" height="1496" alt="image" src="https://github.com/user-attachments/assets/b0fb36c8-3cf7-476a-9f73-f544fb562200" />

This pr adds a button that directly jumps to the result scene from music selector scene. For easier debugging and skin making. The loaded song/score would be the last chart player played. Things like replay and gauge data wouldn't work.

TODO: Some skins might cause immediate crash when pressing the goto button. This is because the implementation strategy is trying to mimic the normal game behavior. Demanding further tests.