### PR TITLE
Fix incorrect color format handling for 32-bit BMP images

### DIFF
--- a/core/src/bms/player/beatoraja/PixmapResourcePool.java
+++ b/core/src/bms/player/beatoraja/PixmapResourcePool.java
@@ -78,7 +78,9 @@ public class PixmapResourcePool extends ResourcePool<String, Pixmap> {
 				tex = new Pixmap(bi.getWidth(), bi.getHeight(), Pixmap.Format.RGBA8888);
 				for(int x = 0;x < bi.getWidth();x++) {
 					for(int y = 0;y < bi.getHeight();y++) {
-						tex.drawPixel(x, y, (bi.getRGB(x, y) << 8 | 0x000000ff));
+						int argb = bi.getRGB(x, y);
+						int rgba = ((argb & 0x00FFFFFF) << 8) | ((argb >> 24) & 0xFF);
+						tex.drawPixel(x, y, rgba);
 					}
 				}
 			} catch (Throwable e) {


### PR DESCRIPTION
Fixes #223

32-bit BMP images were failing to load due to improper ARGB to RGBA color format conversion. The original code wasn't correctly extracting and positioning the alpha channel when converting from BufferedImage to Pixmap format.

The fix properly extracts the RGB and alpha components from the ARGB integer and converts them to the expected RGBA byte order.