### PR TITLE
Allow macos user launch the game without opening the javafx window first

### DIFF
--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -8,7 +8,9 @@ import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import de.damios.guacamole.gdx.log.LoggerService;
+import javafx.application.Platform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
@@ -111,7 +113,14 @@ public class MainLoader extends Application {
 
 		if (Files.exists(Config.configpath) && (bmsPath != null || auto != null)) {
 			IRConnectionManager.getAllAvailableIRConnectionName();
-			play(bmsPath, auto, true, null, null, bmsPath != null);
+			if (UIUtils.isMac) {
+				BMSPlayerMode finalAuto = auto;
+				Platform.runLater(() -> {
+					play(bmsPath, finalAuto, true, null, null, bmsPath != null);
+				});
+			} else {
+				play(bmsPath, auto, true, null, null, bmsPath != null);
+			}
 		} else {
 			launch(args);
 		}


### PR DESCRIPTION
As the title describes, there was a known bug that when trying to apply `-s` flag to skip the launcher configuration window on macos, the game would simply crash out:
```
严重: java.lang.IllegalStateException : GLFW may only be used on the main thread and that thread must be the first thread in the process. Please run the JVM with -XstartOnFirstThread. This check may be disabled with Configuration.GLFW_CHECK_THREAD0.
12月 18, 2025 3:23:15 下午 bms.player.beatoraja.MainLoader play
严重: Uncaught global exception: 
java.lang.IllegalStateException: GLFW may only be used on the main thread and that thread must be the first thread in the process. Please run the JVM with -XstartOnFirstThread. This check may be disabled with Configuration.GLFW_CHECK_THREAD0.
    at org.lwjgl.glfw.EventLoop.check(EventLoop.java:33)
    at org.lwjgl.glfw.GLFW.glfwInit(GLFW.java:1078)
    at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.initializeGlfw(Lwjgl3Application.java:89)
    at com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration.getMonitors(Lwjgl3ApplicationConfiguration.java:287)
    at bms.player.beatoraja.MainLoader.play(MainLoader.java:165)
    at bms.player.beatoraja.MainLoader.main(MainLoader.java:117)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:569)
    at javafx.graphics/com.sun.javafx.application.LauncherImpl.launchApplicationWithArgs(LauncherImpl.java:465)
    at javafx.graphics/com.sun.javafx.application.LauncherImpl.launchApplication(LauncherImpl.java:364)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:569)
    at java.base/sun.launcher.LauncherHelper$FXHelper.main(LauncherHelper.java:1099)
```

Previously, we've discovered that the root cause is `MainLoader` is a subclass of `Application` from javafx, which has some magic code that "steal" the glfw context from `main thread`(which is the first thread of the progress) to the javafx's own thread. By applying `-XstartOnFirstThread` actually fixes nothing.
Today I just remembered that the problem isn't how we bring the context back, we can force the function `play` being executed on the correct thread (i.e. javafx's thread) by using `Platform.runLater`.

TODO: I don't know if this code is working fine on other platforms (linux & windows), if they're working fine we could remove the platform specify code. 