### PR TITLE
In-game skin property documentation

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -158,6 +158,10 @@ dependencies {
     implementation(libs.javawebsocket)
     implementation(libs.bundles.slf4j)
 
+    // runtime-javadoc is split into an annotation processor and a library
+    annotationProcessor(libs.runtime.javadoc.scribe)
+    implementation(libs.runtime.javadoc)
+
     // non-gradle managed file dependencies. jportaudio not on maven. "custom" scares me.
     implementation(":jportaudio")
     implementation(":luaj-jse:3.0.2-custom")

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -422,6 +422,10 @@ public class MainController {
             ImGuiRenderer.init();
         }
 
+		try (var perf = PerformanceMetrics.get().Event("Skin manual init")) {
+			SkinPropertyManual.init();
+		}
+
         try (var perf = PerformanceMetrics.get().Event("System font load")) {
 			FreeTypeFontGenerator generator = new FreeTypeFontGenerator(Gdx.files.internal(config.getSystemfontpath()));
 			FreeTypeFontParameter parameter = new FreeTypeFontParameter();

--- a/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
+++ b/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
@@ -46,6 +46,7 @@ public class ImGuiRenderer {
     private static ImBoolean SHOW_SKIN_WIDGET_MANAGER = new ImBoolean(false);
     private static ImBoolean SHOW_PERFORMANCE_MONITOR = new ImBoolean(false);
     private static ImBoolean SHOW_SKIN_MENU = new ImBoolean(false);
+    private static ImBoolean SHOW_SKIN_PROPERTY_MANUAL = new ImBoolean(false);
     private static ImBoolean SHOW_MISC_SETTING = new ImBoolean(false);
 
 
@@ -123,6 +124,7 @@ public class ImGuiRenderer {
                 SHOW_PERFORMANCE_MONITOR.get()) {
                 PerformanceMonitor.reloadEventTree();
             }
+            ImGui.checkbox("Show Skin Property Manual", SHOW_SKIN_PROPERTY_MANUAL);
             ImGui.checkbox("Show Misc Setting Window", SHOW_MISC_SETTING);
 
             if (SHOW_FREQ_PLUS.get()) {
@@ -152,6 +154,9 @@ public class ImGuiRenderer {
             }
             if (SHOW_SKIN_MENU.get()) {
                 SkinMenu.show(SHOW_SKIN_MENU);
+            }
+            if (SHOW_SKIN_PROPERTY_MANUAL.get()) {
+                SkinPropertyManual.show(SHOW_SKIN_PROPERTY_MANUAL);
             }
             if (SHOW_MISC_SETTING.get()) {
                 MiscSettingMenu.show(SHOW_MISC_SETTING);

--- a/core/src/bms/player/beatoraja/modmenu/SkinPropertyManual.java
+++ b/core/src/bms/player/beatoraja/modmenu/SkinPropertyManual.java
@@ -1,0 +1,75 @@
+package bms.player.beatoraja.modmenu;
+
+import bms.player.beatoraja.skin.SkinManualEntry;
+import bms.player.beatoraja.skin.SkinProperty.PropertyType;
+import bms.player.beatoraja.skin.property.*;
+import com.github.therapi.runtimejavadoc.*;
+import imgui.ImGui;
+import imgui.flag.ImGuiCond;
+import imgui.type.ImBoolean;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static bms.player.beatoraja.modmenu.ImGuiRenderer.windowHeight;
+import static bms.player.beatoraja.modmenu.ImGuiRenderer.windowWidth;
+
+public class SkinPropertyManual {
+	private static final Map<PropertyType, List<SkinManualEntry<?>>> manualEntries = new HashMap<>();
+
+	/**
+	 * Initialize the manual entries, must be called during game startup process
+	 */
+	public static void init() {
+		manualEntries.put(
+				PropertyType.Boolean,
+				Arrays.stream(BooleanPropertyFactory.BooleanType.values())
+						.map(BooleanPropertyFactory.BooleanType::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		manualEntries.put(
+				PropertyType.Event,
+				Arrays.stream(EventFactory.EventType.values())
+						.map(EventFactory.EventType::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		manualEntries.put(
+				PropertyType.Float,
+				Arrays.stream(FloatPropertyFactory.FloatType.values())
+						.map(FloatPropertyFactory.FloatType::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		manualEntries.put(
+				PropertyType.String,
+				Arrays.stream(StringPropertyFactory.StringType.values())
+						.map(StringPropertyFactory.StringType::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+	}
+
+	public static void show(ImBoolean showSkinPropertyManual) {
+		float relativeX = windowWidth * 0.455f;
+		float relativeY = windowHeight * 0.04f;
+		ImGui.setNextWindowPos(relativeX, relativeY, ImGuiCond.FirstUseEver);
+		float textLineHeight = ImGui.getTextLineHeight();
+		ImGui.setNextWindowSizeConstraints(30f, 40f, 30 * textLineHeight, 30 * textLineHeight);
+
+		if (ImGui.begin("Skin Property Manual", showSkinPropertyManual)) {
+			for (PropertyType propertyType : PropertyType.values()) {
+				if (!manualEntries.containsKey(propertyType)) {
+					continue;
+				}
+				if (ImGui.treeNodeEx(propertyType.name())) {
+					manualEntries.get(propertyType).forEach(entry -> {
+						if (ImGui.treeNodeEx(entry.getFullName())) {
+							ImGui.textWrapped(entry.getComment());
+							ImGui.treePop();
+						}
+					});
+					ImGui.treePop();
+				}
+			}
+			ImGui.end();
+		}
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/SkinWidgetManager.java
+++ b/core/src/bms/player/beatoraja/modmenu/SkinWidgetManager.java
@@ -2,6 +2,8 @@ package bms.player.beatoraja.modmenu;
 
 import bms.player.beatoraja.skin.Skin;
 import bms.player.beatoraja.skin.SkinObject;
+import bms.player.beatoraja.skin.SkinProperty;
+import bms.player.beatoraja.skin.property.StringPropertyFactory;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Clipboard;
 import com.badlogic.gdx.math.Rectangle;

--- a/core/src/bms/player/beatoraja/skin/SkinManualEntry.java
+++ b/core/src/bms/player/beatoraja/skin/SkinManualEntry.java
@@ -1,0 +1,52 @@
+package bms.player.beatoraja.skin;
+
+import com.github.therapi.runtimejavadoc.CommentFormatter;
+import com.github.therapi.runtimejavadoc.FieldJavadoc;
+import com.github.therapi.runtimejavadoc.RuntimeJavadoc;
+
+/**
+ * Represents one skin property's manual
+ *
+ * @param <T> Skin property corresponding enums, see StringPropertyFactory.StringProperty for example
+ * @implNote getComment & getFullName are lazy functions
+ */
+public class SkinManualEntry<T extends Enum<T>> {
+    private static final CommentFormatter formatter = new CommentFormatter();
+
+    private final Enum<T> ref;
+    private final String name;
+    private final int id;
+    private String comment;
+    private String fullName;
+
+    public SkinManualEntry(Enum<T> ref, String name, int id) {
+        this.ref = ref;
+        this.name = name;
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getFullName() {
+        if (this.fullName != null) {
+            return this.fullName;
+        }
+        this.fullName = String.format("%s(%d)", this.name, this.id);
+        return this.fullName;
+    }
+
+    public String getComment() {
+        if (this.comment != null) {
+            return this.comment;
+        }
+        FieldJavadoc javadoc = RuntimeJavadoc.getJavadoc(ref);
+        this.comment = javadoc.isEmpty() ? "" : formatter.format(javadoc.getComment());
+        return this.comment;
+    }
+}

--- a/core/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/core/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -1,6 +1,14 @@
 package bms.player.beatoraja.skin;
 
 public class SkinProperty {
+    public enum PropertyType {
+        Boolean,
+        Event,
+        Float,
+        Integer,
+        String,
+        Timer
+    }
 
 	public static final int IMAGE_STAGEFILE = 100;
 	public static final int IMAGE_BACKBMP = 101;

--- a/core/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
@@ -15,6 +15,7 @@ import bms.player.beatoraja.result.CourseResult;
 import bms.player.beatoraja.result.MusicResult;
 import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.select.bar.*;
+import bms.player.beatoraja.skin.SkinManualEntry;
 import bms.player.beatoraja.skin.SkinProperty;
 import bms.player.beatoraja.song.SongData;
 
@@ -676,10 +677,14 @@ public class BooleanPropertyFactory {
 		 * StringProperty
 		 */
 		private final BooleanProperty property;
-		
+
 		private BooleanType(int id, BooleanProperty property) {
 			this.id = id;
 			this.property = property;
+		}
+
+		public SkinManualEntry<BooleanType> intoManualEntry() {
+			return new SkinManualEntry<>(this, this.name(), this.id);
 		}
 	}
 }

--- a/core/src/bms/player/beatoraja/skin/property/EventFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/EventFactory.java
@@ -11,6 +11,7 @@ import bms.player.beatoraja.result.*;
 import bms.player.beatoraja.select.BarSorter;
 import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.select.bar.*;
+import bms.player.beatoraja.skin.SkinManualEntry;
 import bms.player.beatoraja.skin.SkinProperty;
 import bms.player.beatoraja.song.SongData;
 import com.badlogic.gdx.graphics.Color;
@@ -779,7 +780,11 @@ public class EventFactory {
 			this.id = id;
 			this.event = createTwoArgEvent(action, id);
 		}
-		
+
+		public SkinManualEntry<EventType> intoManualEntry() {
+			return new SkinManualEntry<>(this, this.name(), this.id);
+		}
+
 	    private static BiConsumer<MainState, Integer> changeAutoSaveReplay(final int index) {
 	    	return (state, arg1) -> {
 	    		if(state instanceof MusicSelector selector) {

--- a/core/src/bms/player/beatoraja/skin/property/FloatPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/FloatPropertyFactory.java
@@ -12,6 +12,7 @@ import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.select.bar.Bar;
 import bms.player.beatoraja.select.bar.GradeBar;
 import bms.player.beatoraja.select.bar.SongBar;
+import bms.player.beatoraja.skin.SkinManualEntry;
 import bms.player.beatoraja.song.SongData;
 import bms.player.beatoraja.result.AbstractResult;
 
@@ -22,9 +23,6 @@ import bms.player.beatoraja.result.AbstractResult;
  */
 public class FloatPropertyFactory {
 	
-	private static RateType[] RateTypeValues = RateType.values();
-	private static FloatType[] FloatTypeValues = FloatType.values();
-
 	private static final int PG = 0;
 	private static final int GR = 1;
 	private static final int GD = 2;
@@ -37,7 +35,7 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatProperty
 	 */
 	public static FloatProperty getRateProperty(int optionid) {
-		for(RateType t : RateTypeValues) {
+		for(RateType t : RateType.values()) {
 			if(t.id == optionid) {
 				return t.property;
 			}
@@ -52,7 +50,7 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatProperty
 	 */
 	public static FloatProperty getRateProperty(String name) {
-		for(RateType t : RateTypeValues) {
+		for(RateType t : RateType.values()) {
 			if(t.name().equals(name)) {
 				return t.property;
 			}
@@ -67,7 +65,7 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatWriter
 	 */
 	public static FloatWriter getRateWriter(int id) {
-		for(RateType t : RateTypeValues) {
+		for(RateType t : RateType.values()) {
 			if(t.id == id) {
 				return t.writer;
 			}
@@ -82,7 +80,7 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatWriter
 	 */
 	public static FloatWriter getRateWriter(String name) {
-		for(RateType t : RateTypeValues) {
+		for(RateType t : RateType.values()) {
 			if(t.name().equals(name)) {
 				return t.writer;
 			}
@@ -94,16 +92,16 @@ public class FloatPropertyFactory {
 	 * FloatType IDに対応するFloatPropertyを返す
 	 * なければRateType IDに対応するFloatPropertyを返す
 	 * 
-	 * @param id property ID
+	 * @param optionid property ID
 	 * @return 対応するFloatProperty
 	 */
 	public static FloatProperty getFloatProperty(int optionid) {
-		for(FloatType t : FloatTypeValues) {
+		for(FloatType t : FloatType.values()) {
 			if(t.id == optionid) {
 				return t.property;
 			}
 		}
-		for(RateType r : RateTypeValues) {
+		for(RateType r : RateType.values()) {
 			if(r.id == optionid) {
 				return r.property;
 			}
@@ -119,12 +117,12 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatProperty
 	 */
 	public static FloatProperty getFloatProperty(String name) {
-		for(FloatType t : FloatTypeValues) {
+		for(FloatType t : FloatType.values()) {
 			if(t.name().equals(name)) {
 				return t.property;
 			}
 		}
-		for(RateType r : RateTypeValues) {
+		for(RateType r : RateType.values()) {
 			if(r.name().equals(name)) {
 				return r.property;
 			}
@@ -493,6 +491,9 @@ public class FloatPropertyFactory {
 			this.property = property;
 		}
 
+		public SkinManualEntry<FloatType> intoManualEntry() {
+			return new SkinManualEntry<>(this, this.name(), this.id);
+		}
 	}
 
 	private static FloatProperty createIRClearRateProperty(int clearType) {

--- a/core/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
@@ -14,8 +14,12 @@ import bms.player.beatoraja.result.AbstractResult;
 import bms.player.beatoraja.result.CourseResult;
 import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.select.bar.*;
+import bms.player.beatoraja.skin.SkinManualEntry;
 import bms.player.beatoraja.song.SongData;
 import com.badlogic.gdx.utils.IntMap;
+import com.github.therapi.runtimejavadoc.CommentFormatter;
+import com.github.therapi.runtimejavadoc.FieldJavadoc;
+import com.github.therapi.runtimejavadoc.RuntimeJavadoc;
 
 import java.util.*;
 
@@ -53,8 +57,10 @@ public class StringPropertyFactory {
 	}
 	
 	public enum StringType {
-		
-		rival(1, (state) -> {
+        /**
+         * In music select scene, it's the selected rival's name. Otherwise, it's based on the target score
+         */
+        rival(1, (state) -> {
 			if (state instanceof MusicSelector selector) {
 				final PlayerInformation rival = selector.getRival();
 				return rival != null ? rival.getName() : "";
@@ -63,7 +69,13 @@ public class StringPropertyFactory {
 				return rival != null ? rival.getPlayer() : "";
 			}
 		}),
+		/**
+		 * Current profile's player name
+		 */
 		player(2, (state) -> (state.resource.getPlayerConfig().getName())),
+		/**
+		 * In music select scene, it's the selected score rank target. Otherwise, it's based on the target score
+		 */
 		target(3, (state) -> {
 			if (state instanceof MusicSelector) {
 				return TargetProperty.getTargetName(state.resource.getPlayerConfig().getTargetid());					
@@ -72,6 +84,11 @@ public class StringPropertyFactory {
 				return target != null ? target.getPlayer() : "";
 			}
 		}),
+		/**
+		 * In music select scene, it's the current bar's name. In music decide and course result scene, it's the
+		 * course's title. Otherwise, it's the song's title.
+		 * When enabling rate mode, song's title has a special prefix like [1.20x] represents the current rate
+		 */
 		title(10, (state) -> {
 			if (state instanceof MusicSelector selector && selector.getSelectedBar() instanceof DirectoryBar) {
 				return selector.getSelectedBar().getTitle();
@@ -86,6 +103,9 @@ public class StringPropertyFactory {
 			}
 			return song != null ? song.getTitle() : "";
 		}),
+		/**
+		 * In music select scene, it's the current bar's sub title. Otherwise, it's the current song's sub title
+		 */
         subtitle(11, (state) -> {
 			if (state instanceof MusicSelector selector && selector.getSelectedBar() instanceof FunctionBar) {
 				return ((FunctionBar) selector.getSelectedBar()).getSubtitle();
@@ -311,7 +331,11 @@ public class StringPropertyFactory {
 		public static StringType get(int id) {
 			return ID_MAP.get(id);
 		}
-		
+
+        public SkinManualEntry<StringType> intoManualEntry() {
+            return new SkinManualEntry<>(this, this.name(), this.id);
+        }
+
 		private StringType(int id, StringProperty property) {
 			this.id = id;
 			this.property = property;
@@ -406,4 +430,17 @@ public class StringPropertyFactory {
 			};
 		}		
 	}
+
+    public static void main(String[] args) {
+        CommentFormatter formatter = new CommentFormatter();
+        FieldJavadoc javadoc = RuntimeJavadoc.getJavadoc(StringType.rival);
+        if (javadoc.isEmpty()) {
+            System.out.println("No documentation");
+            return ;
+        }
+
+        System.out.println(javadoc.getName());
+        System.out.println(formatter.format(javadoc.getComment()));
+        System.out.println();
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ ebur128java = "1.2.6-2"
 jna = "5.13.0"
 websocket = "1.6.0"
 slf4j = "2.0.17"
+runtime-javadoc = "0.13.0"
+
 junit-bom = "6.0.3"
 
 [libraries]
@@ -86,6 +88,9 @@ slf4j-jul = { group = "org.slf4j", name = "slf4j-jdk14", version.ref = "slf4j" }
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit-bom" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
+
+runtime-javadoc-scribe = { group = "com.github.therapi", name = "therapi-runtime-javadoc-scribe", version.ref = "runtime-javadoc"}
+runtime-javadoc = { group = "com.github.therapi", name = "therapi-runtime-javadoc", version.ref = "runtime-javadoc"}
 
 [bundles]
 libgdx = ["gdx-core", "gdx-backend", "gdx-freetype", "gdx-controllers-core", "gdx-controllers-desktop"]


### PR DESCRIPTION
> This pr's implementation is completed. It's lacking the documentation. So I'm calling helps for completing the skin property documentations.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a95cd094-1d6a-47f7-bc7b-f08ff8058ce7" />

This is a proposal for providing an in-game skin property documentation. As the picture shows, there's an expandable tree in game window and it shows the skin properties. If a skin property has javadoc in source code, it'll be rendered as well.

We have discussed internally about the documentation strategy. There's mainly two ideas:

- Introducing a new project that handles the documentation.
  - Pros:
    - Could be easier for contribution.
    - Can have better render strategy, like a website.
    - I18n support could be easier
  - Cons:
    - Introduces a new standalone project. So we need to put efforts in gluing two projects
    - Versions could be hard to keep the pace (i.e. if we change a skin property's behavior in ED 0.5.0, the documentation project needs to know that and mark the difference manually)
- Keeping the documentation inside same project
  - Pros:
    - Easier to keep the pace. For example, if a pr changes one skin property's behavior, we can easily check if this pr had changed the corresponding documentation or not.
    - No glue layer introduced. Implementation could be very easy.
  - Cons:
    - I18n support is almost impossible.
    - Need extra efforts to export the documentation outside.
    - Could cause many prs for changing the documentation. Put extra stress on maintaining the project
    - Hard for non-programmers to evolve. As the documentation is bound with source code

This pr picked the second way to have an easy and clean implementation for a start. If we have gathered many documentations in the future. It wouldn't be hard to migrate to the first way too.