### PR TITLE
Update build dependencies and ensure more Gradle cache uses

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,12 @@
 plugins {
-    id("org.gradle.kotlin.kotlin-dsl") version "4.2.1"
+    id("org.gradle.kotlin.kotlin-dsl") version "6.5.3"
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 repositories {
     mavenCentral()

--- a/buildSrc/src/main/kotlin/org/endlessdream/extra/multiplatform-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/endlessdream/extra/multiplatform-convention.gradle.kts
@@ -7,19 +7,13 @@ plugins {
 // use `-Dplatform=[platform]` or change this value to set the target platform for the jar
 // Available platforms:
 //    "windows", "linux", "macos"
-var platform = when(System.getProperty("platform") != null)  {
-    true -> System.getProperty("platform")
-    false -> "windows"
-}!!
+val platform = System.getProperty("platform") ?: "windows"
 
 // use `-Darch=[arch]` or change this value to set the target arch for the jar
 // Available arch:
 //    "x86-64", "aarch64"
 // Defauls to x86-64
-var arch = when(System.getProperty("arch") != null) {
-    true -> System.getProperty("arch")
-    false -> "x86-64"
-}
+val arch = System.getProperty("arch") ?: "x86-64"
 
 tasks {
     register<Copy>("resolveRuntimeClasspath") {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,14 +1,9 @@
-import org.gradle.internal.classpath.Instrumented.systemProperty
-import java.io.ByteArrayOutputStream
 import java.nio.file.FileSystems
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
 
 plugins {
     id("java-library")
     id("application")
-    id("com.gradleup.shadow") version "8.3.9"
+    id("com.gradleup.shadow") version "9.3.2"
     id("org.endlessdream.extra.multiplatform-convention")
 }
 
@@ -46,19 +41,22 @@ application {
 }
 
 tasks {
+    jar {
+        dependsOn("generateBuildMetaInfo")
+    }
+    compileTestJava {
+        dependsOn("generateBuildMetaInfo")
+    }
+
     // fat/uber-jar task provided by https://github.com/GradleUp/shadow
     shadowJar {
         dependsOn("generateBuildMetaInfo", "test")
-        val platformProp = System.getProperty("platform")
+
         val archProp = System.getProperty("arch")
-        val archVariant = when (archProp != null) {
-            true -> archProp.plus("-")
-            false -> ""
-        }
-        val classifierPlatform = when (platformProp != null) {
-            true -> platformProp.plus("-").plus(archVariant).plus(libs.versions.endlessdream.get())
-            false -> "".plus(libs.versions.endlessdream.get())
-        }
+        val archVariant = archProp?.let { "$it-" } ?: ""
+        val platformProp = System.getProperty("platform")
+        val endlessDreamVersion = libs.versions.endlessdream.get()
+        val classifierPlatform = platformProp?.let { "$it-$archVariant$endlessDreamVersion"} ?: endlessDreamVersion
 
         destinationDirectory.set(projectDir.resolveSibling("dist"))
         archiveBaseName.set("lr2oraja")
@@ -86,34 +84,27 @@ tasks.test {
     useJUnitPlatform()
 }
 
-// Generate current build's meta info: git commit hash, commit time, etc
+val gitHashProvider = providers.exec {
+    commandLine("git", "rev-parse", "--short", "HEAD")
+}.standardOutput.asText.map { it.trim() }.orElse("unknown")
+
+// Generate current build's meta info: git commit hash, build time, etc
 tasks.register("generateBuildMetaInfo") {
-    val gitHash: String by lazy {
-        try {
-            val stdout = ByteArrayOutputStream()
-            exec {
-                commandLine("git", "rev-parse", "--short", "HEAD")
-                standardOutput = stdout
-            }
-            stdout.toString().trim()
-        } catch (e: Exception) {
-            "unknown"
-        }
-    }
+    inputs.property("gitHash", gitHashProvider)
 
-    val buildTime: String by lazy {
-        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
-        sdf.timeZone = TimeZone.getTimeZone("UTC")
-        sdf.format(Date())
-    }
+    val output = layout.buildDirectory.file("resources/main/resources/build.properties")
+    outputs.file(output)
 
-    var output = file("src/resources/build.properties")
-    output.writeText(
-        """
+    doLast {
+        val outputFile = output.get().asFile
+        outputFile.parentFile.mkdirs()
+        val gitHash = gitHashProvider.get()
+        outputFile.writeText(
+            """
             git_commit=${gitHash}
-            build_time=${buildTime} 
-        """.trimIndent()
-    )
+            """.trimIndent()
+        )
+    }
 }
 
 // versions and bundles defined in ../gradle/libs.versions.toml

--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -262,7 +262,7 @@ public class MainLoader extends Application {
 
 				public void create() {
 					logger.info("Starting {}", Version.versionLong);
-					logger.info("[Build info] Build date: {}, Commit: {}", Version.getBuildDate(), Version.getGitCommitHash());
+					logger.info("[Build info] Commit: {}", Version.getGitCommitHash());
 					main.create();
 					if (displaymode == Config.DisplayMode.FULLSCREEN) {
 						Gdx.graphics.setFullscreenMode(finalGdxDisplayMode);

--- a/core/src/bms/player/beatoraja/Version.java
+++ b/core/src/bms/player/beatoraja/Version.java
@@ -1,16 +1,13 @@
 package bms.player.beatoraja;
 
-import java.io.InputStream;
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Properties;
-import java.util.TimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Properties;
+
 public class Version {
-    private static Logger logger = LoggerFactory.getLogger(Version.class);
+    private static final Logger logger = LoggerFactory.getLogger(Version.class);
     public static final int VERSION_MAJOR = 0;
     public static final int VERSION_MINOR = 5;
     public static final int VERSION_PATCH = 0;
@@ -23,7 +20,7 @@ public class Version {
     public static String getVersion() { return version; }
     public static String getLongVersion() { return versionLong; }
 
-    private static Properties buildMetaInfo = new Properties();
+    private static final Properties buildMetaInfo = new Properties();
 
     static {
         BUILD_TYPE = BuildType.PRERELEASE;
@@ -88,22 +85,6 @@ public class Version {
         return buildMetaInfo.getProperty("git_commit");
     }
 
-    /**
-     * Get the build time of the current build
-     * @return a date represents when it's being built, or null if anything went wrong
-     */
-    public static Date getBuildDate() {
-        try {
-            String buildDate = buildMetaInfo.getProperty("build_time");
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-            return sdf.parse(buildDate);
-        } catch (Exception e) {
-			logger.error("Failed to parse build time: {}", e.getMessage());
-            return null;
-        }
-    }
-
     public enum BuildType {
         PRERELEASE("pre"),
         STABLE("");
@@ -116,7 +97,7 @@ public class Version {
     }
 
     /**
-     * Try loading the build meta data, no exceptions would be thrown
+     * Try loading the build metadata, no exceptions would be thrown
      */
     private static void tryLoadingBuildMetaInfo() {
         try {

--- a/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
+++ b/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
@@ -161,7 +161,6 @@ public class ImGuiRenderer {
                 float axis;
 
                 ImGui.text("Commit hash: " + Version.getGitCommitHash());
-                ImGui.text("Build time: " + Version.getBuildDate());
                 ImGui.text("GLFW version: " + GLFW.glfwGetVersionString());
                 for (Controller con : manager.getControllers()) {
                     ImGui.text("Controller Name: " + con.getName());

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@ org.gradle.configureondemand=true
 org.gradle.logging.level=info
 systemProp.file.encoding=utf-8
 rootProject.name="beatoraja"
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates several dependencies related to the build process, and updates parts of it that were required to change in new versions.

Most importantly, `build_time` property is removed (as discussed internally), and `git_commit` property is generated through a provider, while also being marked as an input of our custom metadata task. It ensures that Gradle can reuse its cache whenever applicable, as it won't be invalidated by the time changing. This will speed up the build in some cases, if one runs on a state of the project that's already cached.

Version updates themselves save about 1 second on both my Windows and Linux setups, although that of course depends on the machine. It's not a lot, but at the very least it doesn't run longer.