### PR TITLE
Fix the compatibility with lr2ir-read-only

### DIFF
--- a/core/src/bms/player/beatoraja/PlayDataAccessor.java
+++ b/core/src/bms/player/beatoraja/PlayDataAccessor.java
@@ -20,7 +20,7 @@ import bms.player.beatoraja.CourseData.CourseDataConstraint;
 import bms.player.beatoraja.ScoreData.SongTrophy;
 import bms.player.beatoraja.ScoreDatabaseAccessor.ScoreDataCollector;
 import bms.player.beatoraja.ScoreLogDatabaseAccessor.ScoreLog;
-import bms.player.beatoraja.ir.LR2IRConnection;
+import bms.player.beatoraja.ir.LR2IRAccessor;
 import bms.player.beatoraja.song.SongData;
 
 import com.badlogic.gdx.utils.Json;
@@ -75,7 +75,7 @@ public final class PlayDataAccessor {
 			scorelogdb = new ScoreLogDatabaseAccessor(playerpath + File.separatorChar + player + File.separatorChar + "scorelog.db");
 			scoredatalogdb = new ScoreDataLogDatabaseAccessor(playerpath + File.separatorChar + player + File.separatorChar + "scoredatalog.db");
 			// Share scoredb to LR2IR
-			LR2IRConnection.setScoreDatabaseAccessor(scoredb);
+			LR2IRAccessor.setScoreDatabaseAccessor(scoredb);
 		} catch (ClassNotFoundException e) {
 			e.printStackTrace();
 		}

--- a/core/src/bms/player/beatoraja/ir/LR2IRAccessor.java
+++ b/core/src/bms/player/beatoraja/ir/LR2IRAccessor.java
@@ -1,10 +1,8 @@
 package bms.player.beatoraja.ir;
 
-import bms.player.beatoraja.MainController;
 import bms.player.beatoraja.ScoreData;
 import bms.player.beatoraja.ScoreDatabaseAccessor;
 import bms.player.beatoraja.modmenu.ImGuiNotify;
-import bms.player.beatoraja.skin.property.StringPropertyFactory;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -36,14 +34,14 @@ import java.util.function.ToIntFunction;
  * @implNote This class is not a real IR connection, but the original repo is. It keeps the
  * original form to make things easier
  */
-public class LR2IRConnection {
+public class LR2IRAccessor {
 	private static final String IRUrl = "http://dream-pro.info/~lavalse/LR2IR/2";
 	private static ScoreDatabaseAccessor scoreDatabaseAccessor;
 
     private static Map<String, LeaderboardEntry[]> lr2IRRankingCache = new HashMap<>();
 
 	public static void setScoreDatabaseAccessor(ScoreDatabaseAccessor scoreDatabaseAccessor) {
-		LR2IRConnection.scoreDatabaseAccessor = scoreDatabaseAccessor;
+		LR2IRAccessor.scoreDatabaseAccessor = scoreDatabaseAccessor;
 	}
 
 	private static Object convertXMLToObject(String xml, Class c) {

--- a/core/src/bms/player/beatoraja/select/bar/LeaderBoardBar.java
+++ b/core/src/bms/player/beatoraja/select/bar/LeaderBoardBar.java
@@ -6,7 +6,7 @@ import bms.player.beatoraja.ir.IRChartData;
 import bms.player.beatoraja.ir.IRResponse;
 import bms.player.beatoraja.ir.IRScoreData;
 import bms.player.beatoraja.ir.LeaderboardEntry;
-import bms.player.beatoraja.ir.LR2IRConnection;
+import bms.player.beatoraja.ir.LR2IRAccessor;
 import bms.player.beatoraja.ir.LR2GhostData;
 import bms.player.beatoraja.play.GhostBattlePlay;
 import bms.player.beatoraja.modmenu.ImGuiNotify;
@@ -55,7 +55,7 @@ public class LeaderBoardBar extends DirectoryBar {
                                                  .toArray(LeaderboardEntry[] ::new);
             return fromIRScoreData(leaderboard);
 		} else {
-			Pair<IRScoreData, LeaderboardEntry[]> scores = LR2IRConnection.getScoreData(new IRChartData(songData));
+			Pair<IRScoreData, LeaderboardEntry[]> scores = LR2IRAccessor.getScoreData(new IRChartData(songData));
 			IRScoreData localScore = scores.getKey();
 			LeaderboardEntry[] scoreData = scores.getValue();
 			if (localScore != null) {
@@ -138,7 +138,7 @@ public class LeaderBoardBar extends DirectoryBar {
                 ImGuiNotify.warning("LR2IR Ghost battle is currently only supported for 7K.");
             }
 
-            LR2GhostData ghost = LR2IRConnection.getGhostData(songData.getMd5(), entry.getLR2Id());
+            LR2GhostData ghost = LR2IRAccessor.getGhostData(songData.getMd5(), entry.getLR2Id());
             // ghost might be null in case of issues with fetching or parsing
             // the ghost data; whatever caused the error should have already
             // been reported by this point


### PR DESCRIPTION
When porting `LR2IRConnection` from [lr2ir-read-only](https://github.com/SayakaIsBaka/lr2ir-read-only), there's an unexpected coincidence: they have the exact same class path, which causes ED doesn't recognize `lr2ir-read-only.jar` as an ir service jar.