### PR TITLE
Migrate from jbms-parser to kbms-parser

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -31,7 +31,7 @@ version = libs.versions.beatoraja.get()
 
 sourceSets {
     main {
-        java.srcDirs(listOf("src/", "dependencies/jbms-parser/", "dependencies/jbmstable-parser"))
+        java.srcDirs(listOf("src/", "dependencies/jbmstable-parser"))
         resources.srcDirs(listOf("src/"))
     }
 }
@@ -171,6 +171,8 @@ dependencies {
 
     implementation(libs.javawebsocket)
     implementation(libs.bundles.slf4j)
+
+    implementation(libs.kbms.parser)
 
     // non-gradle managed file dependencies. jportaudio not on maven. "custom" scares me.
     implementation(":jportaudio")

--- a/core/src/bms/player/beatoraja/BMSResource.java
+++ b/core/src/bms/player/beatoraja/BMSResource.java
@@ -71,7 +71,7 @@ public class BMSResource {
 			stagefile = null;
 		}
 		try {
-			Pixmap pix = PixmapResourcePool.loadPicture(f.getParent().resolve(model.getStagefile()).toString());
+			Pixmap pix = PixmapResourcePool.loadPicture(f.getParent().resolve(model.getStageFile()).toString());
 			if(pix != null) {
 				stagefile = new TextureRegion(new Texture(pix));
 				pix.dispose();
@@ -85,7 +85,7 @@ public class BMSResource {
 			backbmp = null;
 		}
 		try {
-			Pixmap pix = PixmapResourcePool.loadPicture(f.getParent().resolve(model.getBackbmp()).toString());
+			Pixmap pix = PixmapResourcePool.loadPicture(f.getParent().resolve(model.getBackBMP()).toString());
 			if(pix != null) {
 				backbmp = new TextureRegion(new Texture(pix));
 				pix.dispose();

--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -62,7 +62,6 @@ public class MainLoader extends Application {
 	private static VersionChecker version;
 
 	public static void main(String[] args) {
-
 		if(!ALLOWS_32BIT_JAVA && !System.getProperty( "os.arch" ).contains( "64")) {
 			JOptionPane.showMessageDialog(null, "This Application needs 64bit-Java.", "Error", JOptionPane.ERROR_MESSAGE);
 			System.exit(1);

--- a/core/src/bms/player/beatoraja/PlayDataAccessor.java
+++ b/core/src/bms/player/beatoraja/PlayDataAccessor.java
@@ -12,7 +12,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import bms.model.BMSModel;
-import bms.model.TimeLine;
+import bms.model.Timeline;
 import static bms.player.beatoraja.ClearType.*;
 import static bms.player.beatoraja.CourseData.CourseDataConstraint.*;
 
@@ -151,7 +151,7 @@ public final class PlayDataAccessor {
 	 * @return スコアデータ
 	 */
 	public ScoreData readScoreData(BMSModel model, int lnmode) {
-		String hash = model.getSHA256();
+		String hash = model.getSha256();
 		boolean ln = model.containsUndefinedLongNote();
 		return readScoreData(hash, ln, lnmode);
 	}
@@ -198,7 +198,7 @@ public final class PlayDataAccessor {
 	 *            プレイ回数のみ反映する場合はfalse
 	 */
 	public void writeScoreData(ScoreData newscore, BMSModel model, int lnmode, boolean updateScore) {
-		String hash = model.getSHA256();
+		String hash = model.getSha256();
 		if (newscore == null) {
 			return;
 		}
@@ -290,7 +290,7 @@ public final class PlayDataAccessor {
 
 		// 楽曲のプレイ時間算出(秒)
 		long time = 0;
-		for (TimeLine tl : model.getAllTimeLines()) {
+		for (Timeline tl : model.getAllTimelines()) {
 			for (int i = 0; i < model.getMode().key; i++) {
 				if (tl.getNote(i) != null && tl.getNote(i).getState() != 0) {
 					time = tl.getMicroTime() / 1000000;
@@ -344,7 +344,7 @@ public final class PlayDataAccessor {
 		String[] hash = new String[models.length];
 		boolean ln = false;
 		for (int i = 0; i < models.length; i++) {
-			hash[i] = models[i].getSHA256();
+			hash[i] = models[i].getSha256();
 			ln |= models[i].containsUndefinedLongNote();
 		}
 		return readScoreData(hash, ln, lnmode, option, constraint);
@@ -368,7 +368,7 @@ public final class PlayDataAccessor {
 		int totalnotes = 0;
 		boolean ln = false;
 		for (BMSModel model : models) {
-			hash += model.getSHA256();
+			hash += model.getSha256();
 			totalnotes += model.getTotalNotes();
 			ln |= model.containsUndefinedLongNote();
 		}
@@ -494,12 +494,12 @@ public final class PlayDataAccessor {
 	}
 
 	public void deleteScoreData(BMSModel model, int lnmode) {
-		scoredb.deleteScoreData(model.getSHA256(), model.containsUndefinedLongNote() ? lnmode : 0);
+		scoredb.deleteScoreData(model.getSha256(), model.containsUndefinedLongNote() ? lnmode : 0);
 	}
 
 	public boolean existsReplayData(BMSModel model, int lnmode, int index) {
 		boolean ln = model.containsUndefinedLongNote();
-		return Files.exists(Paths.get(this.getReplayDataFilePath(model.getSHA256(), ln, lnmode, index) + ".brd"));
+		return Files.exists(Paths.get(this.getReplayDataFilePath(model.getSha256(), ln, lnmode, index) + ".brd"));
 	}
 
 	public boolean existsReplayData(String hash, boolean ln, int lnmode, int index) {
@@ -512,7 +512,7 @@ public final class PlayDataAccessor {
 		boolean ln = false;
 		for (int i = 0; i < models.length; i++) {
 			BMSModel model = models[i];
-			hash[i] = model.getSHA256();
+			hash[i] = model.getSha256();
 			ln |= model.containsUndefinedLongNote();
 		}
 		return Files.exists(Paths.get(this.getReplayDataFilePath(hash, ln, lnmode, index, constraint) + ".brd"));
@@ -589,7 +589,7 @@ public final class PlayDataAccessor {
 		String[] hashes = new String[models.length];
 		boolean ln = false;
 		for (int i = 0; i < models.length; i++) {
-			hashes[i] = models[i].getSHA256();
+			hashes[i] = models[i].getSha256();
 			ln |= models[i].containsUndefinedLongNote();
 		}
 		return this.readReplayData(hashes, ln, lnmode, index, constraint);
@@ -637,7 +637,7 @@ public final class PlayDataAccessor {
 		String[] hashes = new String[models.length];
 		boolean ln = false;
 		for (int i = 0; i < models.length; i++) {
-			hashes[i] = models[i].getSHA256();
+			hashes[i] = models[i].getSha256();
 			ln |= models[i].containsUndefinedLongNote();
 		}
 		this.wrireReplayData(rd, hashes, ln, lnmode, index, constraint);
@@ -683,7 +683,7 @@ public final class PlayDataAccessor {
 	}
 
 	private String getReplayDataFilePath(BMSModel model, int lnmode, int index) {
-		return getReplayDataFilePath(model.getSHA256(), model.containsUndefinedLongNote(), lnmode, index);
+		return getReplayDataFilePath(model.getSha256(), model.containsUndefinedLongNote(), lnmode, index);
 	}
 
 	private String getReplayDataFilePath(String hash, boolean ln, int lnmode, int index) {

--- a/core/src/bms/player/beatoraja/TableDataAccessor.java
+++ b/core/src/bms/player/beatoraja/TableDataAccessor.java
@@ -10,12 +10,13 @@ import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import bms.model.BMSDecoder;
 import bms.model.Mode;
 import bms.player.beatoraja.CourseData.TrophyData;
 import bms.player.beatoraja.song.SongData;
 import bms.table.Course.Trophy;
 import bms.table.*;
+
+import static io.github.catizard.kbms.parser.RadixHelperKt.convertHexString;
 
 /**
  * 難易度表データアクセス用クラス
@@ -135,7 +136,7 @@ public class TableDataAccessor {
 		try {
 			MessageDigest digest = MessageDigest.getInstance("SHA-256");
 			digest.update(name.getBytes());
-			return BMSDecoder.convertHexString(digest.digest());
+			return convertHexString(digest.digest());
 		} catch (NoSuchAlgorithmException e) {
 			e.printStackTrace();
 			return null;
@@ -181,7 +182,7 @@ public class TableDataAccessor {
 				td.setUrl(url);
 				td.setName(dt.getName());
 				td.setTag(dt.getTag());
-				Mode defaultMode = dt.getMode() != null ? Mode.getMode(dt.getMode()) : null;
+				Mode defaultMode = dt.getMode() != null ? Mode.valueOf(dt.getMode()) : null;
 				td.setFolder(Stream.of(dt.getLevelDescription()).map(lv -> {
 					TableData.TableFolder tde = new TableData.TableFolder();
 					tde.setName(td.getTag() + lv);
@@ -239,7 +240,7 @@ public class TableDataAccessor {
 		}
 		song.setTitle(te.getTitle());
 		song.setArtist(te.getArtist());
-		Mode mode = te.getMode() != null ? Mode.getMode(te.getMode()) : null;
+		Mode mode = te.getMode() != null ? Mode.valueOf(te.getMode()) : null;
 		song.setMode(mode != null ? mode.id : (defaultMode != null ? defaultMode.id : 0));
 		song.setUrl(te.getURL());
 		song.setIpfs(te.getIPFS());

--- a/core/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
+++ b/core/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
@@ -255,15 +255,15 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 		// BMS格納ディレクトリ
 		Path dpath = Paths.get(model.getPath()).getParent();
 
-		if (model.getVolwav() > 0 && model.getVolwav() < 100) {
-			volume = model.getVolwav() / 100f;
+		if (model.getVolWAV() > 0 && model.getVolWAV() < 100) {
+			volume = model.getVolWAV() / 100f;
 		} else {
 			volume = 1.0f;
 		}
 
 		IntMap<List<Note>> notemap = new IntMap<List<Note>>();
 		final int lanes = model.getMode().key;
-		for (TimeLine tl : model.getAllTimeLines()) {
+		for (Timeline tl : model.getAllTimelines()) {
 			for (int i = 0; i < lanes; i++) {
 				final Note n = tl.getNote(i);
 				if (n != null) {
@@ -280,7 +280,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 					addNoteList(notemap, tl.getHiddenNote(i));
 				}
 			}
-			for (Note n : tl.getBackGroundNotes()) {
+			for (Note n : tl.getBgNotes()) {
 				addNoteList(notemap, n);
 			}
 		}
@@ -313,7 +313,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 				}
 				for (Note note : waventry.getValue()) {
 					// 音切りあり・なし両方のデータが必要になるケースがある
-					if (note.getMicroStarttime() == 0 && note.getMicroDuration() == 0) {
+					if (note.getMicroStart() == 0 && note.getDuration() == 0) {
 						// 音切りなしのケース
 						wavmap[wavid] = cache.get(new AudioKey(p.toString(), note));
 						if (wavmap[wavid] == null) {
@@ -326,7 +326,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 							slicesound[note.getWav()] = new Array<SliceWav<T>>();
 						}
 						for (SliceWav<T> slice : slicesound[note.getWav()]) {
-							if (slice.starttime == note.getMicroStarttime() && slice.duration == note.getMicroDuration()) {
+							if (slice.starttime == note.getMicroStart() && slice.duration == note.getDuration()) {
 								b = false;
 								break;
 							}
@@ -383,7 +383,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 		}
 
 		for (Note note : notes) {
-			if (n.getMicroStarttime() == note.getMicroStarttime() && n.getMicroDuration() == note.getMicroDuration()) {
+			if (n.getMicroStart() == note.getMicroStart() && n.getDuration() == note.getDuration()) {
 				return;
 			}
 		}
@@ -427,8 +427,8 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 			}
 			final int channel = channel(id, pitchShift);
 			final float pitch = pitchShift != 0 ? (float)Math.pow(2.0, pitchShift / 12.0) : 1.0f;
-			final long starttime = n.getMicroStarttime();
-			final long duration = n.getMicroDuration();
+			final long starttime = n.getMicroStart();
+			final long duration = n.getDuration();
 			if (starttime == 0 && duration == 0) {
 				final T wav = (T) wavmap[id];
 				if (wav != null) {
@@ -481,8 +481,8 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 		if (id < 0) {
 			return;
 		}
-		final long starttime = n.getMicroStarttime();
-		final long duration = n.getMicroDuration();
+		final long starttime = n.getMicroStart();
+		final long duration = n.getDuration();
 		if (starttime == 0 && duration == 0) {
 			final T sound = (T) wavmap[id];
 			if (sound != null) {
@@ -519,8 +519,8 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 		if (id < 0) {
 			return;
 		}
-		final long starttime = n.getMicroStarttime();
-		final long duration = n.getMicroDuration();
+		final long starttime = n.getMicroStart();
+		final long duration = n.getDuration();
 		if (starttime == 0 && duration == 0) {
 			final T sound = (T) wavmap[id];
 			if (sound != null) {
@@ -578,8 +578,8 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 		public long playid = -1;
 
 		public SliceWav(Note note, T wav) {
-			this.starttime = note.getMicroStarttime();
-			this.duration = note.getMicroDuration();
+			this.starttime = note.getMicroStart();
+			this.duration = note.getDuration();
 			this.wav = wav;
 		}
 	}
@@ -682,8 +682,8 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 
 		public AudioKey(String path, Note n) {
 			this.path = path;
-			this.start = n.getMicroStarttime();
-			this.duration = n.getMicroDuration();
+			this.start = n.getMicroStart();
+			this.duration = n.getDuration();
 		}
 
 		public boolean equals(Object o) {

--- a/core/src/bms/player/beatoraja/audio/BMSLoudnessAnalyzer.java
+++ b/core/src/bms/player/beatoraja/audio/BMSLoudnessAnalyzer.java
@@ -113,7 +113,7 @@ public class BMSLoudnessAnalyzer {
 	private AnalysisResult analyze(BMSModel model) {
 		try {
 			// Check cache first
-			String hash = model.getSHA256();
+			String hash = model.getSha256();
 			if (hash != null && !hash.isEmpty()) {
 				Double value = readFromCache(hash);
 				if (value != null) {

--- a/core/src/bms/player/beatoraja/input/KeyInputLog.java
+++ b/core/src/bms/player/beatoraja/input/KeyInputLog.java
@@ -4,11 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import bms.model.BMSModel;
-import bms.model.LongNote;
-import bms.model.NormalNote;
-import bms.model.Note;
-import bms.model.TimeLine;
+import bms.model.*;
 import bms.player.beatoraja.Validatable;
 
 /**
@@ -74,7 +70,7 @@ public final class KeyInputLog implements Validatable {
 		int keys = model.getMode().key;
 		int[] sc = model.getMode().scratchKey;
 		Note[] ln = new Note[keys];
-		for (TimeLine tl : model.getAllTimeLines()) {
+		for (Timeline tl : model.getAllTimelines()) {
 			long i = tl.getTime();
 			for (int lane = 0; lane < keys; lane++) {
 				Note note = tl.getNote(lane);
@@ -82,7 +78,7 @@ public final class KeyInputLog implements Validatable {
 					if (note instanceof LongNote) {
 						if (((LongNote) note).isEnd()) {
 							keylog.add(new KeyInputLog(i, lane, false));
-							if (model.getLntype() != 0 && Arrays.asList(sc).contains(lane)) {
+							if (model.getLnType() != LongNoteDef.LONG_NOTE && Arrays.asList(sc).contains(lane)) {
 								// BSS処理
 								keylog.add(new KeyInputLog(i, lane + 1, true));
 							}

--- a/core/src/bms/player/beatoraja/ir/IRChartData.java
+++ b/core/src/bms/player/beatoraja/ir/IRChartData.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import bms.model.BMSModel;
+import bms.model.LongNoteDef;
 import bms.model.Mode;
 import bms.player.beatoraja.song.SongData;
 
@@ -64,8 +65,9 @@ public class IRChartData {
 	public final Mode mode;
 	/**
 	 * LN TYPE(-1: 未指定, 0: LN, 1: CN, 2: HCN)
+	 * TODO: This is very likely to break the IR system
 	 */
-	public final int lntype;
+	public final LongNoteDef lnType;
 	/**
 	 * 判定幅(bmsonのjudgerank表記)
 	 */
@@ -114,10 +116,10 @@ public class IRChartData {
 	public final Map<String, String> values = new HashMap<String, String>();
 	
 	public IRChartData(SongData song) {
-		this(song, song.getBMSModel() != null ? song.getBMSModel().getLntype() : 0);
+		this(song, song.getBMSModel() != null ? song.getBMSModel().getLnType() : LongNoteDef.LONG_NOTE);
 	}
 	
-	public IRChartData(SongData song, int lntype) {
+	public IRChartData(SongData song, LongNoteDef lnType) {
 		this.title = song.getTitle();
 		this.subtitle = song.getSubtitle();
 		this.genre = song.getGenre();
@@ -143,7 +145,7 @@ public class IRChartData {
 		this.hasMine = song.hasMineNote();
 		this.hasRandom = song.hasRandomSequence();
 		this.hasStop = song.isBpmstop();
-		this.lntype = lntype;
+		this.lnType = lnType;
 
 		if(model != null) {
 			values.putAll(model.getValues());			

--- a/core/src/bms/player/beatoraja/ir/LR2IRConnection.java
+++ b/core/src/bms/player/beatoraja/ir/LR2IRConnection.java
@@ -123,7 +123,8 @@ public class LR2IRConnection {
                 scoreData = ranking.toBeatorajaScoreData(chart);
                 lr2IRRankingCache.put(requestURL, scoreData);
             }
-			ScoreData localScore = scoreDatabaseAccessor.getScoreData(chart.sha256, chart.hasUndefinedLN ? chart.lntype : 0);
+			// TODO: ordinal is very likely to be broken here
+			ScoreData localScore = scoreDatabaseAccessor.getScoreData(chart.sha256, chart.hasUndefinedLN ? chart.lnType.ordinal() : 0);
 			if (localScore != null) {
 				// This is intentional behaivor, see IRScoreData's player definition
 				// and how we use this feature in LeaderBoardBar

--- a/core/src/bms/player/beatoraja/ir/RankingDataCache.java
+++ b/core/src/bms/player/beatoraja/ir/RankingDataCache.java
@@ -5,10 +5,11 @@ import java.security.NoSuchAlgorithmException;
 
 import com.badlogic.gdx.utils.ObjectMap;
 
-import bms.model.BMSDecoder;
 import bms.player.beatoraja.CourseData;
 import bms.player.beatoraja.CourseData.CourseDataConstraint;
 import bms.player.beatoraja.song.SongData;
+
+import static io.github.catizard.kbms.parser.RadixHelperKt.convertHexString;
 
 /**
  * IRアクセスデータのキャッシュ
@@ -96,7 +97,7 @@ public class RankingDataCache {
 		try {
 			MessageDigest md = MessageDigest.getInstance("sha-256");
 			md.update(sb.toString().getBytes());
-			return BMSDecoder.convertHexString(md.digest());
+			return convertHexString(md.digest());
 		} catch (NoSuchAlgorithmException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/core/src/bms/player/beatoraja/modmenu/MiscSettingMenu.java
+++ b/core/src/bms/player/beatoraja/modmenu/MiscSettingMenu.java
@@ -66,7 +66,7 @@ public class MiscSettingMenu {
 
             // Below settings are depending on different play mode
             if (ImGui.combo("Play Mode", PLAY_MODE_VALUE, PLAY_MODE_OPTIONS)) {
-                changePlayMode(Mode.getMode(PLAY_MODE_OPTIONS[PLAY_MODE_VALUE.get()]));
+                changePlayMode(Mode.Companion.fromHint(PLAY_MODE_OPTIONS[PLAY_MODE_VALUE.get()]));
             }
 
             if (ImGui.checkbox("Enable Lift", ENABLE_LIFT)) {

--- a/core/src/bms/player/beatoraja/pattern/AutoplayModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/AutoplayModifier.java
@@ -28,10 +28,10 @@ public class AutoplayModifier extends PatternModifier {
 	@Override
 	public void modify(BMSModel model) {
 		AssistLevel assist = AssistLevel.NONE;
-		TimeLine[] tls = model.getAllTimeLines();
+		Timeline[] tls = model.getAllTimelines();
 		boolean[] lns = new boolean[model.getMode().key];
 		for (int i = 0, pos = 0;i < tls.length;i++) {
-			final TimeLine tl = tls[i];
+			final Timeline tl = tls[i];
 			boolean remove = false;
 
 			if(margin > 0) {

--- a/core/src/bms/player/beatoraja/pattern/ExtraNoteModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/ExtraNoteModifier.java
@@ -3,7 +3,7 @@ package bms.player.beatoraja.pattern;
 import bms.model.BMSModel;
 import bms.model.LongNote;
 import bms.model.Note;
-import bms.model.TimeLine;
+import bms.model.Timeline;
 
 /**
  * BGレーンからノーツを追加する譜面オプション
@@ -36,7 +36,7 @@ public class ExtraNoteModifier extends PatternModifier {
     @Override
     public void modify(BMSModel model) {
         AssistLevel assist = AssistLevel.NONE;
-        TimeLine[] tls = model.getAllTimeLines();
+        Timeline[] tls = model.getAllTimelines();
         boolean[] lns = new boolean[model.getMode().key];
         boolean[] blank = new boolean[model.getMode().key];
         Note[] lastnote = new Note[model.getMode().key];
@@ -44,7 +44,7 @@ public class ExtraNoteModifier extends PatternModifier {
         int lastoffset = 0;
 
         for (int i = 0;i < tls.length;i++) {
-            final TimeLine tl = tls[i];
+            final Timeline tl = tls[i];
 
             for(int key = 0;key < model.getMode().key;key++) {
                 final Note note = tl.getNote(key);
@@ -55,8 +55,8 @@ public class ExtraNoteModifier extends PatternModifier {
             }
 
             for(int d = 0; d < depth;d++) {
-                if(tl.getBackGroundNotes().length > 0) {
-                    final Note note = tl.getBackGroundNotes()[0];
+                if(!tl.getBgNotes().isEmpty()) {
+                    final Note note = tl.getBgNotes().get(0);
 
                     int offset = lastoffset;
                     for(int j = 1;j < model.getMode().key;j++, offset = (offset + 1) % model.getMode().key) {
@@ -70,7 +70,7 @@ public class ExtraNoteModifier extends PatternModifier {
                         if(blank[key]) {
                             lastnote[key] = note;
                             tl.setNote(key, note);
-                            tl.removeBackGroundNote(note);
+                            tl.removeBackgroundNote(note);
                             assist = AssistLevel.ASSIST;
                             break;
                         }

--- a/core/src/bms/player/beatoraja/pattern/LaneShuffleModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/LaneShuffleModifier.java
@@ -64,9 +64,9 @@ public abstract class LaneShuffleModifier extends PatternModifier {
 		final Note[] notes = new Note[lanes];
 		final Note[] hnotes = new Note[lanes];
 		final boolean[] clone = new boolean[lanes];
-		TimeLine[] timelines = model.getAllTimeLines();
+		Timeline[] timelines = model.getAllTimelines();
 		for (int index = 0; index < timelines.length; index++) {
-			final TimeLine tl = timelines[index];
+			final Timeline tl = timelines[index];
 			if (tl.existNote() || tl.existHiddenNote()) {
 				for (int i = 0; i < lanes; i++) {
 					notes[i] = tl.getNote(i);
@@ -263,7 +263,7 @@ public abstract class LaneShuffleModifier extends PatternModifier {
 			Arrays.fill(endLnNoteTime, -1);
 
 			//3個押し以上の同時押しパターンのリストを作る
-			for (TimeLine tl : model.getAllTimeLines()) {
+			for (Timeline tl : model.getAllTimelines()) {
 				if (tl.existNote()) {
 					//LN
 					for (int i = 0; i < lanes; i++) {

--- a/core/src/bms/player/beatoraja/pattern/LongNoteModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/LongNoteModifier.java
@@ -27,7 +27,7 @@ public class LongNoteModifier extends PatternModifier {
 
 		if(mode == Mode.REMOVE) {
 			AssistLevel assist = AssistLevel.NONE;
-			for (TimeLine tl : model.getAllTimeLines()) {
+			for (Timeline tl : model.getAllTimelines()) {
 				for(int lane = 0;lane < model.getMode().key;lane++) {
 					if(tl.getNote(lane) instanceof LongNote ln && Math.random() < rate) {
 						tl.setNote(lane, ln.isEnd() ? null : new NormalNote(ln.getWav()));
@@ -41,29 +41,29 @@ public class LongNoteModifier extends PatternModifier {
 
 			AssistLevel assist = AssistLevel.NONE;
 
-			TimeLine[] tls = model.getAllTimeLines();
+			Timeline[] tls = model.getAllTimelines();
 			for (int i = 0;i < tls.length - 1;i++) {
 				for(int lane = 0;lane < model.getMode().key;lane++) {
 					if(tls[i].getNote(lane) instanceof NormalNote && !tls[i + 1].existNote(lane) && Math.random() < rate) {
-						int lntype = switch(mode) {
-							case ADD_LN -> LongNote.TYPE_LONGNOTE;
-							case ADD_CN -> LongNote.TYPE_CHARGENOTE;
-							case ADD_HCN -> LongNote.TYPE_HELLCHARGENOTE;
-							case ADD_ALL -> (int) (Math.random() * 3 + 1);
-							default -> LongNote.TYPE_UNDEFINED;
+						LongNoteDef lnType = switch(mode) {
+							case ADD_LN -> LongNoteDef.LONG_NOTE;
+							case ADD_CN -> LongNoteDef.CHARGE_NOTE;
+							case ADD_HCN -> LongNoteDef.HELL_CHARGE_NOTE;
+//							case ADD_ALL -> (int) (Math.random() * 3 + 1); // TODO: Fix this
+							default -> LongNoteDef.UNDEFINED;
 						};
 
-						if(lntype != LongNote.TYPE_LONGNOTE) {
+						if(lnType != LongNoteDef.LONG_NOTE) {
 							assist = AssistLevel.ASSIST;
 						}
 
-						LongNote lnstart = new LongNote(tls[i].getNote(lane).getWav(),tls[i].getNote(lane).getMicroStarttime(),tls[i].getNote(lane).getMicroDuration());
-						lnstart.setType(lntype);
-						LongNote lnend = new LongNote(-2);
+						LongNote lnstart = new LongNote(tls[i].getNote(lane).getWav(),tls[i].getNote(lane).getMicroStart(),tls[i].getNote(lane).getDuration());
+						lnstart.setType(lnType);
+						LongNote lnend = new LongNote(-2, lnType);
 
 						tls[i].setNote(lane, lnstart);
 						tls[i + 1].setNote(lane, lnend);
-						lnstart.setPair(lnend);
+						lnstart.connectPair(lnend);
 					}
 				}
 			}

--- a/core/src/bms/player/beatoraja/pattern/MineNoteModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/MineNoteModifier.java
@@ -22,7 +22,7 @@ public class MineNoteModifier extends PatternModifier {
 	public void modify(BMSModel model) {
 		if(mode == Mode.REMOVE) {
 			AssistLevel assist = AssistLevel.NONE;
-			for (TimeLine tl : model.getAllTimeLines()) {
+			for (Timeline tl : model.getAllTimelines()) {
 				for(int lane = 0;lane < model.getMode().key;lane++) {
 					if(tl.getNote(lane) instanceof MineNote) {
 						assist = AssistLevel.LIGHT_ASSIST;
@@ -33,12 +33,12 @@ public class MineNoteModifier extends PatternModifier {
 			}
 			setAssistLevel(assist);
 		} else {
-			TimeLine[] tls = model.getAllTimeLines();
+			Timeline[] tls = model.getAllTimelines();
 			boolean[] ln = new boolean[model.getMode().key];
 			boolean[] blank = new boolean[model.getMode().key];
 
 			for (int i = 0;i < tls.length;i++) {
-				final TimeLine tl = tls[i];
+				final Timeline tl = tls[i];
 
 				for(int key = 0;key < model.getMode().key;key++) {
 					final Note note = tl.getNote(key);

--- a/core/src/bms/player/beatoraja/pattern/ModeModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/ModeModifier.java
@@ -8,7 +8,7 @@ import bms.model.BMSModel;
 import bms.model.LongNote;
 import bms.model.Mode;
 import bms.model.Note;
-import bms.model.TimeLine;
+import bms.model.Timeline;
 import bms.player.beatoraja.PlayerConfig;
 /**
  * 譜面のレーン数を変更するクラス。
@@ -50,7 +50,7 @@ public class ModeModifier extends PatternModifier {
 		Arrays.fill(endLnNoteTime, -1);
 		if(config.getHranThresholdBPM() <= 0) hranThreshold = 0;
 		else hranThreshold = (int) (Math.ceil(15000.0f / config.getHranThresholdBPM()));
-		for (TimeLine tl : model.getAllTimeLines()) {
+		for (Timeline tl : model.getAllTimelines()) {
 			if (tl.existNote() || tl.existHiddenNote()) {
 				Note[] notes = new Note[lanes];
 				Note[] hnotes = new Note[lanes];

--- a/core/src/bms/player/beatoraja/pattern/NoteShuffleModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/NoteShuffleModifier.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import bms.model.BMSModel;
 import bms.model.Mode;
-import bms.model.TimeLine;
+import bms.model.Timeline;
 import bms.player.beatoraja.PlayerConfig;
 
 /**
@@ -32,7 +32,7 @@ public class NoteShuffleModifier extends PatternModifier {
 	public void modify(BMSModel model) {
 		randomizer.setRandomSeed(getSeed());
 		randomizer.setModifyLanes(getKeys(model.getMode(), player, isScratchLaneModify));
-		for(TimeLine tl : model.getAllTimeLines()) {
+		for(Timeline tl : model.getAllTimelines()) {
 			if (tl.existNote() || tl.existHiddenNote()) {
 				randomizer.permutate(tl);
 			}

--- a/core/src/bms/player/beatoraja/pattern/PatternModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/PatternModifier.java
@@ -47,7 +47,7 @@ public abstract class PatternModifier {
 	 *            譜面変更ログ
 	 */
 	public static void modify(BMSModel model, List<PatternModifyLog> log) {
-		for (TimeLine tl : model.getAllTimeLines()) {
+		for (Timeline tl : model.getAllTimelines()) {
 			PatternModifyLog pm = null;
 			for (PatternModifyLog pms : log) {
 				if (pms.section == tl.getSection()) {
@@ -144,16 +144,16 @@ public abstract class PatternModifier {
 		return IntStream.range(startkey, startkey + mode.key / mode.player).filter(i -> containsScratch || !mode.isScratchKey(i)).toArray();
 	}
 
-	protected static void moveToBackground(TimeLine[] tls, TimeLine tl, int lane) {
+	protected static void moveToBackground(Timeline[] tls, Timeline tl, int lane) {
 		Note n = tl.getNote(lane);
 		if(n == null) {
 			return;
 		}
 		if(n instanceof LongNote) {
 			LongNote pln = ((LongNote) tl.getNote(lane)).getPair();
-			for(TimeLine tl2 : tls) {
+			for(Timeline tl2 : tls) {
 				if(tl2.getNote(lane) == pln) {
-					tl2.addBackGroundNote(pln);
+					tl2.addBackgroundNote(pln);
 					tl2.setNote(lane, null);
 					break;
 				}
@@ -161,7 +161,7 @@ public abstract class PatternModifier {
 		}
 
 		if(!(n instanceof MineNote)) {
-			tl.addBackGroundNote(tl.getNote(lane));
+			tl.addBackgroundNote(tl.getNote(lane));
 		}
 		tl.setNote(lane, null);
 

--- a/core/src/bms/player/beatoraja/pattern/PracticeModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/PracticeModifier.java
@@ -28,8 +28,8 @@ public class PracticeModifier extends PatternModifier {
 	@Override
 	public void modify(BMSModel model) {
 		int totalnotes = model.getTotalNotes();
-		final TimeLine[] tls = model.getAllTimeLines();
-		for (TimeLine tl : tls) {
+		final Timeline[] tls = model.getAllTimelines();
+		for (Timeline tl : tls) {
 			for (int i = 0; i < model.getMode().key; i++) {
 				if(tl.getTime() < start || tl.getTime() >= end) {
 					moveToBackground(tls, tl, i);

--- a/core/src/bms/player/beatoraja/pattern/Randomizer.java
+++ b/core/src/bms/player/beatoraja/pattern/Randomizer.java
@@ -49,7 +49,7 @@ public abstract class Randomizer {
 	 * [1->3]なら3バスになるということ。
 	 * Listは変更してもよい。TimeLineは変更してはならない。
 	 */
-	abstract Map<Integer, Integer> randomize(TimeLine tl, List<Integer> changeableLane, List<Integer> assignableLane);
+	abstract Map<Integer, Integer> randomize(Timeline tl, List<Integer> changeableLane, List<Integer> assignableLane);
 	/**
 	 * 譜面変更のアシストレベル
 	 */
@@ -58,7 +58,7 @@ public abstract class Randomizer {
 	/**
 	 * TimeLineのノーツをrandomizeで定義された方法で入れ替える
 	 */
-	public int[] permutate(TimeLine tl) {
+	public int[] permutate(Timeline tl) {
 		Map<Integer, Integer> permutationMap = randomize(tl, new ArrayList<>(changeableLane),
 				new ArrayList<>(assignableLane));
 
@@ -195,7 +195,7 @@ abstract class TimeBasedRandomizer extends Randomizer {
 	/**
 	 * threshold[ms]以下の連打ができるだけ発生しないようにレーンを入れ替える
 	 */
-	protected Map<Integer, Integer> timeBasedShuffle(TimeLine tl, List<Integer> changeableLane,
+	protected Map<Integer, Integer> timeBasedShuffle(Timeline tl, List<Integer> changeableLane,
 			List<Integer> assignableLane) {
 		Map<Integer, Integer> randomMap = new HashMap<>();
 		List<Integer> noteLane, emptyLane, primaryLane, inferiorLane;
@@ -248,7 +248,7 @@ abstract class TimeBasedRandomizer extends Randomizer {
 		return randomMap;
 	}
 
-	protected void updateNoteTime(TimeLine tl, Map<Integer, Integer> randomMap) {
+	protected void updateNoteTime(Timeline tl, Map<Integer, Integer> randomMap) {
 		for (Map.Entry<Integer, Integer> el : randomMap.entrySet()) {
 			if (tl.getNote(el.getKey()) != null && !(tl.getNote(el.getKey()) instanceof MineNote)) {
 				lastNoteTime.put(el.getValue(), tl.getTime());
@@ -277,7 +277,7 @@ class SRandomizer extends TimeBasedRandomizer {
 	}
 
 	@Override
-	Map<Integer, Integer> randomize(TimeLine tl, List<Integer> changeableLane, List<Integer> assignableLane) {
+	Map<Integer, Integer> randomize(Timeline tl, List<Integer> changeableLane, List<Integer> assignableLane) {
 		Map<Integer, Integer> randomMap = timeBasedShuffle(tl, changeableLane, assignableLane);
 
 		updateNoteTime(tl, randomMap);
@@ -316,7 +316,7 @@ class SpiralRandomizer extends Randomizer {
 	// modifiLaneから直接Mapを生成する
 	// LNアクティブの時はheadを変化させない
 	@Override
-	Map<Integer, Integer> randomize(TimeLine tl, List<Integer> changeableLane, List<Integer> assignableLane) {
+	Map<Integer, Integer> randomize(Timeline tl, List<Integer> changeableLane, List<Integer> assignableLane) {
 		Map<Integer, Integer> rotateMap = new HashMap<>();
 		if (changeableLane.size() == cycle) {
 			head = (head + increment) % cycle;
@@ -375,7 +375,7 @@ class AllScratchRandomizer extends TimeBasedRandomizer {
 	}
 
 	@Override
-	Map<Integer, Integer> randomize(TimeLine tl, List<Integer> changeableLane, List<Integer> assignableLane) {
+	Map<Integer, Integer> randomize(Timeline tl, List<Integer> changeableLane, List<Integer> assignableLane) {
 		Map<Integer, Integer> randomMap = new HashMap<>();
 
 		// スクラッチレーンにアサインできれば先にアサインする
@@ -468,7 +468,7 @@ class NoMurioshiRandomizer extends TimeBasedRandomizer {
 	}
 
 	@Override
-	Map<Integer, Integer> randomize(TimeLine tl, List<Integer> changeableLane, List<Integer> assignableLane) {
+	Map<Integer, Integer> randomize(Timeline tl, List<Integer> changeableLane, List<Integer> assignableLane) {
 		int noteCount = noteCount(tl);
 		Map<Integer, Integer> randomMap;
 		// タイムラインのノーツ(LNアクティブを含む)が2個以下or7個以上のとき無理押しを考慮しない
@@ -539,12 +539,12 @@ class NoMurioshiRandomizer extends TimeBasedRandomizer {
 	}
 
 	// LNアクティブも含めたタイムラインのノート数
-	private int noteCount(TimeLine tl) {
+	private int noteCount(Timeline tl) {
 		return getNoteExistLane(tl).size() + getLNLane().size();
 	}
 
 	// タイムラインにノーツが存在するレーンのリスト
-	private List<Integer> getNoteExistLane(TimeLine tl) {
+	private List<Integer> getNoteExistLane(Timeline tl) {
 		List<Integer> l = new ArrayList<>();
 		for (int i = 0; i < modifyLanes.length; i++) {
 			// nullでない、地雷ノートでない
@@ -583,7 +583,7 @@ class ConvergeRandomizer extends TimeBasedRandomizer {
 	}
 
 	@Override
-	Map<Integer, Integer> randomize(TimeLine tl, List<Integer> changeableLane, List<Integer> assignableLane) {
+	Map<Integer, Integer> randomize(Timeline tl, List<Integer> changeableLane, List<Integer> assignableLane) {
 		// 連打とならないレーンは連打カウントをリセットする
 		rendaCount.entrySet().stream().forEach(e -> {
 			if (tl.getTime() - lastNoteTime.get(e.getKey()) > threshold2) {

--- a/core/src/bms/player/beatoraja/pattern/ScrollSpeedModifier.java
+++ b/core/src/bms/player/beatoraja/pattern/ScrollSpeedModifier.java
@@ -1,7 +1,7 @@
 package bms.player.beatoraja.pattern;
 
 import bms.model.BMSModel;
-import bms.model.TimeLine;
+import bms.model.Timeline;
 import bms.player.beatoraja.PlayerConfig;
 
 /**
@@ -37,24 +37,24 @@ public class ScrollSpeedModifier extends PatternModifier {
         if(mode == Mode.REMOVE) {
             // スクロールスピード変更、ストップシーケンス無効化
             AssistLevel assist = AssistLevel.NONE;
-            TimeLine starttl = model.getAllTimeLines()[0];
+            Timeline starttl = model.getAllTimelines()[0];
 
-            for (TimeLine tl : model.getAllTimeLines()) {
-                if(tl.getBPM() != starttl.getBPM() || tl.getScroll() != starttl.getScroll() || tl.getStop() != 0) {
+            for (Timeline tl : model.getAllTimelines()) {
+                if(tl.getBpm() != starttl.getBpm() || tl.getScroll() != starttl.getScroll() || tl.getStop() != 0) {
                     assist = AssistLevel.LIGHT_ASSIST;
                 }
-                tl.setSection(starttl.getBPM() * tl.getMicroTime() / 240000000);
-                tl.setStop(0);
-                tl.setBPM(starttl.getBPM());
+                tl.setSection(starttl.getBpm() * tl.getMicroTime() / 240000000);
+                tl.setMicroStop(0);
+                tl.setBpm(starttl.getBpm());
                 tl.setScroll(starttl.getScroll());
             }
             setAssistLevel(assist);
         } else {
-            final double base = model.getAllTimeLines()[0].getScroll();
+            final double base = model.getAllTimelines()[0].getScroll();
             double current = base;
             int sectioncount = 0;
-            for (TimeLine tl : model.getAllTimeLines()) {
-                if(tl.getSectionLine()) {
+            for (Timeline tl : model.getAllTimelines()) {
+                if(tl.getHasSectionLine()) {
                 	sectioncount++;
                 	if(section == sectioncount) {
                         current = base * (1.0 + Math.random() * rate * 2 - rate);

--- a/core/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -167,7 +167,7 @@ public class BMSPlayer extends MainState {
 				} else {
 					// 2曲目以降の処理
 					for (int i = 0; i < resource.getCourseBMSModels().length; i++) {
-						if (resource.getCourseBMSModels()[i].getMD5().equals(resource.getBMSModel().getMD5())) {
+						if (resource.getCourseBMSModels()[i].getMd5().equals(resource.getBMSModel().getMd5())) {
 							replay = resource.getCourseReplay()[i];
 						}
 					}
@@ -218,7 +218,7 @@ public class BMSPlayer extends MainState {
 		boolean forceNoIRSend = false;
 
 		// Allow osu score submission
-		if (model.isFromOSU()) {
+		if (model.getFromOSU()) {
 			forceNoIRSend = false;
 		}
 
@@ -284,14 +284,14 @@ public class BMSPlayer extends MainState {
 				// This could work since beatoraja would firstly convert the judge rank that is not defined as
 				// the window rate to it and directly mark the model as BMSON type (see BMSPlayerRule::validate)
 				int overridingJudgeWindowRate = JudgeTrainer.getJudgeWindowRate(model.getMode());
-				int originalJudgeWindowRate = model.getJudgerank();
+				int originalJudgeWindowRate = model.getJudgeRank();
 				logger.info("Overriding original judge window from {} to {}", originalJudgeWindowRate, overridingJudgeWindowRate);
 				if (originalJudgeWindowRate < overridingJudgeWindowRate) {
 					// Like expand judge treatment above if the original judge window is stricter than customized one
 					assist = Math.max(assist, 2);
 					score = false;
 				}
-				model.setJudgerank(overridingJudgeWindowRate);
+				model.setJudgeRank(overridingJudgeWindowRate);
 			}
 
 			// Constant considered as assist in Endless Dream
@@ -709,7 +709,7 @@ public class BMSPlayer extends MainState {
                     pm.modify(model);
 
 					gauge = practice.getGauge(model);
-					model.setJudgerank(property.judgerank);
+					model.setJudgeRank(property.judgerank);
 					lanerender.init(model);
 					judge.init(model, resource);
 					skin.pomyu.init();
@@ -1031,7 +1031,7 @@ public class BMSPlayer extends MainState {
 		// リプレイデータ保存。スコア保存されない場合はリプレイ保存しない
 		final ReplayData replay = resource.getReplayData();
 		replay.player = main.getPlayerConfig().getName();
-		replay.sha256 = model.getSHA256();
+		replay.sha256 = model.getSha256();
 		replay.mode = config.getLnmode();
 		replay.date = Calendar.getInstance().getTimeInMillis() / 1000;
 		replay.keylog = main.getInputProcessor().getKeyInputLog();
@@ -1055,12 +1055,12 @@ public class BMSPlayer extends MainState {
 		long stddev = 0;
 		ArrayList<Long> playTimes = new ArrayList<Long>();
 		final int lanes = model.getMode().key;
-		for (TimeLine tl : model.getAllTimeLines()) {
+		for (Timeline tl : model.getAllTimelines()) {
 			for (int i = 0; i < lanes; i++) {
 				Note n = tl.getNote(i);
 				if (n != null && (n instanceof NormalNote || (n instanceof LongNote ln &&
-						!(((model.getLntype() == BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-								|| ln.getType() == LongNote.TYPE_LONGNOTE)
+						!(((model.getLnType() == LongNoteDef.LONG_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+								|| ln.getType() == LongNoteDef.LONG_NOTE)
 								&& ((LongNote) n).isEnd())))) {
 					int state = n.getState();
 					long time = n.getMicroPlayTime();

--- a/core/src/bms/player/beatoraja/play/BMSPlayerRule.java
+++ b/core/src/bms/player/beatoraja/play/BMSPlayerRule.java
@@ -1,7 +1,9 @@
 package bms.player.beatoraja.play;
 
 import bms.model.BMSModel;
+import bms.model.JudgeRankType;
 import bms.model.Mode;
+import bms.model.TotalType;
 
 /**
  * プレイヤールール
@@ -56,19 +58,19 @@ public enum BMSPlayerRule {
     
     public static void validate(BMSModel model) {
     	BMSPlayerRule rule = getBMSPlayerRule(model.getMode());
-    	final int judgerank = model.getJudgerank();
-    	switch(model.getJudgerankType()) {
+    	final int judgerank = model.getJudgeRank();
+    	switch(model.getJudgeRankType()) {
     	case BMS_RANK:
-			model.setJudgerank(judgerank >= 0 && model.getJudgerank() < 5 ? rule.judge.windowrule.judgerank[judgerank] : rule.judge.windowrule.judgerank[2]);
+			model.setJudgeRank(judgerank >= 0 && model.getJudgeRank() < 5 ? rule.judge.windowrule.judgerank[judgerank] : rule.judge.windowrule.judgerank[2]);
     		break;
     	case BMS_DEFEXRANK:
-			model.setJudgerank(judgerank > 0 ? judgerank * rule.judge.windowrule.judgerank[2] / 100 : rule.judge.windowrule.judgerank[2]);
+			model.setJudgeRank(judgerank > 0 ? judgerank * rule.judge.windowrule.judgerank[2] / 100 : rule.judge.windowrule.judgerank[2]);
     		break;
     	case BMSON_JUDGERANK:
-			model.setJudgerank(judgerank > 0 ? judgerank : 100);
+			model.setJudgeRank(judgerank > 0 ? judgerank : 100);
     		break;
     	}
-    	model.setJudgerankType(BMSModel.JudgeRankType.BMSON_JUDGERANK);
+    	model.setJudgeRankType(JudgeRankType.BMSON_JUDGERANK);
 		
     	switch(model.getTotalType()) {
     	case BMS:
@@ -82,7 +84,7 @@ public enum BMSPlayerRule {
 			model.setTotal(model.getTotal() > 0 ? model.getTotal() / 100.0 * total : total);
     		break;
     	}
-    	model.setTotalType(BMSModel.TotalType.BMS);
+    	model.setTotalType(TotalType.BMS);
     }
     
 	private static double calculateDefaultTotal(Mode mode, int totalnotes) {

--- a/core/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/core/src/bms/player/beatoraja/play/JudgeManager.java
@@ -29,7 +29,7 @@ public class JudgeManager {
     /**
      * LN type
      */
-    private int lntype;
+    private LongNoteDef lntype;
 
     /**
      * 現在の判定カウント内訳
@@ -145,13 +145,13 @@ public class JudgeManager {
         mjudgefast = new long[judgeregion];
         score = new ScoreData(orgmode);
         score.setNotes(model.getTotalNotes());
-        score.setSha256(model.getSHA256());
+        score.setSha256(model.getSha256());
         ghost = new int[model.getTotalNotes()];
         for (int i=0; i<ghost.length; i++) {
             ghost[i] = 4;
         }
 
-        this.lntype = model.getLntype();
+        this.lntype = model.getLnType();
         Lane[] lanes = model.getLanes();
 
         algorithm = JudgeAlgorithm.valueOf(resource.getPlayerConfig().getPlayConfig(orgmode).getPlayconfig().getJudgetype());
@@ -175,7 +175,7 @@ public class JudgeManager {
             auto_presstime[key] = Long.MIN_VALUE;
         }
 
-        final int judgerank = model.getJudgerank();
+        final int judgerank = model.getJudgeRank();
         final PlayerConfig config = resource.getPlayerConfig();
         final int[] keyJudgeWindowRate = config.isCustomJudge()
                 ? new int[]{config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood()}
@@ -254,8 +254,8 @@ public class JudgeManager {
                 if (note instanceof LongNote) {
                     // HCN判定
                     final LongNote lnote = (LongNote) note;
-                    if ((lnote.getType() == LongNote.TYPE_UNDEFINED && lntype == BMSModel.LNTYPE_HELLCHARGENOTE)
-                            || lnote.getType() == LongNote.TYPE_HELLCHARGENOTE) {
+                    if ((lnote.getType() == LongNoteDef.UNDEFINED && lntype == LongNoteDef.HELL_CHARGE_NOTE)
+                            || lnote.getType() == LongNoteDef.HELL_CHARGE_NOTE) {
                         if (lnote.isEnd()) {
                             state.passing = null;
                             state.mpassingcount = 0;
@@ -283,8 +283,8 @@ public class JudgeManager {
                         if (!ln.isEnd() && ln.getState() == 0 && state.processing == null) {
                             auto_presstime[state.laneassign[0]] = now;
                             keysound.play(note, getKeyVolume(), 0);
-                            if ((lntype == BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-                                    || ln.getType() == LongNote.TYPE_LONGNOTE) {
+                            if ((lntype == LongNoteDef.LONG_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+                                    || ln.getType() == LongNoteDef.LONG_NOTE) {
                                 state.mpassingcount = 0;
                                 //LN時のレーザー色変更処理
                                 this.judge[state.player][state.offset] = 8;
@@ -294,9 +294,9 @@ public class JudgeManager {
                             state.processing = ln.getPair();
                         }
                         if (ln.isEnd() && ln.getState() == 0) {
-                            if ((lntype != BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-                                    || ln.getType() == LongNote.TYPE_CHARGENOTE
-                                    || ln.getType() == LongNote.TYPE_HELLCHARGENOTE) {
+                            if ((lntype != LongNoteDef.LONG_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+                                    || ln.getType() == LongNoteDef.CHARGE_NOTE
+                                    || ln.getType() == LongNoteDef.HELL_CHARGE_NOTE) {
                                 if (state.sckey >= 0 && state.laneassign.length >= 2) {
                                     auto_presstime[state.laneassign[0]] = Long.MIN_VALUE;
                                     auto_presstime[state.laneassign[1]] = now;
@@ -377,9 +377,9 @@ public class JudgeManager {
             if (input.getKeyState(key)) {
                 // キーが押されたときの処理
                 if (state.processing != null) {
-                    if (((lntype != BMSModel.LNTYPE_LONGNOTE && state.processing.getType() == LongNote.TYPE_UNDEFINED)
-                            || state.processing.getType() == LongNote.TYPE_CHARGENOTE
-                            || state.processing.getType() == LongNote.TYPE_HELLCHARGENOTE)) {
+                    if (((lntype != LongNoteDef.LONG_NOTE && state.processing.getType() == LongNoteDef.UNDEFINED)
+                            || state.processing.getType() == LongNoteDef.CHARGE_NOTE
+                            || state.processing.getType() == LongNoteDef.HELL_CHARGE_NOTE)) {
                         if(sc >= 0 && key != sckey[sc]) {
                             // BSS終端処理
                             final long[][] mjudge = scnendmjudge;
@@ -467,8 +467,8 @@ public class JudgeManager {
                             final LongNote ln = (LongNote) tnote;
                             final long dmtime = tnote.getMicroTime() - pmtime;
                             keysound.play(tnote, getKeyVolume(), 0);
-                            if ((lntype == BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-                                    || ln.getType() == LongNote.TYPE_LONGNOTE) {
+                            if ((lntype == LongNoteDef.LONG_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+                                    || ln.getType() == LongNoteDef.LONG_NOTE) {
                                 // LN処理
                                 if(judgeVanish[judge]) {
                                     state.lnstartJudge = judge;
@@ -541,10 +541,10 @@ public class JudgeManager {
                     for (; judge < mjudge.length && !(dmtime >= mjudge[judge][0] && dmtime <= mjudge[judge][1]); judge++)
                         ;
 
-                    if ((lntype != BMSModel.LNTYPE_LONGNOTE
-                            && state.processing.getType() == LongNote.TYPE_UNDEFINED)
-                            || state.processing.getType() == LongNote.TYPE_CHARGENOTE
-                            || state.processing.getType() == LongNote.TYPE_HELLCHARGENOTE) {
+                    if ((lntype != LongNoteDef.LONG_NOTE
+                            && state.processing.getType() == LongNoteDef.UNDEFINED)
+                            || state.processing.getType() == LongNoteDef.CHARGE_NOTE
+                            || state.processing.getType() == LongNoteDef.HELL_CHARGE_NOTE) {
                         // CN, HCN離し処理
                         boolean release = true;
                         if (sc >= 0) {
@@ -607,8 +607,8 @@ public class JudgeManager {
 
             // LN終端判定
             if (state.processing != null) {
-                if((lntype == BMSModel.LNTYPE_LONGNOTE && state.processing.getType() == LongNote.TYPE_UNDEFINED)
-                    || state.processing.getType() == LongNote.TYPE_LONGNOTE) {
+                if((lntype == LongNoteDef.LONG_NOTE && state.processing.getType() == LongNoteDef.UNDEFINED)
+                    || state.processing.getType() == LongNoteDef.LONG_NOTE) {
                     if(state.releasetime != Long.MIN_VALUE && state.releasetime + releasemargin <= mtime) {
                         keysound.setVolume(state.processing.getPair(), 0.0f);
                         this.updateMicro(state, state.processing.getPair(), mtime, state.lnendJudge, state.processing.getMicroTime() - state.releasetime, true);
@@ -646,22 +646,22 @@ public class JudgeManager {
                 } else if (note instanceof LongNote) {
                     final LongNote ln = (LongNote) note;
                     if (!ln.isEnd() && ln.getState() == 0) {
-                        if ((lntype != BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-                                || ln.getType() == LongNote.TYPE_CHARGENOTE
-                                || ln.getType() == LongNote.TYPE_HELLCHARGENOTE) {
+                        if ((lntype != LongNoteDef.LONG_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+                                || ln.getType() == LongNoteDef.CHARGE_NOTE
+                                || ln.getType() == LongNoteDef.HELL_CHARGE_NOTE) {
                             // System.out.println("CN start poor");
                             this.updateMicro(state, note, mtime, 4, mjud, true);
                             this.updateMicro(state, ((LongNote) note).getPair(), mtime, 4, mjud, true);
                         }
-                        if (((lntype == BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-                                || ln.getType() == LongNote.TYPE_LONGNOTE) && state.processing != ln.getPair()) {
+                        if (((lntype == LongNoteDef.LONG_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+                                || ln.getType() == LongNoteDef.LONG_NOTE) && state.processing != ln.getPair()) {
                             // System.out.println("LN start poor");
                             this.updateMicro(state, note, mtime, 4, mjud, true);
                         }
 
                     }
-                    if (((lntype != BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-                            || ln.getType() == LongNote.TYPE_CHARGENOTE || ln.getType() == LongNote.TYPE_HELLCHARGENOTE)
+                    if (((lntype != LongNoteDef.LONG_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+                            || ln.getType() == LongNoteDef.CHARGE_NOTE || ln.getType() == LongNoteDef.HELL_CHARGE_NOTE)
                             && ((LongNote) note).isEnd() && ((LongNote) note).getState() == 0) {
                         // System.out.println("CN end poor");
                         this.updateMicro(state, ((LongNote) note), mtime, 4, mjud, true);

--- a/core/src/bms/player/beatoraja/play/KeyInputProccessor.java
+++ b/core/src/bms/player/beatoraja/play/KeyInputProccessor.java
@@ -2,6 +2,7 @@ package bms.player.beatoraja.play;
 
 import static bms.player.beatoraja.skin.SkinProperty.*;
 
+import bms.model.Timeline;
 import bms.player.beatoraja.modmenu.RandomTrainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import com.badlogic.gdx.math.MathUtils;
 
 import bms.model.BMSModel;
-import bms.model.TimeLine;
 import bms.player.beatoraja.BMSPlayerMode;
 import bms.player.beatoraja.MainController;
 import bms.player.beatoraja.input.BMSPlayerInputProcessor;
@@ -50,7 +50,7 @@ class KeyInputProccessor {
 	}
 
 	public void startJudge(BMSModel model, KeyInputLog[] keylog, long milliMarginTime) {
-		judge = new JudgeThread(model.getAllTimeLines(), keylog, milliMarginTime);
+		judge = new JudgeThread(model.getAllTimelines(), keylog, milliMarginTime);
 		judge.start();
 		isJudgeStarted = true;
 	}
@@ -170,7 +170,7 @@ class KeyInputProccessor {
 
 		// TODO 判定処理スレッドはJudgeManagerに渡した方がいいかも
 
-		private final TimeLine[] timelines;
+		private final Timeline[] timelines;
 		private boolean stop = false;
 		/**
 		 * 自動入力するキー入力ログ
@@ -178,7 +178,7 @@ class KeyInputProccessor {
 		private final KeyInputLog[] keylog;
 		private final long microMarginTime;
 
-		public JudgeThread(TimeLine[] timelines, KeyInputLog[] keylog, long milliMarginTime) {
+		public JudgeThread(Timeline[] timelines, KeyInputLog[] keylog, long milliMarginTime) {
 			this.timelines = timelines;
 			this.keylog = keylog;
 			this.microMarginTime = milliMarginTime * 1000;

--- a/core/src/bms/player/beatoraja/play/KeySoundProcessor.java
+++ b/core/src/bms/player/beatoraja/play/KeySoundProcessor.java
@@ -1,14 +1,12 @@
 package bms.player.beatoraja.play;
 
-import static bms.model.DecodeLog.State.WARNING;
 import static bms.player.beatoraja.skin.SkinProperty.TIMER_PLAY;
 
-import bms.model.DecodeLog;
 import com.badlogic.gdx.utils.Array;
 
 import bms.model.BMSModel;
 import bms.model.Note;
-import bms.model.TimeLine;
+import bms.model.Timeline;
 import bms.player.beatoraja.Config;
 import bms.player.beatoraja.audio.AudioDriver;
 
@@ -56,17 +54,17 @@ public class KeySoundProcessor {
 		private boolean stop = false;
 
 		private final long starttime;
-		final TimeLine[] timelines;
+		final Timeline[] timelines;
 
 		public AutoplayThread(BMSModel model, long starttime) {
 			this.starttime = starttime;
-			Array<TimeLine> tls = new Array<TimeLine>();
-			for(TimeLine tl : model.getAllTimeLines()) {
-				if(tl.getBackGroundNotes().length > 0) {
+			Array<Timeline> tls = new Array<Timeline>();
+			for(Timeline tl : model.getAllTimelines()) {
+				if(!tl.getBgNotes().isEmpty()) {
 					tls.add(tl);
 				}
 			}
-			timelines = tls.toArray(TimeLine.class);
+			timelines = tls.toArray(Timeline.class);
 		}
 
 		@Override
@@ -86,7 +84,7 @@ public class KeySoundProcessor {
 				}
 				// BGレーン再生
 				while (p < timelines.length && timelines[p].getMicroTime() <= time) {
-					for (Note n : timelines[p].getBackGroundNotes()) {
+					for (Note n : timelines[p].getBgNotes()) {
 						audio.play(n, volume, 0);
 					}
 					p++;

--- a/core/src/bms/player/beatoraja/play/LaneRenderer.java
+++ b/core/src/bms/player/beatoraja/play/LaneRenderer.java
@@ -37,7 +37,7 @@ public class LaneRenderer {
 	private float hispeedmargin = 0.25f;
 
 	private BMSModel model;
-	private TimeLine[] timelines;
+	private Timeline[] timelines;
 
 	private int pos;
 
@@ -101,32 +101,32 @@ public class LaneRenderer {
 	public void init(BMSModel model) {
 		pos = 0;
 		this.model = model;
-		List<TimeLine> tls = new ArrayList<TimeLine>();
+		List<Timeline> tls = new ArrayList<Timeline>();
 		double cbpm = model.getBpm();
 		double cscr = 1.0;
-		for (TimeLine tl : model.getAllTimeLines()) {
-			if (cbpm != tl.getBPM() || tl.getStop() > 0 || cscr != tl.getScroll() || tl.getSectionLine()) {
+		for (Timeline tl : model.getAllTimelines()) {
+			if (cbpm != tl.getBpm() || tl.getStop() > 0 || cscr != tl.getScroll() || tl.getHasSectionLine()) {
 				tls.add(tl);
 			} else if (tl.existNote() || tl.existHiddenNote()) {
 				tls.add(tl);
 			}
-			cbpm = tl.getBPM();
+			cbpm = tl.getBpm();
 			cscr = tl.getScroll();
 		}
-		this.timelines = tls.toArray(new TimeLine[tls.size()]);
-		// logger.info("省略したTimeLine数:" +
-		// (model.getAllTimeLines().length - timelines.length) + " / " +
-		// model.getAllTimeLines().length);
+		this.timelines = tls.toArray(new Timeline[tls.size()]);
+		// logger.info("省略したTimeline数:" +
+		// (model.getAlltimelines().length - timelines.length) + " / " +
+		// model.getAlltimelines().length);
 
 		minbpm = model.getMinBPM();
 		maxbpm = model.getMaxBPM();
 		Map<Double, Integer> m = new HashMap<Double, Integer>();
-		for (TimeLine tl : model.getAllTimeLines()) {
-			Integer count = m.get(tl.getBPM());
+		for (Timeline tl : model.getAllTimelines()) {
+			Integer count = m.get(tl.getBpm());
 			if (count == null) {
 				count = 0;
 			}
-			m.put(tl.getBPM(), count + tl.getTotalNotes());
+			m.put(tl.getBpm(), count + tl.getTotalNotes());
 		}
 		int maxcount = 0;
 		for (double bpm : m.keySet()) {
@@ -192,9 +192,9 @@ public class LaneRenderer {
 		return playconfig.getLanecover();
 	}
 
-	public void resetHispeed(double targetbpm) {
+	public void resetHispeed(double targetBpm) {
 		if (playconfig.getFixhispeed() != PlayConfig.FIX_HISPEED_OFF) {
-			playconfig.setHispeed((float) ((2400f / (targetbpm / 100) / playconfig.getDuration()) * (1 - (playconfig.isEnablelanecover() ? playconfig.getLanecover() : 0))));
+			playconfig.setHispeed((float) ((2400f / (targetBpm / 100) / playconfig.getDuration()) * (1 - (playconfig.isEnablelanecover() ? playconfig.getLanecover() : 0))));
 		}
 	}
 	
@@ -270,7 +270,7 @@ public class LaneRenderer {
 		double nbpm = bpm;
 		double nscroll = 1.0;
 		for (int i = (pos > 5 ? pos - 5 : 0); i < timelines.length && timelines[i].getMicroTime() <= microtime; i++) {
-			nbpm = timelines[i].getBPM();
+			nbpm = timelines[i].getBpm();
 			nscroll = timelines[i].getScroll();
 		}
 		nowbpm = nbpm;
@@ -308,7 +308,7 @@ public class LaneRenderer {
 			for (int lane = 0; lane < lanes.length; lane++) {
 				final long[][] judgetime = main.getJudgeManager().getJudgeTimeRegion(lane);
 				for (int i = pos; i < timelines.length; i++) {
-					final TimeLine tl = timelines[i];
+					final Timeline tl = timelines[i];
 					if (tl.getMicroTime() >= microtime) {
 						double rate = (tl.getSection() - (i > 0 ? timelines[i - 1].getSection() : 0)) * (i > 0 ? timelines[i - 1].getScroll() : 1.0) * rxhs
 								/ (tl.getMicroTime() - (i > 0
@@ -331,7 +331,7 @@ public class LaneRenderer {
 		final int baseduration = playconfig.getDuration();
 		final float alphaLimit =  playconfig.getConstantFadeinTime() * 1000;
 		for (int i = pos; i < timelines.length && y <= hu; i++) {
-			final TimeLine tl = timelines[i];
+			final Timeline tl = timelines[i];
 			if (tl.getMicroTime() >= microtime) {
 				if (enableConstant) {
 					final long targetTime = microtime + (baseduration * 1000);
@@ -364,7 +364,7 @@ public class LaneRenderer {
 				}
 
 				if (i > 0) {
-					final TimeLine prevtl = timelines[i - 1];
+					final Timeline prevtl = timelines[i - 1];
 					if (prevtl.getMicroTime() + prevtl.getMicroStop() > microtime) {
 						y += (tl.getSection() - prevtl.getSection()) * prevtl.getScroll() * rxhs;
 					} else {
@@ -388,14 +388,14 @@ public class LaneRenderer {
 				}
 
 				if (config.isBpmguide() || showTimeline) {
-					if (tl.getBPM() != nbpm) {
+					if (tl.getBpm() != nbpm) {
 						for (SkinImage line : skin.getBPMLine()) {
 							line.draw(sprite, time, main, 0, (int) (y - hl));
 						}
 						for (Rectangle r : playerr) {
 							// TODO 数値もスキンベースへ移行
 							if(font != null) {
-								sprite.draw(font, "BPM" + ((int) tl.getBPM()), r.x + r.width / 2, (float) (y + 20), Color.valueOf("00c000"));
+								sprite.draw(font, "BPM" + ((int) tl.getBpm()), r.x + r.width / 2, (float) (y + 20), Color.valueOf("00c000"));
 							}
 							
 						}
@@ -415,12 +415,12 @@ public class LaneRenderer {
 
 				}
 				// 小節線描画
-				if (tl.getSectionLine()) {
+				if (tl.getHasSectionLine()) {
 					for (SkinImage line : skin.getLine()) {
 						line.draw(sprite, time, main, 0, (int) (y - hl));
 					}
 				}
-				nbpm = tl.getBPM();
+				nbpm = tl.getBpm();
 			} else if (pos == i - 1) {
 				boolean b = true;
 				for (int lane = 0; lane < lanes.length; lane++) {
@@ -444,7 +444,7 @@ public class LaneRenderer {
 		final long now = main.timer.getNowTime();
 		
 		for (int i = pos; i < timelines.length && y <= hu; i++) {
-			final TimeLine tl = timelines[i];
+			final Timeline tl = timelines[i];
 			if (enableConstant) {
 				final long targetTime = microtime + (baseduration * 1000);
 				final long timeDifference = tl.getMicroTime() - targetTime;
@@ -477,7 +477,7 @@ public class LaneRenderer {
 
 			if (tl.getMicroTime() >= microtime) {
 				if (i > 0) {
-					final TimeLine prevtl = timelines[i - 1];
+					final Timeline prevtl = timelines[i - 1];
 					if (prevtl.getMicroTime() + prevtl.getMicroStop() > microtime) {
 						y += (tl.getSection() - prevtl.getSection()) * prevtl.getScroll() * rxhs;
 					} else {
@@ -534,10 +534,10 @@ public class LaneRenderer {
 							// .getTime());
 							// } else {
 							double dy = 0;
-							TimeLine prevtl = tl;
+							Timeline prevtl = tl;
 							for (int j = i + 1; j < timelines.length
 									&& prevtl.getSection() != ln.getPair().getSection(); j++) {
-								final TimeLine nowtl = timelines[j];
+								final Timeline nowtl = timelines[j];
 								if (nowtl.getMicroTime() >= microtime) {
 									if (prevtl.getMicroTime() + prevtl.getMicroStop() > microtime) {
 										dy += (nowtl.getSection() - prevtl.getSection()) * prevtl.getScroll() * rxhs;
@@ -589,35 +589,35 @@ public class LaneRenderer {
 			final double rxhs2 = (hu - hl);
 			int nowPos = timelines.length - 1;
 			for (int i = pos; i < timelines.length; i++) {
-				final TimeLine tl = timelines[i];
+				final Timeline tl = timelines[i];
 				if (tl.getMicroTime() >= microtime) {
 					nowPos = i;
 					break;
 				}
 			}
 			for (int i = nowPos; i >= 0 && y >= orgy2; i--) {
-				final TimeLine tl = timelines[i];
+				final Timeline tl = timelines[i];
 				y = orgy;
 				if (i + 1 < timelines.length) {
 					int j;
 					for (j = i; j + 1 < timelines.length && timelines[j + 1].getMicroTime() < microtime; j++) {
 						if(timelines[j + 1].getMicroTime() > tl.getMicroTime() + tl.getMicroStop() + badTime) {
 							stopTime = Math.max(tl.getMicroTime() + tl.getMicroStop() + badTime - timelines[j].getMicroTime() - timelines[j].getMicroStop(), 0);
-							y -= (timelines[j + 1].getMicroTime() - timelines[j].getMicroTime() - timelines[j].getMicroStop() - stopTime) * rxhs2 * timelines[j].getBPM() / 240000000;
+							y -= (timelines[j + 1].getMicroTime() - timelines[j].getMicroTime() - timelines[j].getMicroStop() - stopTime) * rxhs2 * timelines[j].getBpm() / 240000000;
 							//4分の画面上での長さ rxhs2 / 4 [pixel] 4分の時間 60 / BPM [second] 落下速度 rxhs2 * BPM / 240 [pixel/second]
 						}
 					}
 					if(timelines[j].getMicroTime() + timelines[j].getMicroStop() < microtime) {
 						if(microtime > tl.getMicroTime() + tl.getMicroStop() + badTime) {
 							stopTime = Math.max(tl.getMicroTime() + tl.getMicroStop() + badTime - timelines[j].getMicroTime() - timelines[j].getMicroStop(), 0);
-							y -= (microtime - timelines[j].getMicroTime() - timelines[j].getMicroStop() - stopTime) * rxhs2 * timelines[j].getBPM() / 240000000;
+							y -= (microtime - timelines[j].getMicroTime() - timelines[j].getMicroStop() - stopTime) * rxhs2 * timelines[j].getBpm() / 240000000;
 						}
 					}
 				} else {
 					if(tl.getMicroTime() + tl.getMicroStop() < microtime) {
 						if(microtime > tl.getMicroTime() + tl.getMicroStop() + badTime) {
 							stopTime = Math.max(tl.getMicroTime() + tl.getMicroStop() + badTime - tl.getMicroTime() - tl.getMicroStop(), 0);
-							y -= (microtime - tl.getMicroTime() - tl.getMicroStop() - stopTime) * rxhs2 * tl.getBPM() / 240000000;
+							y -= (microtime - tl.getMicroTime() - tl.getMicroStop() - stopTime) * rxhs2 * tl.getBpm() / 240000000;
 						}
 					}
 				}
@@ -676,8 +676,8 @@ public class LaneRenderer {
 
 	final private void drawLongNote(SkinObjectRenderer sprite, TextureRegion[] longImage, float x, float y, float width, float height, float scale,
 			int lane, LongNote ln) {
-		if ((model.getLntype() == BMSModel.LNTYPE_HELLCHARGENOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-				|| ln.getType() == LongNote.TYPE_HELLCHARGENOTE) {
+		if ((model.getLnType() == LongNoteDef.HELL_CHARGE_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+				|| ln.getType() == LongNoteDef.HELL_CHARGE_NOTE) {
 			// HCN
 			final JudgeManager judge = main.getJudgeManager();
 			sprite.draw(
@@ -687,15 +687,15 @@ public class LaneRenderer {
 					x, y - height + scale, width, height - scale);
 			sprite.draw(longImage[4], x, y, width, scale);
 			sprite.draw(longImage[5], x, y - height, width, scale);
-		} else if ((model.getLntype() == BMSModel.LNTYPE_CHARGENOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-				|| ln.getType() == LongNote.TYPE_CHARGENOTE) {
+		} else if ((model.getLnType() == LongNoteDef.CHARGE_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+				|| ln.getType() == LongNoteDef.CHARGE_NOTE) {
 			// CN
 			sprite.draw(longImage[main.getJudgeManager().getProcessingLongNote(lane) == ln.getPair() ? 2 : 3], x,
 					y - height + scale, width, height - scale);
 			sprite.draw(longImage[0], x, y, width, scale);
 			sprite.draw(longImage[1], x, y - height, width, scale);
-		} else if ((model.getLntype() == BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
-				|| ln.getType() == LongNote.TYPE_LONGNOTE) {
+		} else if ((model.getLnType() == LongNoteDef.LONG_NOTE && ln.getType() == LongNoteDef.UNDEFINED)
+				|| ln.getType() == LongNoteDef.LONG_NOTE) {
 			// LN
 			sprite.draw(longImage[main.getJudgeManager().getProcessingLongNote(lane) == ln.getPair() ? 2 : 3], x,
 					y - height + scale, width, height - scale);

--- a/core/src/bms/player/beatoraja/play/PracticeConfiguration.java
+++ b/core/src/bms/player/beatoraja/play/PracticeConfiguration.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import bms.model.BMSModel;
 import bms.model.Mode;
-import bms.model.TimeLine;
+import bms.model.Timeline;
 import bms.player.beatoraja.Config;
 import bms.player.beatoraja.MainState;
 import bms.player.beatoraja.input.BMSPlayerInputProcessor;
@@ -66,9 +66,9 @@ public final class PracticeConfiguration {
 	public static final PracticeElement[] elements = PracticeElement.values();
 
 	public void create(BMSModel model, Config config) {
-		property.judgerank = model.getJudgerank();
+		property.judgerank = model.getJudgeRank();
 		property.endtime = model.getLastTime() + 1000;
-		Path p = Paths.get("practice/" + model.getSHA256() + ".json");
+		Path p = Paths.get("practice/" + model.getSha256() + ".json");
 		if (Files.exists(p)) {
 			Json json = new Json();
 			try {
@@ -106,7 +106,7 @@ public final class PracticeConfiguration {
 			Files.createDirectory(Paths.get("practice"));
 		} catch (IOException e1) {
 		}
-		try (FileWriter fw = new FileWriter("practice/" + model.getSHA256() + ".json")) {
+		try (FileWriter fw = new FileWriter("practice/" + model.getSha256() + ".json")) {
 			Json json = new Json();
 			fw.write(json.prettyPrint(property));
 			fw.flush();
@@ -189,7 +189,7 @@ public final class PracticeConfiguration {
 	enum PracticeElement {
 
 		STARTTIME((practice, inc) -> {
-			final TimeLine[] tl = practice.model.getAllTimeLines();
+			final Timeline[] tl = practice.model.getAllTimelines();
 			final PracticeProperty property = practice.property;
 			if(inc) {
 				if (property.starttime + 2000 <= tl[tl.length - 1].getTime()) {
@@ -206,7 +206,7 @@ public final class PracticeConfiguration {
 		}, property -> String.format("START TIME : %2d:%02d.%1d", property.starttime / 60000,
 				(property.starttime / 1000) % 60, (property.starttime / 100) % 10)),
 		ENDTIME((practice, inc) -> {
-			final TimeLine[] tl = practice.model.getAllTimeLines();
+			final Timeline[] tl = practice.model.getAllTimelines();
 			final PracticeProperty property = practice.property;
 			if(inc) {
 				if (property.endtime <= tl[tl.length - 1].getTime() + 1000) {

--- a/core/src/bms/player/beatoraja/play/RhythmTimerProcessor.java
+++ b/core/src/bms/player/beatoraja/play/RhythmTimerProcessor.java
@@ -3,10 +3,10 @@ package bms.player.beatoraja.play;
 import static bms.player.beatoraja.skin.SkinProperty.TIMER_PLAY;
 import static bms.player.beatoraja.skin.SkinProperty.TIMER_RHYTHM;
 
+import bms.model.Timeline;
 import com.badlogic.gdx.utils.LongArray;
 
 import bms.model.BMSModel;
-import bms.model.TimeLine;
 
 public class RhythmTimerProcessor {
 
@@ -22,9 +22,9 @@ public class RhythmTimerProcessor {
 
 		LongArray sectiontimes = new LongArray();
 		LongArray quarterNoteTimes = new LongArray();
-		TimeLine[] timelines = model.getAllTimeLines();
+		Timeline[] timelines = model.getAllTimelines();
 		for (int i = 0; i < timelines.length; i++) {
-			if(timelines[i].getSectionLine()) {
+			if(timelines[i].getHasSectionLine()) {
 				sectiontimes.add(timelines[i].getMicroTime());
 
 				if(useQuarterNoteTime) {
@@ -33,7 +33,7 @@ public class RhythmTimerProcessor {
 					double nextSectionLineSection = timelines[i].getSection() - sectionLineSection;
 					boolean last = false;
 					for(int j = i + 1; j < timelines.length; j++) {
-						if(timelines[j].getSectionLine()) {
+						if(timelines[j].getHasSectionLine()) {
 							nextSectionLineSection = timelines[j].getSection() - sectionLineSection;
 							break;
 						} else if(j == timelines.length - 1) {
@@ -46,7 +46,7 @@ public class RhythmTimerProcessor {
 							int prevIndex;
 							for(prevIndex = i; timelines[prevIndex].getSection() - sectionLineSection < j; prevIndex++) {}
 							prevIndex--;
-							quarterNoteTimes.add((long) (timelines[prevIndex].getMicroTime() + timelines[prevIndex].getMicroStop() + (j+sectionLineSection-timelines[prevIndex].getSection()) * 240000000 / timelines[prevIndex].getBPM()));
+							quarterNoteTimes.add((long) (timelines[prevIndex].getMicroTime() + timelines[prevIndex].getMicroStop() + (j+sectionLineSection-timelines[prevIndex].getSection()) * 240000000 / timelines[prevIndex].getBpm()));
 						}
 					}					
 				}

--- a/core/src/bms/player/beatoraja/play/bga/BGAProcessor.java
+++ b/core/src/bms/player/beatoraja/play/bga/BGAProcessor.java
@@ -2,10 +2,11 @@ package bms.player.beatoraja.play.bga;
 
 import java.nio.file.*;
 import java.util.Arrays;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import bms.model.Layer.Sequence;
 import bms.model.*;
 import bms.player.beatoraja.Config;
 import bms.player.beatoraja.PlayerConfig;
@@ -64,7 +65,7 @@ public class BGAProcessor {
 
 	private Texture blanktex;
 
-	private TimeLine[] timelines = {};
+	private Timeline[] timelines = {};
 	private int pos;
 	private TextureRegion image;
 	private Rectangle tmpRect = new Rectangle();
@@ -106,11 +107,11 @@ public class BGAProcessor {
 
 		int id = 0;
 
-		Array<TimeLine> tls = new Array<TimeLine>();
+		Array<Timeline> tls = new Array<Timeline>();
 
 		if(model != null) {
-			for(TimeLine tl : model.getAllTimeLines()) {
-				if(tl.getBGA() != -1 || tl.getLayer() != -1 || tl.getEventlayer().length > 0) {
+			for(Timeline tl : model.getAllTimelines()) {
+				if(tl.getBgaID() != -1 || tl.getLayer() != -1 || !tl.getEventLayer().isEmpty()) {
 					tls.add(tl);
 				}
 			}
@@ -206,7 +207,7 @@ public class BGAProcessor {
 				id++;
 			}
 		}
-		timelines = tls.toArray(TimeLine.class);
+		timelines = tls.toArray(Timeline.class);
 
 		disposeOld();
 
@@ -266,13 +267,13 @@ public class BGAProcessor {
 			return;
 		}
 		for (int i = pos; i < timelines.length; i++) {
-			final TimeLine tl = timelines[i];
+			final Timeline tl = timelines[i];
 			if (tl.getTime() > time) {
 				break;
 			}
 
 			if (tl.getTime() > this.time) {
-				final int bga = tl.getBGA();
+				final int bga = tl.getBgaID();
 				if (bga == -2) {
 					playingbgaid = -1;
 					rbga = false;
@@ -290,10 +291,10 @@ public class BGAProcessor {
 					rlayer = false;
 				}
 
-				final Layer[] eventlayer = tl.getEventlayer();
-				
-				for(Layer poor : eventlayer) {
-					if (poor.event.type == Layer.EventType.MISS) {
+				List<Layer> eventLayer = tl.getEventLayer();
+
+				for(Layer poor : eventLayer) {
+					if (poor.getEvent().getType() == EventType.MISS) {
 						misslayer = poor;
 					}					
 				}
@@ -316,8 +317,8 @@ public class BGAProcessor {
 
 		if (misslayer != null && misslayertime != 0 && time >= misslayertime && time < misslayertime + getMisslayerduration) {
 			// draw miss layer
-			final Sequence[] seq = misslayer.sequence[0];
-			final int index = seq[(int) ((seq.length - 1) * (time - misslayertime) / getMisslayerduration)].id;
+			List<LayerSequence> seq = misslayer.getLayerSequence().get(0);
+			final int index = seq.get((int) ((seq.size() - 1) * (time - misslayertime) / getMisslayerduration)).getId();
 			if(index != Integer.MIN_VALUE) {
 				Texture miss = getBGAData(time, index, true);
 				if (miss != null) {

--- a/core/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/core/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -2,10 +2,11 @@ package bms.player.beatoraja.play.bga;
 
 import java.nio.file.Path;
 import java.util.*;
+
+import bms.model.Timeline;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import bms.model.TimeLine;
 import bms.player.beatoraja.PixmapResourcePool;
 
 import com.badlogic.gdx.graphics.Pixmap;
@@ -74,7 +75,7 @@ public class BGImageProcessor {
 	/**
 	 * BGAの初期データをあらかじめキャッシュする
 	 */
-	public void prepare(TimeLine[] timelines) {
+	public void prepare(Timeline[] timelines) {
 		long l = System.currentTimeMillis();
 		Arrays.fill(bgacacheid, -1);
 		for (Texture bga : bgacache) {
@@ -85,8 +86,8 @@ public class BGImageProcessor {
 		Arrays.fill(bgacache, null);
 
 		int count = 0;
-		for (TimeLine tl : timelines) {
-			int bga = tl.getBGA();
+		for (Timeline tl : timelines) {
+			int bga = tl.getBgaID();
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null && bga < bgamap.length && bgamap[bga] != null) {
 				getTexture(bga);
 				count++;

--- a/core/src/bms/player/beatoraja/result/MusicResult.java
+++ b/core/src/bms/player/beatoraja/result/MusicResult.java
@@ -357,10 +357,10 @@ public class MusicResult extends AbstractResult {
 		timingDistribution.init();
 		BMSModel model = resource.getBMSModel();
 		final int lanes = model.getMode().key;
-		for (TimeLine tl : model.getAllTimeLines()) {
+		for (Timeline tl : model.getAllTimelines()) {
 			for (int i = 0; i < lanes; i++) {
 				Note n = tl.getNote(i);
-				if (n != null && !((model.getLnmode() == 1 || (model.getLnmode() == 0 && model.getLntype() == BMSModel.LNTYPE_LONGNOTE))
+				if (n != null && !((model.getLnMode() == LongNoteDef.LONG_NOTE || (model.getLnMode() == LongNoteDef.UNDEFINED && model.getLnType() == LongNoteDef.LONG_NOTE))
 						&& n instanceof LongNote && ((LongNote) n).isEnd())) {
 					int state = n.getState();
 					int time = n.getPlayTime();

--- a/core/src/bms/player/beatoraja/skin/SkinBPMGraph.java
+++ b/core/src/bms/player/beatoraja/skin/SkinBPMGraph.java
@@ -131,18 +131,18 @@ public class SkinBPMGraph extends SkinObject {
 			Map<Double, Integer> bpmNoteCountMap = new HashMap<Double, Integer>();
 			double nowSpeed = model.getBpm();
 			speedList.add(new double[] {nowSpeed, 0.0});
-			final TimeLine[] tls = model.getAllTimeLines();
-			for (TimeLine tl : tls) {
-				int notecount = bpmNoteCountMap.containsKey(tl.getBPM()) ? bpmNoteCountMap.get(tl.getBPM()) : 0;
-				bpmNoteCountMap.put(tl.getBPM(), notecount + tl.getTotalNotes());
+			final Timeline[] tls = model.getAllTimelines();
+			for (Timeline tl : tls) {
+				int notecount = bpmNoteCountMap.containsKey(tl.getBpm()) ? bpmNoteCountMap.get(tl.getBpm()) : 0;
+				bpmNoteCountMap.put(tl.getBpm(), notecount + tl.getTotalNotes());
 
 				if(tl.getStop() > 0) {
 					if(nowSpeed != 0) {
 						nowSpeed = 0;					
 						speedList.add(new double[] {nowSpeed, tl.getTime()});
 					}
-				} else if(nowSpeed != tl.getBPM() * tl.getScroll()) {
-					nowSpeed = tl.getBPM() * tl.getScroll();
+				} else if(nowSpeed != tl.getBpm() * tl.getScroll()) {
+					nowSpeed = tl.getBpm() * tl.getScroll();
 					speedList.add(new double[] {nowSpeed, tl.getTime()});
 				}
 			}

--- a/core/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
+++ b/core/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
@@ -189,7 +189,7 @@ public class SkinHitErrorVisualizer extends SkinObject {
 		BMSModel model = resource.getBMSModel();
 		JudgeProperty rule = BMSPlayerRule.getBMSPlayerRule(resource.getOriginalMode()).judge;
 
-		final int judgerank = model.getJudgerank();
+		final int judgerank = model.getJudgeRank();
 		final PlayerConfig config = resource.getPlayerConfig();
 		final int[] judgeWindowRate = config.isCustomJudge()
 				? new int[]{config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood()}

--- a/core/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
+++ b/core/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
@@ -262,8 +262,8 @@ public final class SkinNoteDistributionGraph extends SkinObject {
 		final Mode mode = model.getMode();
 		// #LNMODE is explicitly set to 1 (LN)
 		// or #LNMODE is undefined and getLntype (which reflects playconfig) is LN (0)
-		final boolean ignoreLNEnd = model.getLnmode() == 1 || (model.getLnmode() == 0 && model.getLntype() == BMSModel.LNTYPE_LONGNOTE);
-		for (TimeLine tl : model.getAllTimeLines()) {
+		final boolean ignoreLNEnd = model.getLnMode() == LongNoteDef.LONG_NOTE || (model.getLnMode() == LongNoteDef.UNDEFINED && model.getLnType() == LongNoteDef.LONG_NOTE);
+		for (Timeline tl : model.getAllTimelines()) {
 			final int index = tl.getTime() / 1000;
 			if(index >= data.length) {
 				break;

--- a/core/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
+++ b/core/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
@@ -153,7 +153,7 @@ public final class SkinTimingVisualizer extends SkinObject {
 		BMSModel model = resource.getBMSModel();
 		JudgeProperty rule = BMSPlayerRule.getBMSPlayerRule(resource.getOriginalMode()).judge;
 
-		final int judgerank = model.getJudgerank();
+		final int judgerank = model.getJudgeRank();
 		final PlayerConfig config = resource.getPlayerConfig();
 		final int[] judgeWindowRate = config.isCustomJudge()
 				? new int[]{config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood()}

--- a/core/src/bms/player/beatoraja/song/SongData.java
+++ b/core/src/bms/player/beatoraja/song/SongData.java
@@ -12,6 +12,8 @@ import bms.player.beatoraja.Validatable;
 import bms.player.beatoraja.play.BMSPlayerRule;
 import bms.tool.mdprocessor.IpfsInformation;
 
+import static io.github.catizard.kbms.parser.RadixHelperKt.convertHexString;
+
 /**
  * 楽曲データ
  * 
@@ -115,7 +117,7 @@ public class SongData implements Validatable, IpfsInformation {
 	private String parent = "";
 
 	private BMSModel model;
-	private TimeLine[] timelines;
+	private Timeline[] timelines;
 	private SongInformation info;
 
 	private String charthash;
@@ -142,17 +144,17 @@ public class SongData implements Validatable, IpfsInformation {
 		setArtist(model.getArtist());
 		setSubartist(model.getSubArtist());
 		path.add(model.getPath());
-		md5 = model.getMD5();
-		sha256 = model.getSHA256();
+		md5 = model.getMd5();
+		sha256 = model.getSha256();
 		banner = model.getBanner();
 
-		setStagefile(model.getStagefile());
-		setBackbmp(model.getBackbmp());
+		setStagefile(model.getStageFile());
+		setBackbmp(model.getBackBMP());
         if(preview == null || preview.length() == 0) {
             setPreview(model.getPreview());
         }
 		try {
-			level = Integer.parseInt(model.getPlaylevel());
+			level = Integer.parseInt(model.getPlayLevel());
 		} catch(NumberFormatException e) {
 
 		}
@@ -160,12 +162,12 @@ public class SongData implements Validatable, IpfsInformation {
 		if(difficulty == 0) {
 			difficulty = model.getDifficulty();			
 		}
-		judge = model.getJudgerank();
+		judge = model.getJudgeRank();
 		minbpm = (int) model.getMinBPM();
 		maxbpm = (int) model.getMaxBPM();
 		feature = 0;
 		final int keys = model.getMode().key;
-		for (TimeLine tl : model.getAllTimeLines()) {
+		for (Timeline tl : model.getAllTimelines()) {
 			if(tl.getStop() > 0) {
 				feature |= FEATURE_STOPSEQUENCE;
 			}
@@ -176,16 +178,16 @@ public class SongData implements Validatable, IpfsInformation {
 			for(int i = 0;i < keys;i++) {
 				if(tl.getNote(i) instanceof LongNote) {
 					switch(((LongNote) tl.getNote(i)).getType()) {
-						case LongNote.TYPE_UNDEFINED:
+						case UNDEFINED:
 							feature |= FEATURE_UNDEFINEDLN;
 							break;
-						case LongNote.TYPE_LONGNOTE:
+						case LONG_NOTE:
 							feature |= FEATURE_LONGNOTE;
 							break;
-						case LongNote.TYPE_CHARGENOTE:
+						case CHARGE_NOTE:
 							feature |= FEATURE_CHARGENOTE;
 							break;
-						case LongNote.TYPE_HELLCHARGENOTE:
+						case HELL_CHARGE_NOTE:
 							feature |= FEATURE_HELLCHARGENOTE;
 							break;
 					}
@@ -198,7 +200,7 @@ public class SongData implements Validatable, IpfsInformation {
 		length = model.getLastTime();
 		notes = model.getTotalNotes();
 
-		timelines = model.getAllTimeLines();
+		timelines = model.getAllTimelines();
 
 		feature |= model.getRandom() != null && model.getRandom().length > 0 ? FEATURE_RANDOM : 0;
 		content |= model.getBgaList().length > 0 ? CONTENT_BGA : 0;
@@ -207,7 +209,7 @@ public class SongData implements Validatable, IpfsInformation {
 		info = new SongInformation(model);
 		try {
 			MessageDigest md = MessageDigest.getInstance("SHA-256");
-			charthash = BMSDecoder.convertHexString(md.digest(model.toChartString().getBytes()));
+			charthash = convertHexString(md.digest(model.toChartString().getBytes()));
 		} catch (NoSuchAlgorithmException e) {
 			e.printStackTrace();
 		}
@@ -457,7 +459,7 @@ public class SongData implements Validatable, IpfsInformation {
 		this.judge = judge;
 	}
 
-	public TimeLine[] getTimelines() {
+	public Timeline[] getTimelines() {
 		return timelines;
 	}
 

--- a/core/src/bms/player/beatoraja/song/SongInformation.java
+++ b/core/src/bms/player/beatoraja/song/SongInformation.java
@@ -84,7 +84,7 @@ public class SongInformation implements Validatable {
 	}
 	
 	public SongInformation(BMSModel model) {
-		sha256 = model.getSHA256();
+		sha256 = model.getSha256();
 		n = BMSModelUtils.getTotalNotes(model, BMSModelUtils.TOTALNOTES_KEY);
 		ln = BMSModelUtils.getTotalNotes(model, BMSModelUtils.TOTALNOTES_LONG_KEY);
 		s = BMSModelUtils.getTotalNotes(model, BMSModelUtils.TOTALNOTES_SCRATCH);
@@ -96,7 +96,7 @@ public class SongInformation implements Validatable {
 		int pos = 0;
 		int border = (int) (model.getTotalNotes() * (1.0 - 100.0 / model.getTotal()));
 		int borderpos = 0;
-		for (TimeLine tl : model.getAllTimeLines()) {
+		for (Timeline tl : model.getAllTimelines()) {
 			if (tl.getTime() / 1000 != pos) {
 				pos = tl.getTime() / 1000;
 			}
@@ -109,7 +109,7 @@ public class SongInformation implements Validatable {
 						}
 					}
 
-					if(!((model.getLnmode() == 1 || (model.getLnmode() == 0 && model.getLntype() == BMSModel.LNTYPE_LONGNOTE))
+					if(!((model.getLnMode() == LongNoteDef.LONG_NOTE || (model.getLnMode() == LongNoteDef.UNDEFINED && model.getLnType() == LongNoteDef.LONG_NOTE))
 							&& n instanceof LongNote && ((LongNote) n).isEnd())){
 						if (n instanceof NormalNote) {
 							data[tl.getTime() / 1000][model.getMode().isScratchKey(i) ? 2 : 5]++;
@@ -163,18 +163,18 @@ public class SongInformation implements Validatable {
 		Map<Double, Integer> bpmNoteCountMap = new HashMap<Double, Integer>();
 		double nowSpeed = model.getBpm();
 		speedList.add(new double[] {nowSpeed, 0.0});
-		final TimeLine[] tls = model.getAllTimeLines();
-		for (TimeLine tl : tls) {
-			int notecount = bpmNoteCountMap.containsKey(tl.getBPM()) ? bpmNoteCountMap.get(tl.getBPM()) : 0;
-			bpmNoteCountMap.put(tl.getBPM(), notecount + tl.getTotalNotes());
+		final Timeline[] tls = model.getAllTimelines();
+		for (Timeline tl : tls) {
+			int notecount = bpmNoteCountMap.containsKey(tl.getBpm()) ? bpmNoteCountMap.get(tl.getBpm()) : 0;
+			bpmNoteCountMap.put(tl.getBpm(), notecount + tl.getTotalNotes());
 
 			if(tl.getStop() > 0) {
 				if(nowSpeed != 0) {
 					nowSpeed = 0;					
 					speedList.add(new double[] {nowSpeed, tl.getTime()});
 				}
-			} else if(nowSpeed != tl.getBPM() * tl.getScroll()) {
-				nowSpeed = tl.getBPM() * tl.getScroll();
+			} else if(nowSpeed != tl.getBpm() * tl.getScroll()) {
+				nowSpeed = tl.getBpm() * tl.getScroll();
 				speedList.add(new double[] {nowSpeed, tl.getTime()});
 			}
 		}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ ebur128java = "1.2.6-2"
 jna = "5.13.0"
 websocket = "1.6.0"
 slf4j = "2.0.17"
+kbms-parser = "108ce4ba42"
 
 
 [libraries]
@@ -82,6 +83,8 @@ jna-platform = { group = "net.java.dev.jna", name = "jna-platform", version.ref 
 javawebsocket = { group = "org.java-websocket", name = "Java-WebSocket", version.ref = "websocket" }
 slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 slf4j-jul = { group = "org.slf4j", name = "slf4j-jdk14", version.ref = "slf4j" }
+
+kbms-parser = { group = "com.github.catizard", name = "kbms-parser", version.ref = "kbms-parser" }
 
 [bundles]
 libgdx = ["gdx-core", "gdx-backend", "gdx-freetype",  "gdx-controllers-core", "gdx-controllers-desktop"]


### PR DESCRIPTION
This is another radical proposal: replace `jbms-parser` with `kbms-parser`. The only benefit gained from this migration is `kbms-parser` has an open-source license. The original `jbms-parser` is running enough fast that no optimization could be done by rewriting it.

This pr is still in early development stage because keeping compatibility/correctness between two projects is hard.