### PR TITLE
Add an initial JUnit6 setup

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,18 +22,22 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 
-    flatDir{
+    flatDir {
         dirs("../lib")
     }
-    maven(url = "https://jitpack.io" )
+    maven(url = "https://jitpack.io")
 }
 
 version = libs.versions.beatoraja.get()
 
 sourceSets {
     main {
-        java.srcDirs(listOf("src/", "dependencies/jbms-parser/", "dependencies/jbmstable-parser"))
-        resources.srcDirs(listOf("src/"))
+        java.srcDirs("src/", "dependencies/jbms-parser/", "dependencies/jbmstable-parser")
+        resources.srcDirs("src/")
+    }
+    test {
+        java.srcDirs("test/")
+        resources.srcDirs("test/resources")
     }
 }
 
@@ -44,14 +48,14 @@ application {
 tasks {
     // fat/uber-jar task provided by https://github.com/GradleUp/shadow
     shadowJar {
-        dependsOn("generateBuildMetaInfo")
+        dependsOn("generateBuildMetaInfo", "test")
         val platformProp = System.getProperty("platform")
         val archProp = System.getProperty("arch")
-        val archVariant = when(archProp != null) {
+        val archVariant = when (archProp != null) {
             true -> archProp.plus("-")
             false -> ""
         }
-        val classifierPlatform = when(platformProp != null)  {
+        val classifierPlatform = when (platformProp != null) {
             true -> platformProp.plus("-").plus(archVariant).plus(libs.versions.endlessdream.get())
             false -> "".plus(libs.versions.endlessdream.get())
         }
@@ -59,14 +63,14 @@ tasks {
         destinationDirectory.set(projectDir.resolveSibling("dist"))
         archiveBaseName.set("lr2oraja")
         archiveClassifier.set(classifierPlatform)
-	    mergeServiceFiles()
+        mergeServiceFiles()
     }
 
     // shadow task that extends java `application` plugin JavaExec to cover fatjars
     // used to test builds, does not contain portaudio natives.
     runShadow {
         val runDirProp = System.getProperty("runDir")
-        val runDir = when(runDirProp != null)  {
+        val runDir = when (runDirProp != null) {
             true -> FileSystems.getDefault().getPath(runDirProp).normalize().toAbsolutePath().toFile()
             false -> projectDir.resolve("../assets")
         }
@@ -76,6 +80,10 @@ tasks {
         }
         workingDir = runDir
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 // Generate current build's meta info: git commit hash, commit time, etc
@@ -111,8 +119,8 @@ tasks.register("generateBuildMetaInfo") {
 // versions and bundles defined in ../gradle/libs.versions.toml
 dependencies {
     implementation(libs.bundles.libgdx)
-    
-    implementation(libs.gdx.platform)  {
+
+    implementation(libs.gdx.platform) {
         artifact {
             classifier = "natives-desktop"
         }
@@ -162,4 +170,8 @@ dependencies {
     // non-gradle managed file dependencies. jportaudio not on maven. "custom" scares me.
     implementation(":jportaudio")
     implementation(":luaj-jse:3.0.2-custom")
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/core/test/bms/player/beatoraja/ScoreDataTest.java
+++ b/core/test/bms/player/beatoraja/ScoreDataTest.java
@@ -1,0 +1,33 @@
+package bms.player.beatoraja;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ScoreDataTest {
+
+    @Test
+    void calculatesExScore() {
+        // given
+        var score = new ScoreData();
+        score.setEpg(1000);
+        score.setLpg(300);
+        score.setEgr(10);
+        score.setLgr(2);
+
+        score.setEgd(100);
+        score.setLgd(100);
+        score.setEbd(100);
+        score.setLbd(100);
+        score.setEpr(100);
+        score.setLpr(100);
+        score.setEms(100);
+        score.setLms(100);
+
+        // when
+        var exScore = score.getExscore();
+
+        // then
+        assertEquals(2612, exScore);
+    }
+}

--- a/core/test/resources/junit-platform.properties
+++ b/core/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ ebur128java = "1.2.6-2"
 jna = "5.13.0"
 websocket = "1.6.0"
 slf4j = "2.0.17"
-
+junit-bom = "6.0.3"
 
 [libraries]
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -73,7 +73,7 @@ jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-datab
 jackson-annotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version.ref = "jackson" }
 jackson-xml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-xml", version.ref = "jackson" }
 
-twitter4j = { group = "org.twitter4j" , name = "twitter4j-core", version.ref = "twitter4j" }
+twitter4j = { group = "org.twitter4j", name = "twitter4j-core", version.ref = "twitter4j" }
 ebur128java = { group = "io.github.llm96", name = "ebur128java", version.ref = "ebur128java" }
 
 jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
@@ -83,8 +83,12 @@ javawebsocket = { group = "org.java-websocket", name = "Java-WebSocket", version
 slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 slf4j-jul = { group = "org.slf4j", name = "slf4j-jdk14", version.ref = "slf4j" }
 
+junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit-bom" }
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter" }
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
+
 [bundles]
-libgdx = ["gdx-core", "gdx-backend", "gdx-freetype",  "gdx-controllers-core", "gdx-controllers-desktop"]
+libgdx = ["gdx-core", "gdx-backend", "gdx-freetype", "gdx-controllers-core", "gdx-controllers-desktop"]
 lwjgl3 = ["lwjgl", "lwjgl-jemalloc", "lwjgl-glfw", "lwjgl-openal", "lwjgl-opengl", "lwjgl-stb"]
 imgui = ["imgui", "imgui-lwjgl3", "imgui-linux", "imgui-windows", "imgui-macos"]
 ffmpeg = ["javacv", "javacpp", "ffmpeg"]


### PR DESCRIPTION
This PR introduces a basic JUnit6 setup so we can start adding tests to the project. Tests and their resources are placed in `core/test` and `core/test/resources` directories. I also made the `shadowJar` task depend on `test` task, so that we ensure they need to pass to actually build the JAR.

The configuration I included with the tests makes it so the test classes are ran [in parallel](https://docs.junit.org/6.0.3/writing-tests/parallel-execution.html), but the methods inside them run sequentially on the same thread. Letting everything run in parallel could probably also work here, and I think with enough care we won't run into an issue where some cases depend on each other, but I just think it's a safe default we can start with to make sure build times won't extend too much.

`ScoreDataTest` is a simple example that ensures exscore is calculated correctly. :cowboy_hat_face: 

I suppose that could also lead into a separate discussion on whether test naming should be standardized differently (should the name start with "should"? should different display names be used?), although for the sake of the setup itself that's not terribly important.