### PR TITLE
Fix shader not working on macos

### DIFF
--- a/core/src/bms/player/beatoraja/ShaderManager.java
+++ b/core/src/bms/player/beatoraja/ShaderManager.java
@@ -4,22 +4,41 @@ import java.util.HashMap;
 import java.util.Map.Entry;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ShaderManager {
+	private static final Logger logger = LoggerFactory.getLogger(ShaderManager.class);
 
 	private static HashMap<String, ShaderProgram> shaders = new HashMap();
 
 	public static ShaderProgram getShader(String name) {
 		if (!shaders.containsKey(name)) {
-			ShaderProgram shader = new ShaderProgram(Gdx.files.classpath("glsl/" + name + ".vert"),
-					Gdx.files.classpath("glsl/" + name + ".frag"));
+			FileHandle vertFile = loadShaderFile(name, ".vert");
+			FileHandle fragFile = loadShaderFile(name, ".frag");
+			ShaderProgram shader = new ShaderProgram(vertFile, fragFile);
 			if(shader.isCompiled()) {
 				shaders.put(name, shader);
 				return shader;				
+			} else {
+				logger.error("Failed to compile shader, vert at {}, frag at {}", vertFile.path(), fragFile.path());
+				logger.error("Shader compilation error: {}", shader.getLog());
 			}
 		}
 		return shaders.get(name);
+	}
+
+	private static FileHandle loadShaderFile(String name, String suffix) {
+		if (UIUtils.isMac || UIUtils.isLinux) {
+			FileHandle unixVariant = Gdx.files.classpath("glsl/" + name + "_unix" + suffix);
+			if (unixVariant.exists()) {
+				return unixVariant;
+			}
+		}
+		return Gdx.files.classpath("glsl/" + name + suffix);
 	}
 	
 	public static void dispose() {

--- a/core/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
+++ b/core/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
@@ -141,11 +141,6 @@ public class FFmpegProcessor implements MovieProcessor {
 		public void run() {
 			try {
 				grabber = new FFmpegFrameGrabber(filepath);
-				// HACK: frame caught by ffmpeg's color order is wrong on macos only
-				// Expected to be RGB, got BGR
-				if (UIUtils.isMac) {
-					grabber.setPixelFormat(AV_PIX_FMT_RGB24);
-				}
 				grabber.start();
 
 				while (grabber.getVideoBitrate() < 10) {

--- a/core/src/glsl/bilinear_unix.frag
+++ b/core/src/glsl/bilinear_unix.frag
@@ -1,0 +1,41 @@
+#version 150
+#ifdef GL_ES
+#define LOWP lowp
+precision mediump float;
+#else
+#define LOWP
+#endif
+in LOWP vec4 v_color;
+in vec2 v_texCoords;
+uniform sampler2D u_texture;
+uniform int filter_type;
+uniform int image_type;
+out vec4 fragColor;
+
+void main() {
+    vec2 texSize = textureSize(u_texture, 0);
+
+    float center_a = texture(u_texture, v_texCoords).a;
+    if(center_a > 0.0) {
+        float texelSizeX = 0.5 / texSize.x;
+        float texelSizeY = 0.5 / texSize.y;
+        vec4 p0q0 = texture(u_texture, v_texCoords + vec2(-texelSizeX, -texelSizeY));
+        vec4 p1q0 = texture(u_texture, v_texCoords + vec2(texelSizeX, -texelSizeY));
+
+        vec4 p0q1 = texture(u_texture, v_texCoords + vec2(-texelSizeX, texelSizeY));
+        vec4 p1q1 = texture(u_texture, v_texCoords + vec2(texelSizeX , texelSizeY));
+
+        float a = fract(v_texCoords.x * texSize.x + 0.5);
+
+        vec4 pInterp_q0 = mix( p0q0 * p0q0.a, p1q0 * p1q0.a, a);
+        vec4 pInterp_q1 = mix( p0q1 * p0q1.a, p1q1 * p1q1.a, a);
+
+        float b = fract(v_texCoords.y * texSize.y + 0.5);
+
+        vec4 result = mix( pInterp_q0, pInterp_q1, b ) / center_a;
+        result.a = center_a;
+        fragColor = v_color * result;
+    } else {
+        fragColor = vec4(0.0, 0.0, 0.0, 0.0);
+    }
+}

--- a/core/src/glsl/bilinear_unix.vert
+++ b/core/src/glsl/bilinear_unix.vert
@@ -1,0 +1,13 @@
+#version 150
+in vec4 a_position;
+in vec4 a_color;
+in vec2 a_texCoord0;
+uniform mat4 u_projTrans;
+out vec4 v_color;
+out vec2 v_texCoords;
+
+void main() {
+   v_color = a_color;
+   v_texCoords = a_texCoord0;
+   gl_Position =  u_projTrans * a_position;
+}

--- a/core/src/glsl/distance_field_unix.frag
+++ b/core/src/glsl/distance_field_unix.frag
@@ -1,0 +1,31 @@
+#version 150
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+uniform sampler2D u_texture;
+uniform float u_outlineDistance; // Between 0 and 0.5, 0 = thick outline, 0.5 = no outline
+uniform vec4 u_outlineColor;
+uniform vec2 u_shadowOffset; // Between 0 and spread / textureSize
+uniform float u_shadowSmoothing; // Between 0 and 0.5
+uniform vec4 u_shadowColor;
+
+in vec4 v_color;
+in vec2 v_texCoord;
+out vec4 fragColor;
+
+const float smoothing = 1.0/16.0;
+
+void main() {
+    float distance = texture(u_texture, v_texCoord).a;
+    float outlineFactor = smoothstep(0.5 - smoothing, 0.5 + smoothing, distance);
+    vec4 color = mix(u_outlineColor, v_color, outlineFactor);
+    float alpha = smoothstep(u_outlineDistance - smoothing, u_outlineDistance + smoothing, distance);
+    vec4 mainColor = vec4(color.rgb, color.a * alpha);
+
+    float shadowDistance = texture(u_texture, v_texCoord - u_shadowOffset).a;
+    float shadowAlpha = smoothstep(0.5 - u_shadowSmoothing, 0.5 + u_shadowSmoothing, shadowDistance);
+    vec4 shadow = vec4(u_shadowColor.rgb, u_shadowColor.a * shadowAlpha);
+
+    fragColor = mix(shadow, mainColor, mainColor.a);
+}

--- a/core/src/glsl/distance_field_unix.vert
+++ b/core/src/glsl/distance_field_unix.vert
@@ -1,0 +1,13 @@
+#version 150
+in vec4 a_position;
+in vec4 a_color;
+in vec2 a_texCoord0;
+uniform mat4 u_projTrans;
+out vec4 v_color;
+out vec2 v_texCoord;
+
+void main() {
+   v_color = a_color;
+   v_texCoord = a_texCoord0;
+   gl_Position =  u_projTrans * a_position;
+}

--- a/core/src/glsl/ffmpeg_unix.frag
+++ b/core/src/glsl/ffmpeg_unix.frag
@@ -1,0 +1,16 @@
+#version 150
+#ifdef GL_ES
+#define LOWP lowp
+precision mediump float;
+#else
+#define LOWP
+#endif
+in LOWP vec4 v_color;
+in vec2 v_texCoords;
+uniform sampler2D u_texture;
+out vec4 fragColor;
+
+void main() {
+    vec4 c4 = texture(u_texture, v_texCoords);
+    fragColor = v_color * vec4(c4.b, c4.g, c4.r, c4.a);
+}

--- a/core/src/glsl/ffmpeg_unix.vert
+++ b/core/src/glsl/ffmpeg_unix.vert
@@ -1,0 +1,13 @@
+#version 150
+in vec4 a_position;
+in vec4 a_color;
+in vec2 a_texCoord0;
+uniform mat4 u_projTrans;
+out vec4 v_color;
+out vec2 v_texCoords;
+
+void main() {
+   v_color = a_color;
+   v_texCoords = a_texCoord0;
+   gl_Position =  u_projTrans * a_position;
+}

--- a/core/src/glsl/layer_unix.frag
+++ b/core/src/glsl/layer_unix.frag
@@ -1,0 +1,20 @@
+#version 150
+#ifdef GL_ES
+#define LOWP lowp
+precision mediump float;
+#else
+#define LOWP
+#endif
+in LOWP vec4 v_color;
+in vec2 v_texCoords;
+uniform sampler2D u_texture;
+out vec4 fragColor;
+
+void main() {
+    vec4 c4 = texture(u_texture, v_texCoords);
+    if(c4.r == 0.0 && c4.g == 0.0 && c4.b == 0.0) {
+        fragColor = v_color * vec4(c4.rgb, 0.0);
+    } else {
+        fragColor = v_color * c4;
+    }
+}

--- a/core/src/glsl/layer_unix.vert
+++ b/core/src/glsl/layer_unix.vert
@@ -1,0 +1,13 @@
+#version 150
+in vec4 a_position;
+in vec4 a_color;
+in vec2 a_texCoord0;
+uniform mat4 u_projTrans;
+out vec4 v_color;
+out vec2 v_texCoords;
+
+void main() {
+   v_color = a_color;
+   v_texCoords = a_texCoord0;
+   gl_Position =  u_projTrans * a_position;
+}


### PR DESCRIPTION
**This pr is demanding volunteers for testing on linux and widnows.**

This pr aims to fix the issue that shander doesn't work on macos, and properly, linux. The initial problem is some old bms, e.g. gengaozo, is using an old trick which is so called "black color keying" to mimic the "transparent color". In beatoraja, this is achieved by using a shader. However, the shader file is using the old standard that simply won't compile on macos and linux. Causing gengaozo's bga looks funny and has crazy flashes that can burn ppl eyes.

In this pr, I rerouted the shader files to _unix variant if os is mac or linux.

For more information, please check out https://hitkey.bms.ms/cmds.htm#BMPXX-LAYER.

This pr has a high possibility is related to #210, I haven't looked into it yet

> Side notes for devs
> There was an old issue when supporting mac: the bga video is displaying RGB color in wrong order (Expected RGB, Got BGR iirc), this issue is having a high possibility that is because the `ffmpeg` shader is not applying because it cannot be compiled on macos