### PR TITLE
Fix NPE when loading #SRC_NUMBER commands in lr2 skins

### DIFF
--- a/core/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/core/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -224,7 +224,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 		});
 
 		addCommandWord(new CommandWord("SRC_NUMBER") {
-			//#SRC_NUMBER,(NULL),gr,x,y,w,h,div_x,div_y,cycle,timer,num,align,keta,zeropadding
+			//#SRC_NUMBER,(NULL),gr,x,y,w,h,div_x,div_y,cycle,timer,num,align,keta
 			@Override
 			public void execute(String[] str) {
 				num = null;
@@ -249,7 +249,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 								}
 							}
 
-							num = new SkinNumber(pn, mn, values[10], values[9], values[13] + 1, str[14].length() > 0 ? values[14] : 2, values[15], values[11], values[12]);
+							num = new SkinNumber(pn, mn, values[10], values[9], values[13] + 1, 2, 0, values[11], values[12]);
 						} else {
 							int d = images.length % 10 == 0 ? 10 : 11;
 
@@ -260,7 +260,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 								}
 							}
 
-							num = new SkinNumber(nimages, values[10], values[9], values[13], d > 10 ? 2 : 0, values[15], values[11], values[12]);
+							num = new SkinNumber(nimages, values[10], values[9], values[13], d > 10 ? 2 : 0, 0, values[11], values[12]);
 						}
 						skin.add(num);
 						// System.out.println("Number Added - " +


### PR DESCRIPTION
According to https://lr2skinhelp.vercel.app/definitions.html#src_number, the definition of `#SRC_NUMBER` should have exactly 14 elements. However, as the comments from upstream shows, it differs of having 15 elements with an extra parameter `zero_padding` defined, which leads to the immediate NPE for certain skins (e.g. KCOOL as known of losing judgement and combo number).

This pr intends to remove the incorrect access (it's not written in the comments but the code shows upstream thinks the parameters count should be 16 for having an extra extra parameter: spacing, which is also removed to avoid NPE).

After this pr the issue of KCOOL is fixed:
<img width="2560" height="1496" alt="ea8cfbdc75f0005fbae34407e96fc0ac" src="https://github.com/user-attachments/assets/06f3caef-bf45-4300-946a-169f1aa974ca" />
