### PR TITLE
Keep game running when errors occurred while rendering a skin object

### DIFF
--- a/core/src/bms/player/beatoraja/Config.java
+++ b/core/src/bms/player/beatoraja/Config.java
@@ -214,6 +214,8 @@ public class Config implements Validatable {
 	private HashMap<String, String> obsScenes = new HashMap<>();
 	private HashMap<String, String> obsActions = new HashMap<>();
 
+	private boolean keepSilentWhenRenderFailed = false;
+
 	/**
 	 * Bank of available tables
 	 *
@@ -826,7 +828,15 @@ public class Config implements Validatable {
 		}
 	}
 
-    public boolean validate() {
+	public boolean isKeepSilentWhenRenderFailed() {
+		return keepSilentWhenRenderFailed;
+	}
+
+	public void setKeepSilentWhenRenderFailed(boolean keepSilentWhenRenderFailed) {
+		this.keepSilentWhenRenderFailed = keepSilentWhenRenderFailed;
+	}
+
+	public boolean validate() {
 		displaymode = (displaymode != null) ? displaymode : DisplayMode.WINDOW;
 		resolution = (resolution != null) ? resolution : Resolution.HD;
 

--- a/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
+++ b/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
@@ -403,6 +403,7 @@
                 <VBox prefHeight="200.0" prefWidth="100.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                     <CheckBox fx:id="usecim" mnemonicParsing="false" prefHeight="25.0" text="%CACHE_SKIN_IMAGE" />
                     <CheckBox fx:id="clipboardScreenshot" mnemonicParsing="false" prefHeight="25.0" text="%CLIPBOARD_SCREENSHOT" />
+                    <CheckBox fx:id="keepSilentWhenRenderFailed" mnemonicParsing="false" prefHeight="25.0" text="%IGNORE_SKIN_OBJECT_RENDER_ERROR" />
 
                     <Button mnemonicParsing="false" onAction="#importScoreDataFromLR2" text="%IMPORT_LR2_SCORE">
                         <VBox.margin>

--- a/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
+++ b/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
@@ -307,6 +307,9 @@ public class PlayConfigurationView implements Initializable {
 	@FXML
 	public CheckBox clipboardScreenshot;
 
+	@FXML
+	private CheckBox keepSilentWhenRenderFailed;
+
 	static void initComboBox(ComboBox<Integer> combo, final String[] values) {
 		combo.setCellFactory((param) -> new OptionListCell(values));
 		combo.setButtonCell(new OptionListCell(values));
@@ -477,6 +480,7 @@ public class PlayConfigurationView implements Initializable {
 
         usecim.setSelected(config.isCacheSkinImage());
         clipboardScreenshot.setSelected(config.isSetClipboardWhenScreenshot());
+		keepSilentWhenRenderFailed.setSelected(config.isKeepSilentWhenRenderFailed());
 
 		enableIpfs.setSelected(config.isEnableIpfs());
 		ipfsurl.setText(config.getIpfsUrl());
@@ -625,6 +629,7 @@ public class PlayConfigurationView implements Initializable {
         // jkoc_hack is integer but *.setJKOC needs boolean type
 
         config.setCacheSkinImage(usecim.isSelected());
+		config.setKeepSilentWhenRenderFailed(keepSilentWhenRenderFailed.isSelected());
 
 		config.setEnableIpfs(enableIpfs.isSelected());
 		config.setIpfsUrl(ipfsurl.getText());

--- a/core/src/bms/player/beatoraja/modmenu/SkinWidgetManager.java
+++ b/core/src/bms/player/beatoraja/modmenu/SkinWidgetManager.java
@@ -16,8 +16,10 @@ import imgui.flag.ImGuiWindowFlags;
 import imgui.type.ImBoolean;
 import imgui.type.ImFloat;
 
+import java.awt.*;
 import java.text.DecimalFormat;
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -162,7 +164,15 @@ public class SkinWidgetManager {
                 if (!isWidgetDrawingOnScreen) {
                     ImGui.pushStyleColor(ImGuiCol.Text, ImColor.rgb(128, 128, 128));
                 }
+                Exception error = widget.getError();
+                if (error != null) {
+                    ImGui.pushStyleColor(ImGuiCol.Text, ImColor.rgb(Color.RED));
+                }
                 boolean isOpen = ImGui.treeNodeEx(widget.name);
+                if (error != null) {
+                    ImGui.setItemTooltip(error.getMessage());
+                    ImGui.popStyleColor();
+                }
                 if (!isWidgetDrawingOnScreen) {
                     ImGui.popStyleColor();
                 }
@@ -422,6 +432,10 @@ public class SkinWidgetManager {
 
         public boolean isDrawingOnScreen() {
             return skinObject.draw && skinObject.visible;
+        }
+
+        public Exception getError() {
+            return skinObject.error;
         }
 
         public void toggleVisible() {

--- a/core/src/bms/player/beatoraja/skin/Skin.java
+++ b/core/src/bms/player/beatoraja/skin/Skin.java
@@ -5,6 +5,7 @@ import bms.player.beatoraja.MainState;
 import bms.player.beatoraja.Resolution;
 import bms.player.beatoraja.ShaderManager;
 import bms.player.beatoraja.SkinConfig.Offset;
+import bms.player.beatoraja.modmenu.ImGuiNotify;
 import bms.player.beatoraja.skin.SkinObject.SkinOffset;
 import bms.player.beatoraja.skin.property.BooleanProperty;
 import bms.player.beatoraja.play.BMSPlayer;
@@ -309,8 +310,18 @@ public class Skin {
 			}
 
 			for (SkinObject obj : objectarray) {
-				if (obj.draw && obj.visible) {
-					obj.draw(renderer);
+				if (obj.draw && obj.visible && obj.error == null) {
+					try {
+						obj.draw(renderer);
+					} catch (Exception e) {
+						logger.error("Error while rendering object", e);
+						if (state.main.getConfig().isKeepSilentWhenRenderFailed()) {
+							obj.error = e;
+							ImGuiNotify.error(String.format("Suppressing fatal error while rendering object: %s: %s", obj.getName(), e.getMessage()));
+						} else {
+							throw e;
+						}
+					}
 				}
 			}
 		}

--- a/core/src/bms/player/beatoraja/skin/SkinObject.java
+++ b/core/src/bms/player/beatoraja/skin/SkinObject.java
@@ -101,6 +101,7 @@ public abstract class SkinObject extends DisposableObject {
 	public boolean draw;
 	// Controlled by debugger instead of constraints defined by skin
 	public boolean visible = true;
+	public Exception error = null;
 	public Rectangle region = new Rectangle();
 	public Color color = new Color();
 	public int angle;

--- a/core/src/resources/UIResources.properties
+++ b/core/src/resources/UIResources.properties
@@ -181,3 +181,4 @@ PROGRESS_TABLE_LABEL=Loading Table Info. Please wait warmly...
 PROGRESS_TABLE_TITLE=Loading Table Info
 MARK_AS_DOWNLOAD_DIRECTORY=Set DL Directory
 MARK_AS_DOWNLOAD_DIRECTORY_HINT=Mark this directory as download directory
+IGNORE_SKIN_OBJECT_RENDER_ERROR=Keep running when errors occurred while rendering a skin object


### PR DESCRIPTION
This pr adds a new configurable option in `other` tab, which allows the game keeps running even there's an unexpected error happening from rendering some skin objects. Aiming to improve the making process of skins.

It notifies the user when error occurs:
<img width="2560" height="1496" alt="image" src="https://github.com/user-attachments/assets/2777eff7-2810-467e-88a2-e30bbb47a080" />

And can be viewed in widget menu after(highlighted as red):

<img width="2560" height="1496" alt="image" src="https://github.com/user-attachments/assets/7ffd0c64-e25c-40aa-9e07-fa725d35e12a" />
