### PR TITLE
Migrate from jbmstable-parser to kbmstable-parser

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -32,7 +32,7 @@ version = libs.versions.beatoraja.get()
 
 sourceSets {
     main {
-        java.srcDirs(listOf("src/", "dependencies/jbms-parser/", "dependencies/jbmstable-parser"))
+        java.srcDirs(listOf("src/", "dependencies/jbms-parser/"))
         resources.srcDirs(listOf("src/"))
     }
 }
@@ -158,6 +158,9 @@ dependencies {
 
     implementation(libs.javawebsocket)
     implementation(libs.bundles.slf4j)
+
+    implementation(libs.kotlin.reflect)
+    implementation(libs.kbmstableparser)
 
     // non-gradle managed file dependencies. jportaudio not on maven. "custom" scares me.
     implementation(":jportaudio")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,11 +23,13 @@ ebur128java = "1.2.6-2"
 jna = "5.13.0"
 websocket = "1.6.0"
 slf4j = "2.0.17"
+kbmstable-parser = "1.0.0"
 
 
 [libraries]
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-serialization-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 
 gdx-core = { group = "com.badlogicgames.gdx", name = "gdx", version.ref = "gdx" }
 gdx-backend = { group = "com.badlogicgames.gdx", name = "gdx-backend-lwjgl3", version.ref = "gdx" }
@@ -82,6 +84,8 @@ jna-platform = { group = "net.java.dev.jna", name = "jna-platform", version.ref 
 javawebsocket = { group = "org.java-websocket", name = "Java-WebSocket", version.ref = "websocket" }
 slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 slf4j-jul = { group = "org.slf4j", name = "slf4j-jdk14", version.ref = "slf4j" }
+
+kbmstableparser = { group = "io.github.catizard", name = "kbmstable-parser", version.ref = "kbmstable-parser" }
 
 [bundles]
 libgdx = ["gdx-core", "gdx-backend", "gdx-freetype",  "gdx-controllers-core", "gdx-controllers-desktop"]


### PR DESCRIPTION
This is a radical proposal: remove the jbmstable-parser dependency with [kbmstable-parser](https://github.com/Catizard/kbmstable-parser)

Pros:

- It has a more concise, clean code base. Old designs and some of the old fields are abandoned.
- It's slightly faster

Cons:

- I cannot make sure it can provide 100% compatibility to all existing difficult tables, see [here](https://github.com/Catizard/kbmstable-parser/blob/main/src/test/kotlin/ParserTest.kt) for what tables are tested

> How does this project been tested?
>
> It runs a "clap test": for each difficult table, comparing the parse result from kbmstable-parser and jbmstable-parser and make sure they're identical.

## Compatibility issue

There're two fields that used by ED but completed removed in kbmstable-parser: one is `mode` and one is `parentHash`. The `mode` field is indicating what this table's play mode is: 7k/9k/5k. The `parentHash` is only used in `ipfs` download feature and no documentation about it.