### PR TITLE
Improve skin widget debugger

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -158,6 +158,10 @@ dependencies {
     implementation(libs.javawebsocket)
     implementation(libs.bundles.slf4j)
 
+    // runtime-javadoc is split into an annotation processor and a library
+    annotationProcessor(libs.runtime.javadoc.scribe)
+    implementation(libs.runtime.javadoc)
+
     // non-gradle managed file dependencies. jportaudio not on maven. "custom" scares me.
     implementation(":jportaudio")
     implementation(":luaj-jse:3.0.2-custom")

--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -3,6 +3,9 @@ package bms.player.beatoraja;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+
+import bms.player.beatoraja.modmenu.skin.debugger.SkinDebugger;
+import bms.player.beatoraja.modmenu.skin.debugger.SkinWidgetManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -422,6 +425,10 @@ public class MainController {
             ImGuiRenderer.init();
         }
 
+		try (var perf = PerformanceMetrics.get().Event("Skin manual init")) {
+			SkinPropertyManual.init();
+		}
+
         try (var perf = PerformanceMetrics.get().Event("System font load")) {
 			FreeTypeFontGenerator generator = new FreeTypeFontGenerator(Gdx.files.internal(config.getSystemfontpath()));
 			FreeTypeFontParameter parameter = new FreeTypeFontParameter();
@@ -448,6 +455,7 @@ public class MainController {
     	initializeStates();
 		updateStateReferences();
 		MiscSettingMenu.setMain(this);
+		SkinDebugger.init(this);
 		if (bmsfile != null) {
 			if(resource.setBMSFile(bmsfile, auto)) {
 				changeState(MainStateType.PLAY);

--- a/core/src/bms/player/beatoraja/MainState.java
+++ b/core/src/bms/player/beatoraja/MainState.java
@@ -1,7 +1,8 @@
 package bms.player.beatoraja;
 
 import bms.player.beatoraja.SkinConfig.Offset;
-import bms.player.beatoraja.modmenu.SkinWidgetManager;
+import bms.player.beatoraja.modmenu.skin.debugger.SkinDebugger;
+import bms.player.beatoraja.modmenu.skin.debugger.SkinWidgetManager;
 import bms.player.beatoraja.skin.*;
 import bms.player.beatoraja.skin.SkinObject.SkinOffset;
 import bms.player.beatoraja.skin.property.EventFactory.EventType;
@@ -115,9 +116,10 @@ public abstract class MainState {
 		if (this.skin != null) {
 			this.skin.dispose();
 		}
+		beforeSetSkin();
 		this.skin = skin;
 		if (skin != null) {
-			SkinWidgetManager.changeSkin(skin);
+			afterSetSkin(skin);
 			for (IntMap.Entry<Offset> e : skin.getOffset().entries()) {
 				SkinOffset offset = main.getOffset(e.key);
 				if(offset == null || e.value == null) {
@@ -131,6 +133,14 @@ public abstract class MainState {
 				offset.a = e.value.a;
 			}
 		}
+	}
+
+	private void beforeSetSkin() {
+		SkinDebugger.listenBeforeSetSkin();
+	}
+
+	private void afterSetSkin(Skin skin) {
+		SkinDebugger.listenAfterSetSkin(skin);
 	}
 
 	public void loadSkin(SkinType skinType) {

--- a/core/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
+++ b/core/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 
 import bms.player.beatoraja.PlayModeConfig.KeyboardConfig;
 import bms.player.beatoraja.Resolution;
-import bms.player.beatoraja.modmenu.SkinWidgetManager;
+import bms.player.beatoraja.modmenu.skin.debugger.SkinWidgetManager;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.utils.IntArray;

--- a/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
+++ b/core/src/bms/player/beatoraja/modmenu/ImGuiRenderer.java
@@ -3,6 +3,8 @@ package bms.player.beatoraja.modmenu;
 import bms.player.beatoraja.Version;
 import bms.player.beatoraja.controller.Lwjgl3ControllerManager;
 
+import bms.player.beatoraja.modmenu.skin.debugger.SkinDebugger;
+import bms.player.beatoraja.modmenu.skin.debugger.SkinWidgetManager;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
@@ -16,11 +18,9 @@ import imgui.glfw.ImGuiImplGlfw;
 import imgui.type.ImBoolean;
 import org.lwjgl.glfw.GLFW;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 
 
 public class ImGuiRenderer {
@@ -43,9 +43,10 @@ public class ImGuiRenderer {
     private static ImBoolean SHOW_JUDGE_TRAINER = new ImBoolean(false);
     private static ImBoolean SHOW_SONG_MANAGER = new ImBoolean(false);
     private static ImBoolean SHOW_DOWNLOAD_MENU = new ImBoolean(false);
-    private static ImBoolean SHOW_SKIN_WIDGET_MANAGER = new ImBoolean(false);
+    private static ImBoolean SHOW_SKIN_DEBUG_MENU = new ImBoolean(false);
     private static ImBoolean SHOW_PERFORMANCE_MONITOR = new ImBoolean(false);
     private static ImBoolean SHOW_SKIN_MENU = new ImBoolean(false);
+    private static ImBoolean SHOW_SKIN_PROPERTY_MANUAL = new ImBoolean(false);
     private static ImBoolean SHOW_MISC_SETTING = new ImBoolean(false);
 
 
@@ -116,13 +117,14 @@ public class ImGuiRenderer {
             ImGui.checkbox("Show Random Trainer Window", SHOW_RANDOM_TRAINER);
             ImGui.checkbox("Show Judge Trainer Window", SHOW_JUDGE_TRAINER);
             if (ImGui.checkbox("Show Skin Configuration Window", SHOW_SKIN_MENU)) { SkinMenu.invalidate(); }
-            ImGui.checkbox("Show Skin Widget Manager Window", SHOW_SKIN_WIDGET_MANAGER);
+            ImGui.checkbox("Show Skin Debugger Window", SHOW_SKIN_DEBUG_MENU);
             ImGui.checkbox("Show Song Manager Window", SHOW_SONG_MANAGER);
             ImGui.checkbox("Show Download Tasks Window", SHOW_DOWNLOAD_MENU);
             if (ImGui.checkbox("Show Performance Monitor Window", SHOW_PERFORMANCE_MONITOR) &&
                 SHOW_PERFORMANCE_MONITOR.get()) {
                 PerformanceMonitor.reloadEventTree();
             }
+            ImGui.checkbox("Show Skin Property Manual", SHOW_SKIN_PROPERTY_MANUAL);
             ImGui.checkbox("Show Misc Setting Window", SHOW_MISC_SETTING);
 
             if (SHOW_FREQ_PLUS.get()) {
@@ -141,9 +143,8 @@ public class ImGuiRenderer {
             if (SHOW_DOWNLOAD_MENU.get()) {
                 DownloadTaskMenu.show(SHOW_DOWNLOAD_MENU);
             }
-            if (SHOW_SKIN_WIDGET_MANAGER.get()) {
-                SkinWidgetManager.focus = true;
-                SkinWidgetManager.show(SHOW_SKIN_WIDGET_MANAGER);
+            if (SHOW_SKIN_DEBUG_MENU.get()) {
+                SkinDebugger.show(SHOW_SKIN_DEBUG_MENU);
             } else {
                 SkinWidgetManager.focus = false;
             }
@@ -152,6 +153,9 @@ public class ImGuiRenderer {
             }
             if (SHOW_SKIN_MENU.get()) {
                 SkinMenu.show(SHOW_SKIN_MENU);
+            }
+            if (SHOW_SKIN_PROPERTY_MANUAL.get()) {
+                SkinPropertyManual.show(SHOW_SKIN_PROPERTY_MANUAL);
             }
             if (SHOW_MISC_SETTING.get()) {
                 MiscSettingMenu.show(SHOW_MISC_SETTING);

--- a/core/src/bms/player/beatoraja/modmenu/SkinPropertyManual.java
+++ b/core/src/bms/player/beatoraja/modmenu/SkinPropertyManual.java
@@ -1,0 +1,124 @@
+package bms.player.beatoraja.modmenu;
+
+import bms.player.beatoraja.skin.SkinManualEntry;
+import bms.player.beatoraja.skin.SkinProperty.PropertyType;
+import bms.player.beatoraja.skin.lr2.LR2ButtonDef;
+import bms.player.beatoraja.skin.lr2.LR2DestinationOptions;
+import bms.player.beatoraja.skin.lr2.LR2NumberDef;
+import bms.player.beatoraja.skin.lr2.LR2TextDef;
+import bms.player.beatoraja.skin.property.BooleanPropertyFactory;
+import bms.player.beatoraja.skin.property.EventFactory;
+import bms.player.beatoraja.skin.property.FloatPropertyFactory;
+import bms.player.beatoraja.skin.property.StringPropertyFactory;
+import imgui.ImGui;
+import imgui.flag.ImGuiCond;
+import imgui.type.ImBoolean;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static bms.player.beatoraja.modmenu.ImGuiRenderer.windowHeight;
+import static bms.player.beatoraja.modmenu.ImGuiRenderer.windowWidth;
+
+public class SkinPropertyManual {
+	private static final Map<PropertyType, List<SkinManualEntry<?>>> rajaManualEntries = new HashMap<>();
+	private static final Map<PropertyType, List<SkinManualEntry<?>>> lr2ManualEntries = new HashMap<>();
+
+	/**
+	 * Initialize the manual entries, must be called during game startup process
+	 */
+	public static void init() {
+		rajaManualEntries.put(
+				PropertyType.Boolean,
+				Arrays.stream(BooleanPropertyFactory.BooleanType.values())
+						.map(BooleanPropertyFactory.BooleanType::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		rajaManualEntries.put(
+				PropertyType.Event,
+				Arrays.stream(EventFactory.EventType.values())
+						.map(EventFactory.EventType::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		rajaManualEntries.put(
+				PropertyType.Float,
+				Arrays.stream(FloatPropertyFactory.FloatType.values())
+						.map(FloatPropertyFactory.FloatType::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		rajaManualEntries.put(
+				PropertyType.String,
+				Arrays.stream(StringPropertyFactory.StringType.values())
+						.map(StringPropertyFactory.StringType::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		lr2ManualEntries.put(
+				PropertyType.Boolean,
+				Arrays.stream(LR2DestinationOptions.values())
+						.map(LR2DestinationOptions::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		lr2ManualEntries.put(
+				PropertyType.String,
+				Arrays.stream(LR2TextDef.values())
+						.map(LR2TextDef::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		lr2ManualEntries.put(
+				PropertyType.Number,
+				Arrays.stream(LR2NumberDef.values())
+						.map(LR2NumberDef::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+		lr2ManualEntries.put(
+				PropertyType.Button,
+				Arrays.stream(LR2ButtonDef.values())
+						.map(LR2ButtonDef::intoManualEntry)
+						.collect(Collectors.toList())
+		);
+	}
+
+	public static void show(ImBoolean showSkinPropertyManual) {
+		float relativeX = windowWidth * 0.455f;
+		float relativeY = windowHeight * 0.04f;
+		ImGui.setNextWindowPos(relativeX, relativeY, ImGuiCond.FirstUseEver);
+		float textLineHeight = ImGui.getTextLineHeight();
+		ImGui.setNextWindowSizeConstraints(30f, 40f, 30 * textLineHeight, 30 * textLineHeight);
+
+		if (ImGui.begin("Skin Property Manual", showSkinPropertyManual)) {
+			if (ImGui.beginTabBar("##TabBar##SkinPropertyManual")) {
+				if (ImGui.beginTabItem("Endless Dream")) {
+					renderManualEntries(rajaManualEntries);
+					ImGui.endTabItem();
+				}
+				if (ImGui.beginTabItem("LR2")) {
+					renderManualEntries(lr2ManualEntries);
+					ImGui.endTabItem();
+				}
+				ImGui.endTabBar();
+			}
+
+			ImGui.end();
+		}
+	}
+
+	private static void renderManualEntries(Map<PropertyType, List<SkinManualEntry<?>>> entries) {
+		for (PropertyType propertyType : PropertyType.values()) {
+			if (!entries.containsKey(propertyType)) {
+				continue;
+			}
+			if (ImGui.treeNodeEx(propertyType.name())) {
+				entries.get(propertyType).forEach(entry -> {
+					if (ImGui.treeNodeEx(entry.getFullName())) {
+						ImGui.textWrapped(entry.getComment());
+						ImGui.treePop();
+					}
+				});
+				ImGui.treePop();
+			}
+		}
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/CustomChanges.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/CustomChanges.java
@@ -1,0 +1,24 @@
+package bms.player.beatoraja.modmenu.skin.debugger;
+
+import java.util.List;
+
+public class CustomChanges {
+	private String version;
+	private List<PersistedEvent> events;
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public List<PersistedEvent> getEvents() {
+		return events;
+	}
+
+	public void setEvents(List<PersistedEvent> events) {
+		this.events = events;
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/Event.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/Event.java
@@ -1,0 +1,41 @@
+package bms.player.beatoraja.modmenu.skin.debugger;
+
+public abstract class Event<T> {
+	protected EventType type;
+	protected T handle; // reference to the event object
+
+	// NOTE: This is kinda naive, but it works...
+	public enum EventType {
+		// ChangeSingleFieldEvent
+		CHANGE_X,
+		CHANGE_Y,
+		CHANGE_W,
+		CHANGE_H,
+		// ToggleVisibleEvent
+		TOGGLE_VISIBLE;
+
+		public static EventType from(String name) {
+			for (EventType et : EventType.values()) {
+				if (et.name().equalsIgnoreCase(name)) {
+					return et;
+				}
+			}
+			return null;
+		}
+	}
+
+	public Event(EventType type, T handle) {
+		this.type = type;
+		this.handle = handle;
+	}
+
+	public abstract void redo();
+
+	public abstract void undo();
+
+	public abstract String getDescription();
+
+	public abstract String getName();
+
+	public abstract PersistedEvent persist();
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/PersistedEvent.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/PersistedEvent.java
@@ -1,0 +1,99 @@
+package bms.player.beatoraja.modmenu.skin.debugger;
+
+import bms.player.beatoraja.modmenu.ImGuiNotify;
+import bms.player.beatoraja.modmenu.skin.debugger.events.ChangeSingleFieldEvent;
+import bms.player.beatoraja.modmenu.skin.debugger.events.ToggleVisibleEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class PersistedEvent {
+	private static final Logger logger = LoggerFactory.getLogger(PersistedEvent.class);
+	private String version;
+	private String clazz;
+	private String type;
+	private String handleName;
+	private Map<String, Object> payload;
+
+	public PersistedEvent() {
+
+	}
+
+	public PersistedEvent(String version, String clazz, String type, String handleName, Map<String, Object> payload) {
+		this.version = version;
+		this.clazz = clazz;
+		this.type = type;
+		this.handleName = handleName;
+		this.payload = payload;
+	}
+
+	public Event<?> load() {
+		Event.EventType eventType = Event.EventType.from(type);
+		if (eventType == null) {
+			return null;
+		}
+
+		try {
+			return switch (clazz) {
+				case "ChangeSingleFieldEvent" -> new ChangeSingleFieldEvent(eventType, new SkinWidgetDestination(handleName, null, null), getFloat("previous"), getFloat("current"));
+				case "ToggleVisibleEvent" ->  new ToggleVisibleEvent(new SkinWidget(handleName, null, null, null), getBoolean("isVisibleBefore"));
+				default -> null;
+			};
+		} catch (Exception e) {
+			logger.error("Failed to load a persisted event: ", e);
+			ImGuiNotify.error(String.format("Failed to load a persisted event: %s", e.getMessage()));
+		}
+
+		return null;
+	}
+
+	private float getFloat(String key) {
+		Number v = (Number) payload.get(key);
+		return v.floatValue();
+	}
+
+	private boolean getBoolean(String key) {
+		return ((boolean) payload.get(key));
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public String getClazz() {
+		return clazz;
+	}
+
+	public void setClazz(String clazz) {
+		this.clazz = clazz;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public Map<String, Object> getPayload() {
+		return payload;
+	}
+
+	public void setPayload(Map<String, Object> payload) {
+		this.payload = payload;
+	}
+
+	public String getHandleName() {
+		return handleName;
+	}
+
+	public void setHandleName(String handleName) {
+		this.handleName = handleName;
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinDebugger.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinDebugger.java
@@ -1,0 +1,63 @@
+package bms.player.beatoraja.modmenu.skin.debugger;
+
+import bms.player.beatoraja.MainController;
+import bms.player.beatoraja.skin.Skin;
+import bms.player.beatoraja.skin.SkinHeader;
+import imgui.ImGui;
+import imgui.flag.ImGuiWindowFlags;
+import imgui.type.ImBoolean;
+
+/**
+ * Facade of the debugging facility of skins
+ */
+public class SkinDebugger {
+	private static final Object LOCK = new Object();
+	private static int skinType = SkinHeader.TYPE_BEATORJASKIN;
+
+	public static void init(MainController main) {
+		SkinPropertyWatcher.init(main);
+	}
+
+	public static void listenBeforeSetSkin() {
+		SkinOptions.removeCurrentOptions();
+	}
+
+	public static void listenAfterSetSkin(Skin skin) {
+		changeSkin(skin);
+	}
+
+	private static void changeSkin(Skin skin) {
+		synchronized (LOCK) {
+			skinType = skin.header.getType();
+			SkinWidgetManager.changeSkin(skin);
+			SkinOptions.changeSkin(skin);
+		}
+	}
+
+	public static void show(ImBoolean showSkinDebuggerMenu) {
+		synchronized (LOCK) {
+			if (ImGui.begin("Skin Debugger", showSkinDebuggerMenu, ImGuiWindowFlags.AlwaysAutoResize)) {
+				if (ImGui.beginTabBar("##TabBar##Skin Debugger"))	{
+					if (ImGui.beginTabItem("Widgets##Skin Debugger"))	{
+						SkinWidgetManager.render();
+						ImGui.endTabItem();
+					} else {
+						SkinWidgetManager.focus = false;
+					}
+					if (ImGui.beginTabItem("Watcher##Skin Debugger")) {
+						SkinPropertyWatcher.render();
+						ImGui.endTabItem();
+					}
+					if (skinType == SkinHeader.TYPE_LR2SKIN) {
+						if (ImGui.beginTabItem("Options##Skin Debugger")) {
+							SkinOptions.render();
+							ImGui.endTabItem();
+						}
+					}
+					ImGui.endTabBar();
+				}
+			}
+			ImGui.end();
+		}
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinOptions.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinOptions.java
@@ -1,0 +1,200 @@
+package bms.player.beatoraja.modmenu.skin.debugger;
+
+import bms.player.beatoraja.skin.Skin;
+import bms.player.beatoraja.skin.SkinObject;
+import bms.player.beatoraja.skin.lr2.LR2DestinationOptions;
+import bms.player.beatoraja.skin.lr2.LR2NumberDef;
+import bms.player.beatoraja.skin.lr2.LR2TextDef;
+import bms.tool.util.Pair;
+import imgui.ImGui;
+import imgui.ImGuiListClipper;
+import imgui.callback.ImListClipperCallback;
+import imgui.flag.ImGuiTableFlags;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Show current skin's customized options, used internal options and the options that are missing implementation
+ */
+public class SkinOptions {
+	private static final List<Pair<Integer, Integer>> skinOptions = new ArrayList<>();
+	private static final List<Integer> missingOps = new ArrayList<>();
+	private static final List<Integer> missingTextDefinitions = new ArrayList<>();
+	private static final List<Integer> missingNumberDefinitions = new ArrayList<>();
+
+	static void removeCurrentOptions() {
+		skinOptions.clear();
+	}
+
+	static void changeSkin(Skin skin) {
+		SkinObject[] skinObjects = skin.getAllSkinObjects();
+		for (SkinObject skinObject : skinObjects) {
+			int[] dstOp = skinObject.getOption();
+			for (int op : dstOp) {
+				op = Math.abs(op);
+				if (op >= 900 && op <= 999) {
+					continue;
+				}
+				registerMissingOp(op);
+			}
+		}
+
+		skin.getOption().forEach(entry -> skinOptions.add(Pair.of(entry.key, entry.value)));
+		skinOptions.sort(Pair.DEFAULT_COMPARATOR());
+
+		missingOps.sort(Integer::compareTo);
+		missingNumberDefinitions.sort(Integer::compareTo);
+		missingTextDefinitions.sort(Integer::compareTo);
+	}
+
+	public static void registerMissingOp(int value) {
+		if (!missingOps.contains(value)) {
+			missingOps.add(value);
+		}
+	}
+
+	public static void registerMissingTextDefinition(int value) {
+		if (!missingTextDefinitions.contains(value)) {
+			missingTextDefinitions.add(value);
+		}
+	}
+
+	public static void registerMissingNumberDefinition(int value) {
+		if (!missingNumberDefinitions.contains(value)) {
+			missingNumberDefinitions.add(value);
+		}
+	}
+
+	public static void render() {
+		if (ImGui.beginTabBar("##TabBar##Skin Options")) {
+			if (ImGui.beginTabItem("Options##TabItem##Skin Options")) {
+				renderSkinOptions();
+				ImGui.endTabItem();
+			}
+			if (ImGui.beginTabItem("Unimplemented##TabItem##Skin Options")) {
+				renderUnimplementedOptions();
+				ImGui.endTabItem();
+			}
+			ImGui.endTabBar();
+		}
+	}
+
+	private static void renderUnimplementedOptions() {
+		if (ImGui.treeNodeEx("DstOp##MissingNo")) {
+			if (ImGui.beginTable("DstOp##MissingNo##Table", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY, 0, ImGui.getTextLineHeight() * 20)) {
+				ImGui.tableSetupScrollFreeze(0, 1);
+				ImGui.tableSetupColumn("Name");
+				ImGui.tableSetupColumn("Value");
+				ImGui.tableHeadersRow();
+				ImGuiListClipper.forEach(missingOps.size(), new ImListClipperCallback() {
+					@Override
+					public void accept(int row) {
+						ImGui.pushID(row);
+						ImGui.tableNextRow();
+
+						Integer value = missingOps.get(row);
+						ImGui.tableSetColumnIndex(0);
+						LR2DestinationOptions opDef = LR2DestinationOptions.valueOf(value);
+						ImGui.text(opDef != null ? opDef.name() : "ERROR");
+
+						ImGui.tableSetColumnIndex(1);
+						ImGui.text(value.toString());
+						ImGui.popID();
+					}
+				});
+				ImGui.endTable();
+			}
+			ImGui.treePop();
+		}
+		if (ImGui.treeNodeEx("Text##MissingNo")) {
+			if (ImGui.beginTable("Text##MissingNo##Table", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY, 0, ImGui.getTextLineHeight() * 20)) {
+				ImGui.tableSetupScrollFreeze(0, 1);
+				ImGui.tableSetupColumn("Name");
+				ImGui.tableSetupColumn("Value");
+				ImGui.tableHeadersRow();
+				ImGuiListClipper.forEach(missingTextDefinitions.size(), new ImListClipperCallback() {
+					@Override
+					public void accept(int row) {
+						ImGui.pushID(row);
+						ImGui.tableNextRow();
+
+						Integer value = missingTextDefinitions.get(row);
+						ImGui.tableSetColumnIndex(0);
+						LR2TextDef textDef = LR2TextDef.valueOf(value);
+						ImGui.text(textDef != null ? textDef.name() : "ERROR");
+
+						ImGui.tableSetColumnIndex(1);
+						ImGui.text(value.toString());
+						ImGui.popID();
+					}
+				});
+				ImGui.endTable();
+			}
+			ImGui.treePop();
+		}
+		if (ImGui.treeNodeEx("Number##MissingNo")) {
+			if (ImGui.beginTable("Number##MissingNo##Table", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY, 0, ImGui.getTextLineHeight() * 20)) {
+				ImGui.tableSetupScrollFreeze(0, 1);
+				ImGui.tableSetupColumn("Name");
+				ImGui.tableSetupColumn("Value");
+				ImGui.tableHeadersRow();
+				ImGuiListClipper.forEach(missingNumberDefinitions.size(), new ImListClipperCallback() {
+					@Override
+					public void accept(int row) {
+						ImGui.pushID(row);
+						ImGui.tableNextRow();
+
+						Integer value = missingNumberDefinitions.get(row);
+						ImGui.tableSetColumnIndex(0);
+						LR2NumberDef numberDef = LR2NumberDef.valueOf(value);
+						ImGui.text(numberDef != null ? numberDef.name() : "ERROR");
+
+						ImGui.tableSetColumnIndex(1);
+						ImGui.text(value.toString());
+						ImGui.popID();
+					}
+				});
+				ImGui.endTable();
+			}
+			ImGui.treePop();
+		}
+	}
+
+	private static void renderSkinOptions() {
+		if (ImGui.beginTable("Options##SkinOptions", 3, ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY, 0, ImGui.getTextLineHeight() * 20)) {
+			ImGui.tableSetupScrollFreeze(0, 1);
+			ImGui.tableSetupColumn("Name##SkinOptions");
+			ImGui.tableSetupColumn("Op##SkinOptions");
+			ImGui.tableSetupColumn("Value##SkinOptions");
+			ImGui.tableHeadersRow();
+			ImGuiListClipper.forEach(skinOptions.size(), new ImListClipperCallback() {
+				@Override
+				public void accept(int row) {
+					ImGui.pushID(row);
+
+					Pair<Integer, Integer> p = skinOptions.get(row);
+					ImGui.tableNextRow();
+
+					ImGui.tableSetColumnIndex(0);
+					Integer op = p.getFirst();
+					if (op >= 900 && op <= 999) {
+						ImGui.text("-");
+					} else {
+						LR2DestinationOptions dstDef = LR2DestinationOptions.valueOf(op);
+						ImGui.text(dstDef != null ? dstDef.getName() : "ERROR");
+					}
+
+					ImGui.tableSetColumnIndex(1);
+					ImGui.text(op.toString());
+
+					ImGui.tableSetColumnIndex(2);
+					ImGui.text(p.getSecond().toString());
+
+					ImGui.popID();
+				}
+			});
+			ImGui.endTable();
+		}
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinPropertyWatcher.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinPropertyWatcher.java
@@ -57,7 +57,6 @@ public class SkinPropertyWatcher {
 		}
 		ImGui.sameLine();
 		if (ImGui.checkbox("Auto Refresh##SkinPropertyWatcher", autoRefresh)) {
-			// TODO: Implement me!
 			autoRefresh = !autoRefresh;
 		}
 		if (ImGui.beginPopup("Add Skin Property Watcher", ImGuiWindowFlags.AlwaysAutoResize)) {

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinPropertyWatcher.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinPropertyWatcher.java
@@ -1,0 +1,210 @@
+package bms.player.beatoraja.modmenu.skin.debugger;
+
+import bms.player.beatoraja.MainController;
+import bms.player.beatoraja.MainState;
+import bms.player.beatoraja.modmenu.FontAwesomeIcons;
+import bms.player.beatoraja.modmenu.ImGuiNotify;
+import bms.player.beatoraja.skin.SkinProperty;
+import bms.player.beatoraja.skin.property.BooleanPropertyFactory;
+import bms.player.beatoraja.skin.property.FloatPropertyFactory;
+import bms.player.beatoraja.skin.property.IntegerPropertyFactory;
+import bms.player.beatoraja.skin.property.StringPropertyFactory;
+import bms.tool.utils.Either;
+import imgui.ImGui;
+import imgui.ImGuiListClipper;
+import imgui.callback.ImListClipperCallback;
+import imgui.flag.ImGuiComboFlags;
+import imgui.flag.ImGuiTableFlags;
+import imgui.flag.ImGuiWindowFlags;
+import imgui.type.ImString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Skin property watcher
+ */
+public class SkinPropertyWatcher {
+	private static final Logger logger = LoggerFactory.getLogger(SkinPropertyWatcher.class);
+
+	private static final List<Watcher> watchers = new ArrayList<>();
+	private static MainController main;
+	private static final int AUTO_REFRESH_THRESHOLD = 500; // unit: ms
+	private static long lastAutoRefreshTimestamp = 0;
+
+	private static String addingWatcherType = SkinProperty.PropertyType.Boolean.name();
+	private static ImString addingWatcherIdOrName = new ImString(64);
+	private static boolean autoRefresh = false;
+
+	public static void init(MainController main) {
+		SkinPropertyWatcher.main = main;
+	}
+
+	public static void render() {
+		tryAutoRefreshWatchers();
+		if (ImGui.button("Add##SkinPropertyWatcher")) {
+			// NOTE: We don't reset watcher's type here because users are more likely to add
+			//  same type of watchers sequentially
+			addingWatcherIdOrName.set("");
+			ImGui.openPopup("Add Skin Property Watcher");
+		}
+		ImGui.sameLine();
+		if (ImGui.button("Refresh All##SkinPropertyWatcher")) {
+			watchers.forEach(watcher -> watcher.evaluate(main.getCurrentState()));
+		}
+		ImGui.sameLine();
+		if (ImGui.checkbox("Auto Refresh##SkinPropertyWatcher", autoRefresh)) {
+			// TODO: Implement me!
+			autoRefresh = !autoRefresh;
+		}
+		if (ImGui.beginPopup("Add Skin Property Watcher", ImGuiWindowFlags.AlwaysAutoResize)) {
+			if (ImGui.beginCombo("type##SkinPropertyWatcher", addingWatcherType, ImGuiComboFlags.HeightLarge)) {
+				for (SkinProperty.PropertyType propertyType : SkinProperty.PropertyType.values()) {
+					ImGui.pushID(propertyType.name());
+					if (ImGui.selectable(propertyType.name())) {
+						addingWatcherType = propertyType.name();
+					}
+					ImGui.popID();
+				}
+				ImGui.endCombo();
+			}
+			ImGui.inputText("ID/Name", addingWatcherIdOrName);
+			if (ImGui.button("Submit##SkinPropertyWatcher")) {
+				Optional<Watcher> watcher = Watcher.create(
+						SkinProperty.PropertyType.valueOf(addingWatcherType),
+						addingWatcherIdOrName.get(),
+						main.getCurrentState()
+				);
+				if (watcher.isPresent()) {
+					watchers.add(watcher.get());
+				} else {
+					ImGuiNotify.error("No such property");
+				}
+				ImGui.closeCurrentPopup();
+			}
+			ImGui.endPopup();
+		}
+		if (ImGui.beginTable("Watchers", 4, ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY, 0, ImGui.getTextLineHeight() * 20)) {
+			ImGui.tableSetupScrollFreeze(0, 1);
+			ImGui.tableSetupColumn("Type");
+			ImGui.tableSetupColumn("Symbol");
+			ImGui.tableSetupColumn("Value");
+			ImGui.tableSetupColumn("Op");
+			ImGui.tableHeadersRow();
+			ImGuiListClipper.forEach(watchers.size(), new ImListClipperCallback() {
+				@Override
+				public void accept(int row) {
+					ImGui.pushID(row);
+
+					ImGui.tableNextRow();
+					Watcher watcher = watchers.get(row);
+
+					ImGui.tableNextColumn();
+					ImGui.text(watcher.type.name());
+
+					ImGui.tableNextColumn();
+					ImGui.text(String.valueOf(watcher.getSymbol()));
+
+					ImGui.tableNextColumn();
+					ImGui.text(watcher.value);
+
+					ImGui.tableNextColumn();
+					if (ImGui.button(FontAwesomeIcons.Redo)) {
+						watcher.evaluate(main.getCurrentState());
+					}
+					ImGui.sameLine();
+					// TODO: Is unsafe to remove the element inside an iteration
+					if (ImGui.button(FontAwesomeIcons.WindowClose)) {
+						watchers.remove(watcher);
+					}
+
+					ImGui.popID();
+				}
+			});
+			ImGui.endTable();
+		}
+	}
+
+	private static void tryAutoRefreshWatchers() {
+		long current = System.currentTimeMillis();
+		if (lastAutoRefreshTimestamp == 0 || current - lastAutoRefreshTimestamp > AUTO_REFRESH_THRESHOLD) {
+			watchers.forEach(watcher -> watcher.evaluate(main.getCurrentState()));
+			lastAutoRefreshTimestamp = current;
+		}
+	}
+
+	private static class Watcher {
+		private final SkinProperty.PropertyType type;
+		private final Either<Integer, String> idOrName;
+		private String value;
+
+		/**
+		 * Create a watcher, which initial value is evaluated by current 'state'
+		 *
+		 * @param type  the watching property's type
+		 * @param input skin property's id or name
+		 * @param state current game state
+		 * @return empty when property doesn't exist
+		 */
+		public static Optional<Watcher> create(SkinProperty.PropertyType type, String input, MainState state) {
+			Either<Integer, String> idOrName = Either.parseInteger(input);
+			Optional<String> evaluated = Either.unwrap(idOrName.apply(
+					id -> evaluate(id, type, state),
+					name -> evaluate(name, type, state)
+			));
+			return evaluated.map(value -> new Watcher(type, idOrName, value));
+		}
+
+		/**
+		 * Evaluate the watching property
+		 *
+		 * @implNote If a watcher is ever created, it's not possible that it doesn't be connected
+		 * to a skin property, so we should be safe to unwrap the optional returned by 'evaluate'
+		 */
+		public void evaluate(MainState state) {
+			this.value = Either.unwrap(idOrName.apply(
+					id -> evaluate(id, type, state),
+					name -> evaluate(name, type, state)
+			)).orElse("[!] Failed to evaluate");
+		}
+
+		public String getSymbol() {
+			return idOrName.isLeft() ? String.valueOf(idOrName.getLeft()) : idOrName.getRight();
+		}
+
+		private Watcher(SkinProperty.PropertyType type, Either<Integer, String> idOrName, String value) {
+			this.type = type;
+			this.idOrName = idOrName;
+			this.value = value;
+		}
+
+		private static Optional<String> evaluate(int id, SkinProperty.PropertyType type, MainState state) {
+			return switch (type) {
+				case Boolean -> Optional.ofNullable(BooleanPropertyFactory.getBooleanProperty(id))
+						.map(booleanProperty -> String.valueOf(booleanProperty.get(state)));
+				case Float -> Optional.ofNullable(FloatPropertyFactory.getFloatProperty(id))
+						.map(floatProperty -> String.valueOf(floatProperty.get(state)));
+				case Integer -> Optional.ofNullable(IntegerPropertyFactory.getIntegerProperty(id))
+						.map(integerProperty -> String.valueOf(integerProperty.get(state)));
+				case String -> Optional.ofNullable(StringPropertyFactory.getStringProperty(id))
+						.map(stringProperty -> String.valueOf(stringProperty.get(state)));
+				default -> Optional.empty();
+			};
+		}
+
+		private static Optional<String> evaluate(String name, SkinProperty.PropertyType type, MainState state) {
+			return switch (type) {
+				case Float -> Optional.ofNullable(FloatPropertyFactory.getFloatProperty(name))
+						.map(floatProperty -> String.valueOf(floatProperty.get(state)));
+				case Integer -> Optional.ofNullable(IntegerPropertyFactory.getIntegerProperty(name))
+						.map(integerProperty -> String.valueOf(integerProperty.get(state)));
+				case String -> Optional.ofNullable(StringPropertyFactory.getStringProperty(name))
+						.map(stringProperty -> String.valueOf(stringProperty.get(state)));
+				default -> Optional.empty();
+			};
+		}
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidget.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidget.java
@@ -1,0 +1,43 @@
+package bms.player.beatoraja.modmenu.skin.debugger;
+
+import bms.player.beatoraja.modmenu.skin.debugger.events.ToggleVisibleEvent;
+import bms.player.beatoraja.skin.SkinObject;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * A simple wrapper class of SkinObject
+ *
+ * @implNote setter functions must provide an extra argument to not trigger event system
+ */
+public class SkinWidget {
+	public final String name;
+	public final List<SkinWidgetDestination> destinations;
+
+	private final SkinObject skinObject;
+	private final Consumer<Event<?>> pushupEvent;
+
+	public SkinWidget(String name, SkinObject skinObject, List<SkinWidgetDestination> destinations,  Consumer<Event<?>> pushupEvent) {
+		this.name = name;
+		this.skinObject = skinObject;
+		this.destinations = destinations;
+		this.pushupEvent = pushupEvent;
+	}
+
+	public boolean isDrawingOnScreen() {
+		return skinObject.draw && skinObject.visible;
+	}
+
+	public void toggleVisible() {
+		toggleVisible(true);
+	}
+
+	public void toggleVisible(boolean createEvent) {
+		boolean isVisibleBefore = skinObject.visible;
+		if (createEvent) {
+			pushupEvent.accept(new ToggleVisibleEvent(this, isVisibleBefore));
+		}
+		skinObject.visible = !isVisibleBefore;
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidgetDestination.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidgetDestination.java
@@ -1,0 +1,126 @@
+package bms.player.beatoraja.modmenu.skin.debugger;
+
+import bms.player.beatoraja.modmenu.ImGuiNotify;
+import bms.player.beatoraja.modmenu.skin.debugger.events.ChangeSingleFieldEvent;
+import bms.player.beatoraja.skin.SkinObject;
+
+import java.util.function.Consumer;
+
+/**
+ * A simple wrapper class of SkinObject.SkinObjectDestination
+ *
+ * @implNote setter functions must provide an extra argument to not trigger event system
+ */
+public class SkinWidgetDestination {
+	private static final double eps = 1e-5;
+
+	public final String name;
+	public SkinObject.SkinObjectDestination beforeMove = null;
+	/**
+	 * <ul>
+	 *     <li>0: haven't started moving</li>
+	 *     <li>1: user enabled the move feature, but hasn't move around</li>
+	 *     <li>2: user has moved the widget</li>
+	 * </ul>
+	 */
+	public int movingState;
+
+	private final SkinObject.SkinObjectDestination destination;
+	private final Consumer<Event<?>> pushupEvent;
+
+	public SkinWidgetDestination(String name, SkinObject.SkinObjectDestination destination, Consumer<Event<?>> pushupEvent) {
+		this.name = name;
+		this.destination = destination;
+		this.movingState = 0;
+		this.pushupEvent = pushupEvent;
+	}
+
+	public float getDstX() {
+		return destination.region.x;
+	}
+
+	public float getDstY() {
+		return destination.region.y;
+	}
+
+	public float getDstW() {
+		return destination.region.width;
+	}
+
+	public float getDstH() {
+		return destination.region.height;
+	}
+
+	public void setDstX(float x) {
+		setDstX(x, true);
+	}
+
+	public void setDstX(float x, boolean createEvent) {
+		float previous = this.getDstX();
+		if (createEvent && Math.abs(x - previous) > eps) {
+			pushupEvent.accept(new ChangeSingleFieldEvent(Event.EventType.CHANGE_X, this, previous, x));
+		}
+		destination.region.x = x;
+	}
+
+	public void setDstY(float y) {
+		setDstY(y, true);
+	}
+
+	public void setDstY(float y, boolean createEvent) {
+		float previous = this.getDstY();
+		if (createEvent && Math.abs(y - previous) > eps) {
+			pushupEvent.accept(new ChangeSingleFieldEvent(Event.EventType.CHANGE_Y, this, previous, y));
+		}
+		destination.region.y = y;
+	}
+
+	public void setDstW(float w) {
+		setDstW(w, true);
+	}
+
+	public void setDstW(float w, boolean createEvent) {
+		float previous = this.getDstW();
+		if (createEvent && Math.abs(w - previous) > eps) {
+			pushupEvent.accept(new ChangeSingleFieldEvent(Event.EventType.CHANGE_W, this, previous, w));
+		}
+		destination.region.width = w;
+	}
+
+	public void setDstH(float h) {
+		setDstH(h, true);
+	}
+
+	public void setDstH(float h, boolean createEvent) {
+		float previous = this.getDstH();
+		if (createEvent && Math.abs(h - previous) > eps) {
+			pushupEvent.accept(new ChangeSingleFieldEvent(Event.EventType.CHANGE_H, this, previous, h));
+		}
+		destination.region.height = h;
+	}
+
+	/**
+	 * Submit the move result, producing the event
+	 */
+	public void submitMovement() {
+		if (beforeMove == null) {
+			ImGuiNotify.error("Cannot submit the move result because there's no original position");
+			return;
+		}
+		float nextX = getDstX();
+		float nextY = getDstY();
+		float nextW = getDstW();
+		float nextH = getDstH();
+		// Reset the position, to mimic that we are never left the original position
+		setDstX(beforeMove.region.x, false);
+		setDstY(beforeMove.region.y, false);
+		setDstW(beforeMove.region.width, false);
+		setDstH(beforeMove.region.height, false);
+		// Truly move to the target position
+		setDstX(nextX);
+		setDstY(nextY);
+		setDstW(nextW);
+		setDstH(nextH);
+		beforeMove = null;
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidgetManager.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidgetManager.java
@@ -98,7 +98,7 @@ public class SkinWidgetManager {
         }
         if (ImGui.beginTabBar("SkinWidgetsTabBar")) {
             if (ImGui.beginTabItem("Instances##SkinWidgetManager")) {
-                if (ImGui.button("undo")) {
+                if (ImGui.button("Undo##SkinWidgetManager")) {
                     eventHistory.undo();
                 }
                 ImGui.sameLine();
@@ -108,6 +108,13 @@ public class SkinWidgetManager {
                 ImGui.endTabItem();
             }
             if (ImGui.beginTabItem("History##SkinWidgetManager")) {
+                if (ImGui.button("Undo##SkinWidgetManager")) {
+                    eventHistory.undo();
+                }
+                ImGui.sameLine();
+                if (ImGui.button("Squash##SkinWidgetManager")) {
+                    eventHistory.squash();
+                }
                 renderHistoryTable();
                 ImGui.endTabItem();
             }
@@ -235,7 +242,7 @@ public class SkinWidgetManager {
                 }
 
                 ImGui.tableSetColumnIndex(colSize - 1);
-                if (ImGui.button("Toggle")) {
+                if (ImGui.button("Toggle##SkinWidgetManager")) {
                     widget.toggleVisible();
                 }
 
@@ -755,6 +762,7 @@ public class SkinWidgetManager {
      *     <li> Push one event </li>
      *     <li> Pop most recent events</li>
      *     <li> Query specified widget has specific event or not </li>
+     *     <li> Squash all stored events </li>
      * </ul>
      *
      * @apiNote Requires lock
@@ -824,6 +832,39 @@ public class SkinWidgetManager {
                 targetNameToEvents.putIfAbsent(event.getName(), new ArrayList<>());
                 targetNameToEvents.get(event.getName()).add(event);
             }
+        }
+
+        private void squash() {
+            List<Event<?>> hand = new ArrayList<>();
+            eventStack.forEach(event -> {
+                if (hand.isEmpty()) {
+                    hand.add(event);
+                    return ;
+                }
+
+                if (event instanceof ToggleVisibleEvent) {
+                    boolean isolated = true;
+                    for (Event<?> e_ : hand) {
+                        if (e_ instanceof ToggleVisibleEvent && e_.handle.equals(event.handle)) {
+                            hand.remove(e_);
+                            isolated = false;
+                            break;
+                        }
+                    }
+                    if (isolated) {
+                        hand.add(event);
+                    }
+                } else if (event instanceof ChangeSingleFieldEvent) {
+                    List<Event<?>> shouldBeRemoved = hand.stream().filter(e_ -> e_ instanceof ChangeSingleFieldEvent && e_.handle.equals(event.handle) && e_.type == event.type).toList();
+                    if (!shouldBeRemoved.isEmpty()) {
+                        hand.removeAll(shouldBeRemoved);
+                    }
+                    hand.add(event);
+                }
+            });
+
+            clear();
+            hand.forEach(this::pushEvent);
         }
     }
 }

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidgetManager.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidgetManager.java
@@ -1,7 +1,11 @@
-package bms.player.beatoraja.modmenu;
+package bms.player.beatoraja.modmenu.skin.debugger;
 
+import bms.player.beatoraja.modmenu.FontAwesomeIcons;
+import bms.player.beatoraja.modmenu.ImGuiNotify;
+import bms.player.beatoraja.play.SkinJudge;
 import bms.player.beatoraja.skin.Skin;
 import bms.player.beatoraja.skin.SkinObject;
+import bms.tool.util.Pair;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Clipboard;
 import com.badlogic.gdx.math.Rectangle;
@@ -11,26 +15,29 @@ import imgui.ImGuiListClipper;
 import imgui.ImVec2;
 import imgui.callback.ImListClipperCallback;
 import imgui.flag.ImGuiCol;
+import imgui.flag.ImGuiInputTextFlags;
 import imgui.flag.ImGuiTableFlags;
 import imgui.flag.ImGuiWindowFlags;
 import imgui.type.ImBoolean;
 import imgui.type.ImFloat;
+import imgui.type.ImString;
 
 import java.text.DecimalFormat;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
+import static bms.player.beatoraja.modmenu.ImGuiRenderer.helpMarker;
 import static bms.player.beatoraja.modmenu.ImGuiRenderer.windowHeight;
 
+/**
+ * Debug menu for controlling the widgets in current skin
+ */
 public class SkinWidgetManager {
     private static final double eps = 1e-5;
-    private static final Object LOCK = new Object();
     private static final EventHistory eventHistory = new EventHistory();
     private static final List<SkinWidget> widgets = new ArrayList<>();
-
     private static final List<WidgetTableColumn> WIDGET_TABLE_COLUMNS = new ArrayList<>();
+    private static final List<Pair<String, String>> removedObjects = new ArrayList<>();
 
     static {
         WIDGET_TABLE_COLUMNS.add(new WidgetTableColumn("ID", new ImBoolean(true), true, null, null));
@@ -40,6 +47,9 @@ public class SkinWidgetManager {
         WIDGET_TABLE_COLUMNS.add(new WidgetTableColumn("h", new ImBoolean(true), false, SkinWidgetDestination::getDstH, Event.EventType.CHANGE_H));
         WIDGET_TABLE_COLUMNS.add(new WidgetTableColumn("Operation", new ImBoolean(true), true, null, null));
     }
+
+    private static boolean enableFilteringWidgets = false;
+    private static final ImString searchWidgetName = new ImString(128);
 
     private static final ImFloat editingWidgetX = new ImFloat(0);
     private static final ImFloat editingWidgetY = new ImFloat(0);
@@ -52,86 +62,85 @@ public class SkinWidgetManager {
 
     public static boolean focus = false;
 
-    public static void changeSkin(Skin skin) {
-        synchronized (LOCK) {
-            widgets.clear();
-            eventHistory.clear();
-            if (skin == null) {
-                return ;
+    static void changeSkin(Skin skin) {
+        widgets.clear();
+        eventHistory.clear();
+        if (skin == null) {
+            return;
+        }
+        SkinObject[] allSkinObjects = skin.getAllSkinObjects();
+        // NOTE: We're using skin object's name as id, we need to keep name is unique
+        Map<String, Integer> duplicatedSkinObjectNameCount = new HashMap<>();
+        for (SkinObject skinObject : allSkinObjects) {
+            if (skinObject instanceof SkinJudge skinJudge) {
+                // Support 2P? Currently don't have to
+                registerSkinObject(skinJudge.getJudge(0), duplicatedSkinObjectNameCount);
+                registerSkinObject(skinJudge.getJudgeCount(0), duplicatedSkinObjectNameCount);
+            } else {
+                registerSkinObject(skinObject, duplicatedSkinObjectNameCount);
             }
-            SkinObject[] allSkinObjects = skin.getAllSkinObjects();
-            // NOTE: We're using skin object's name as id, we need to keep name is unique
-            Map<String, Integer> duplicatedSkinObjectNameCount = new HashMap<>();
-            for (SkinObject skinObject : allSkinObjects) {
-                String skinObjectName = skinObject.getName();
-                SkinObject.SkinObjectDestination[] dsts = skinObject.getAllDestination();
-                List<SkinWidgetDestination> destinations = new ArrayList<>();
-                for (int i = 0; i < dsts.length; ++i) {
-                    String dstBaseName = skinObjectName == null ? "Unnamed Destination" : skinObjectName;
-                    String combinedName = dsts.length == 1 ? dstBaseName : String.format("%s(%d)", dstBaseName, i);
-                    destinations.add(new SkinWidgetDestination(combinedName, dsts[i]));
-                }
-                String widgetBaseName = skinObjectName == null ? "Unnamed Widget" : skinObjectName;
-                Integer count = duplicatedSkinObjectNameCount.getOrDefault(widgetBaseName, 0);
-                duplicatedSkinObjectNameCount.compute(widgetBaseName, (pk, pv) -> pv == null ? 1 : pv + 1);
-                String widgetName = count == 0 ? widgetBaseName : String.format("%s(%d)", widgetBaseName, count);
-                widgets.add(new SkinWidget(widgetName, skinObject, destinations));
-            }
+        }
+        widgets.sort(Comparator.comparing(widget -> widget.name));
+    }
+
+    public static void registerRemovedObject(String name, String reason) {
+        String safeName = name == null ? "No name" : name;
+        if (!removedObjects.stream().anyMatch(p -> p.getFirst().equals(name))) {
+            removedObjects.add(Pair.of(safeName, reason));
         }
     }
 
-    public static void show(ImBoolean showSkinWidgetManagerMenu) {
-        synchronized (LOCK) {
-            if (ImGui.begin("Skin Widgets", showSkinWidgetManagerMenu, ImGuiWindowFlags.AlwaysAutoResize)) {
-                if (widgets.isEmpty()) {
-                    ImGui.text("No skin is loaded");
-                } else {
-                    if (ImGui.beginTabBar("SkinWidgetsTabBar")) {
-                        if (ImGui.beginTabItem("SkinWidgets")) {
-                            if (ImGui.button("undo")) {
-                                eventHistory.undo();
-                            }
-                            ImGui.sameLine();
-                            renderPreferColumnSetting();
-                            ImGui.sameLine();
-                            ImGui.checkbox("Show Position", SHOW_CURSOR_POSITION);
-                            ImGui.sameLine();
-                            if (ImGui.button("export")) {
-                                exportChanges();
-                            }
-
-
-                            renderSkinWidgetsTable();
-                            ImGui.endTabItem();
-                        }
-                        if (ImGui.beginTabItem("History")) {
-                            renderHistoryTable();
-                            ImGui.endTabItem();
-                        }
-                        ImGui.endTabBar();
-                    }
-                    // Overlay cursor position
-                    if (SHOW_CURSOR_POSITION.get()) {
-                        ImGui.beginTooltip();
-                        ImGui.text(
-                                String.format("(%s, %s)",
-                                normalizeFloat(Gdx.input.getX()),
-                                normalizeFloat(windowHeight - Gdx.input.getY()))
-                        );
-                        ImGui.endTooltip();
-                    }
+    public static void render() {
+        SkinWidgetManager.focus = true;
+        if (widgets.isEmpty()) {
+            ImGui.text("No skin is loaded");
+            return;
+        }
+        if (ImGui.beginTabBar("SkinWidgetsTabBar")) {
+            if (ImGui.beginTabItem("Instances##SkinWidgetManager")) {
+                if (ImGui.button("undo")) {
+                    eventHistory.undo();
                 }
+                ImGui.sameLine();
+                renderFilterOptions();
+
+                renderSkinWidgetsTable();
+                ImGui.endTabItem();
             }
-            ImGui.end();
+            if (ImGui.beginTabItem("History##SkinWidgetManager")) {
+                renderHistoryTable();
+                ImGui.endTabItem();
+            }
+            if (ImGui.beginTabItem("Removed Objects##SkinWidgetManager")) {
+                renderRemovedObjects();
+                ImGui.endTabItem();
+            }
+            if (ImGui.beginTabItem("Settings##SkinWidgetManager")) {
+                renderSettings();
+                ImGui.endTabItem();
+            }
+
+            ImGui.endTabBar();
+        }
+
+        // Overlay cursor position
+        if (SHOW_CURSOR_POSITION.get()) {
+            ImGui.beginTooltip();
+            ImGui.text(
+                    String.format("(%s, %s)",
+                            normalizeFloat(Gdx.input.getX()),
+                            normalizeFloat(windowHeight - Gdx.input.getY()))
+            );
+            ImGui.endTooltip();
         }
     }
 
-    private static void renderPreferColumnSetting() {
-        if (ImGui.button("Columns")) {
-            ImGui.openPopup("PreferColumnSetting");
+    private static void renderSettings() {
+        ImGui.checkbox("Show cursor position", SHOW_CURSOR_POSITION);
+        if (ImGui.button("Configure Columns##SkinWidgetManager")) {
+            ImGui.openPopup("PreferColumnSettings##SkinWidgetManager");
         }
-
-        if (ImGui.beginPopup("PreferColumnSetting")) {
+        if (ImGui.beginPopup("PreferColumnSettings##SkinWidgetManager")) {
             for (WidgetTableColumn column : WIDGET_TABLE_COLUMNS) {
                 if (column.persistent) {
                     continue;
@@ -139,6 +148,56 @@ public class SkinWidgetManager {
                 ImGui.checkbox(column.name, column.show);
             }
             ImGui.endPopup();
+        }
+        if (ImGui.button("Export##SkinWidgetManager")) {
+            exportChanges();
+        }
+    }
+
+    private static void registerSkinObject(SkinObject skinObject, Map<String, Integer> duplicatedSkinObjectNameCount) {
+        String skinObjectName = skinObject.getName();
+
+        SkinObject.SkinObjectDestination[] dsts = skinObject.getAllDestination();
+        List<SkinWidgetDestination> destinations = new ArrayList<>();
+        for (int i = 0; i < dsts.length; ++i) {
+            String dstBaseName = skinObjectName == null ? "Unnamed Destination" : skinObjectName;
+            String combinedName = dsts.length == 1 ? dstBaseName : String.format("%s(%d)", dstBaseName, i);
+            destinations.add(new SkinWidgetDestination(combinedName, dsts[i]));
+        }
+
+        String widgetBaseName = skinObjectName == null ? "Unnamed Widget" : skinObjectName;
+        Integer count = duplicatedSkinObjectNameCount.getOrDefault(widgetBaseName, 0);
+        duplicatedSkinObjectNameCount.compute(widgetBaseName, (pk, pv) -> pv == null ? 1 : pv + 1);
+        String widgetName = count == 0 ? widgetBaseName : String.format("%s(%d)", widgetBaseName, count);
+        widgets.add(new SkinWidget(widgetName, skinObject, destinations));
+    }
+
+    private static void renderFilterOptions() {
+        if (ImGui.button("Filter Options##SkinWidgetManager")) {
+            ImGui.openPopup("Filter Options Popup##SkinWidgetManager");
+        }
+
+        if (ImGui.beginPopup("Filter Options Popup##SkinWidgetManager")) {
+            if (ImGui.checkbox("Enable Filtering##SkinWidgetManager", enableFilteringWidgets)) {
+                enableFilteringWidgets = !enableFilteringWidgets;
+            }
+            if (ImGui.inputText("Widget Name##FilterOptions", searchWidgetName, ImGuiInputTextFlags.EnterReturnsTrue)) {
+                if (!enableFilteringWidgets) {
+                    enableFilteringWidgets = true;
+                }
+                ImGui.closeCurrentPopup();
+            }
+            helpMarker("Press enter in input box to submit your search string");
+            ImGui.endPopup();
+        }
+
+        if (enableFilteringWidgets) {
+            ImGui.sameLine();
+            ImGui.pushStyleColor(ImGuiCol.Text, ImColor.rgb("#FFFF66"));
+            ImGui.text(FontAwesomeIcons.Search);
+            ImGui.sameLine();
+            ImGui.text("Filtering");
+            ImGui.popStyleColor();
         }
     }
 
@@ -153,7 +212,10 @@ public class SkinWidgetManager {
             ImGui.tableSetupScrollFreeze(0, 1);
             showingColumns.forEach(column -> ImGui.tableSetupColumn(column.name));
             ImGui.tableHeadersRow();
-            for (SkinWidget widget : widgets) {
+            List<SkinWidget> showingWidgets = !enableFilteringWidgets
+                    ? widgets
+                    : widgets.stream().filter(widget -> widget.name.contains(searchWidgetName.get())).toList();
+            for (SkinWidget widget : showingWidgets) {
                 ImGui.tableNextRow();
                 ImGui.pushID(widget.name);
 
@@ -177,6 +239,18 @@ public class SkinWidgetManager {
                     widget.toggleVisible();
                 }
 
+                if (!isWidgetDrawingOnScreen) {
+                    ImGui.sameLine();
+                    if (ImGui.button("Reason")) {
+                        ImGui.openPopup("Reason##SkinWidgetManager");
+                    }
+                    if (ImGui.beginPopup("Reason##SkinWidgetManager")) {
+                        ImGui.text(removedObjects.stream().filter(obj -> obj.getFirst().equals(widget.name)).findAny().map(Pair::getSecond).orElse("ERROR"));
+                        ImGui.endPopup();
+                    }
+                }
+
+
                 if (isOpen) {
                     for (SkinWidgetDestination dst : widget.destinations) {
                         ImGui.pushID(dst.name);
@@ -195,13 +269,13 @@ public class SkinWidgetManager {
                         // If you want to implement a dynamic system, you can combine the event type & getter
                         // in a pair type: Pair<EventType, Function<SkinWidget, Float>
                         // The remaining things are trivial
-                        for (int i = 1; i <= colSize - 2;++i) {
+                        for (int i = 1; i <= colSize - 2; ++i) {
                             WidgetTableColumn column = showingColumns.get(i);
                             drawFloatValueColumn(i, eventHistory.hasEvent(dst.name, column.changeEventType), column.getter.apply(dst));
                         }
 
                         ImGui.tableSetColumnIndex(colSize - 1);
-                        if (ImGui.button("Edit")) {
+                        if (ImGui.button("Edit##SkinWidgetManager")) {
                             editingWidgetX.set(dst.getDstX());
                             editingWidgetY.set(dst.getDstY());
                             editingWidgetW.set(dst.getDstW());
@@ -214,7 +288,7 @@ public class SkinWidgetManager {
                             ImGui.inputFloat("y", editingWidgetY);
                             ImGui.inputFloat("w", editingWidgetW);
                             ImGui.inputFloat("h", editingWidgetH);
-                            if (ImGui.button("Submit")) {
+                            if (ImGui.button("Submit##SkinWidgetManager")) {
                                 dst.setDstX(editingWidgetX.get());
                                 dst.setDstY(editingWidgetY.get());
                                 dst.setDstW(editingWidgetW.get());
@@ -223,8 +297,8 @@ public class SkinWidgetManager {
                             }
 
                             if ((ImGui.checkbox("Move", move_overlay_enabled)
-                                 && move_overlay_enabled.get())
-                                || reset_move_overlay) {
+                                    && move_overlay_enabled.get())
+                                    || reset_move_overlay) {
                                 float w = dst.getDstW();
                                 float h = dst.getDstH();
                                 float x = dst.getDstX();
@@ -245,8 +319,8 @@ public class SkinWidgetManager {
                                 ImGui.pushStyleColor(ImGuiCol.ResizeGrip, 1.f, .3f, .3f, 1.f);
                                 ImGui.pushStyleColor(ImGuiCol.ResizeGripHovered, 1.f, 0.7f, .7f, 1.f);
                                 if (ImGui.begin("widget-overlay-popup",
-                                                move_overlay_enabled,
-                                                ImGuiWindowFlags.NoNav |
+                                        move_overlay_enabled,
+                                        ImGuiWindowFlags.NoNav |
                                                 ImGuiWindowFlags.NoBringToFrontOnFocus | ImGuiWindowFlags.NoFocusOnAppearing |
                                                 ImGuiWindowFlags.NoSavedSettings | ImGuiWindowFlags.NoCollapse |
                                                 ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoTitleBar)) {
@@ -331,12 +405,37 @@ public class SkinWidgetManager {
         }
     }
 
+    private static void renderRemovedObjects() {
+        if (ImGui.beginTable("RemovedObjects##Table", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.ScrollY, 0, ImGui.getTextLineHeight() * 20)) {
+            ImGui.tableSetupScrollFreeze(0, 1);
+            ImGui.tableSetupColumn("Name");
+            ImGui.tableSetupColumn("Reason");
+            ImGui.tableHeadersRow();
+            ImGuiListClipper.forEach(removedObjects.size(), new ImListClipperCallback() {
+                @Override
+                public void accept(int row) {
+                    ImGui.pushID(row);
+                    ImGui.tableNextRow();
+
+                    Pair<String, String> p = removedObjects.get(row);
+                    ImGui.tableSetColumnIndex(0);
+                    ImGui.text(p.getFirst());
+
+                    ImGui.tableSetColumnIndex(1);
+                    ImGui.text(p.getSecond());
+                    ImGui.popID();
+                }
+            });
+            ImGui.endTable();
+        }
+    }
+
     /**
      * This is a small helper function to draw columns in table, draw red text if the cell value has been modified
      *
-     * @param index column index
+     * @param index    column index
      * @param modified whether current cell's value has been modified
-     * @param value cell value
+     * @param value    cell value
      */
     private static void drawFloatValueColumn(int index, boolean modified, float value) {
         ImGui.tableSetColumnIndex(index);
@@ -364,7 +463,7 @@ public class SkinWidgetManager {
                     }
                 }
                 if (!(hasChangedX || hasChangedY || hasChangedW || hasChangedH)) {
-                    return ;
+                    return;
                 }
                 StringBuilder sb = new StringBuilder("{dst=").append(dst.name);
                 if (hasChangedX) {
@@ -400,7 +499,8 @@ public class SkinWidgetManager {
     /**
      * Represents one widget table's column
      */
-    private record WidgetTableColumn(String name, ImBoolean show, boolean persistent, Function<SkinWidgetDestination, Float> getter, Event.EventType changeEventType) {
+    private record WidgetTableColumn(String name, ImBoolean show, boolean persistent,
+                                     Function<SkinWidgetDestination, Float> getter, Event.EventType changeEventType) {
     }
 
     /**
@@ -531,7 +631,7 @@ public class SkinWidgetManager {
         public void submitMovement() {
             if (beforeMove == null) {
                 ImGuiNotify.error("Cannot submit the move result because there's no original position");
-                return ;
+                return;
             }
             float nextX = getDstX();
             float nextY = getDstY();

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidgetManager.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/SkinWidgetManager.java
@@ -2,6 +2,8 @@ package bms.player.beatoraja.modmenu.skin.debugger;
 
 import bms.player.beatoraja.modmenu.FontAwesomeIcons;
 import bms.player.beatoraja.modmenu.ImGuiNotify;
+import bms.player.beatoraja.modmenu.skin.debugger.events.ChangeSingleFieldEvent;
+import bms.player.beatoraja.modmenu.skin.debugger.events.ToggleVisibleEvent;
 import bms.player.beatoraja.play.SkinJudge;
 import bms.player.beatoraja.skin.Skin;
 import bms.player.beatoraja.skin.SkinObject;
@@ -9,6 +11,7 @@ import bms.tool.util.Pair;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Clipboard;
 import com.badlogic.gdx.math.Rectangle;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import imgui.ImColor;
 import imgui.ImGui;
 import imgui.ImGuiListClipper;
@@ -21,10 +24,14 @@ import imgui.flag.ImGuiWindowFlags;
 import imgui.type.ImBoolean;
 import imgui.type.ImFloat;
 import imgui.type.ImString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static bms.player.beatoraja.modmenu.ImGuiRenderer.helpMarker;
 import static bms.player.beatoraja.modmenu.ImGuiRenderer.windowHeight;
@@ -33,11 +40,14 @@ import static bms.player.beatoraja.modmenu.ImGuiRenderer.windowHeight;
  * Debug menu for controlling the widgets in current skin
  */
 public class SkinWidgetManager {
-    private static final double eps = 1e-5;
-    private static final EventHistory eventHistory = new EventHistory();
+    private static final Logger logger = LoggerFactory.getLogger(SkinWidgetManager.class);
+    private static final Map<String, EventHistory> eventHistories = new HashMap<>();
     private static final List<SkinWidget> widgets = new ArrayList<>();
     private static final List<WidgetTableColumn> WIDGET_TABLE_COLUMNS = new ArrayList<>();
     private static final List<Pair<String, String>> removedObjects = new ArrayList<>();
+
+    private static EventHistory eventHistory = new EventHistory();
+    private static String skinDirectory;
 
     static {
         WIDGET_TABLE_COLUMNS.add(new WidgetTableColumn("ID", new ImBoolean(true), true, null, null));
@@ -64,10 +74,12 @@ public class SkinWidgetManager {
 
     static void changeSkin(Skin skin) {
         widgets.clear();
-        eventHistory.clear();
+        String skinName = skin == null ? "NULL" : skin.header.getName();
+        eventHistory = eventHistories.getOrDefault(skinName, new EventHistory());
         if (skin == null) {
             return;
         }
+        skinDirectory = skin.header.getPath().getParent().toString();
         SkinObject[] allSkinObjects = skin.getAllSkinObjects();
         // NOTE: We're using skin object's name as id, we need to keep name is unique
         Map<String, Integer> duplicatedSkinObjectNameCount = new HashMap<>();
@@ -79,6 +91,40 @@ public class SkinWidgetManager {
             } else {
                 registerSkinObject(skinObject, duplicatedSkinObjectNameCount);
             }
+        }
+        // Apply the custom changes
+        if (skin.getCustomChanges() != null) {
+            List<Event<?>> customEvents = skin.getCustomChanges().getEvents().stream().map(PersistedEvent::load).collect(Collectors.toList());
+            // Before we "recover" the changes, we should filter out the events that no handle can be found
+            Set<String> names = new HashSet<>();
+            widgets.forEach(widget -> {
+                names.add(widget.name);
+                widget.destinations.forEach(dst -> names.add(dst.name));
+            });
+            List<Event<?>> validEvents = customEvents.stream().filter(e -> names.contains(e.getName())).toList();
+            eventHistory.setEvents(validEvents);
+
+            widgets.forEach(widget -> {
+                List<Event<?>> eventsOnWidget = eventHistory.getEvents(widget.name);
+                if (!eventsOnWidget.isEmpty()) {
+                    eventsOnWidget.forEach(e -> {
+                        if (e.handle instanceof SkinWidget) {
+                            ((Event<SkinWidget>) e).handle = widget;
+                        }
+                    });
+                }
+                widget.destinations.forEach(dst -> {
+                    List<Event<?>> eventsOnDst = eventHistory.getEvents(dst.name);
+                    if (!eventsOnDst.isEmpty()) {
+                        eventsOnDst.forEach(e -> {
+                            if (e.handle instanceof SkinWidgetDestination) {
+                                ((Event<SkinWidgetDestination>) e).handle = dst;
+                            }
+                        });
+                    }
+                });
+            });
+            eventHistory.getEvents().forEach(Event::redo);
         }
         widgets.sort(Comparator.comparing(widget -> widget.name));
     }
@@ -169,14 +215,14 @@ public class SkinWidgetManager {
         for (int i = 0; i < dsts.length; ++i) {
             String dstBaseName = skinObjectName == null ? "Unnamed Destination" : skinObjectName;
             String combinedName = dsts.length == 1 ? dstBaseName : String.format("%s(%d)", dstBaseName, i);
-            destinations.add(new SkinWidgetDestination(combinedName, dsts[i]));
+            destinations.add(new SkinWidgetDestination(combinedName, dsts[i], eventHistory::pushEvent));
         }
 
         String widgetBaseName = skinObjectName == null ? "Unnamed Widget" : skinObjectName;
         Integer count = duplicatedSkinObjectNameCount.getOrDefault(widgetBaseName, 0);
         duplicatedSkinObjectNameCount.compute(widgetBaseName, (pk, pv) -> pv == null ? 1 : pv + 1);
         String widgetName = count == 0 ? widgetBaseName : String.format("%s(%d)", widgetBaseName, count);
-        widgets.add(new SkinWidget(widgetName, skinObject, destinations));
+        widgets.add(new SkinWidget(widgetName, skinObject, destinations, eventHistory::pushEvent));
     }
 
     private static void renderFilterOptions() {
@@ -454,45 +500,21 @@ public class SkinWidgetManager {
     }
 
     /**
-     * Export all changes, currently it simply copies the change logs to clipboard
+     * Export all changes, currently it writes to a json file as 'custom.json' located as the same as the skin
      */
     private static void exportChanges() {
-        List<String> changes = new ArrayList<>();
-        widgets.forEach(widget -> {
-            widget.destinations.forEach(dst -> {
-                boolean hasChangedX = false, hasChangedY = false, hasChangedW = false, hasChangedH = false;
-                for (Event<?> event : eventHistory.getEvents(dst.name)) {
-                    switch (event.type) {
-                        case CHANGE_X -> hasChangedX = true;
-                        case CHANGE_Y -> hasChangedY = true;
-                        case CHANGE_W -> hasChangedW = true;
-                        case CHANGE_H -> hasChangedH = true;
-                    }
-                }
-                if (!(hasChangedX || hasChangedY || hasChangedW || hasChangedH)) {
-                    return;
-                }
-                StringBuilder sb = new StringBuilder("{dst=").append(dst.name);
-                if (hasChangedX) {
-                    sb.append(", x=").append(dst.getDstX());
-                }
-                if (hasChangedY) {
-                    sb.append(", y=").append(dst.getDstY());
-                }
-                if (hasChangedX) {
-                    sb.append(", w=").append(dst.getDstW());
-                }
-                if (hasChangedY) {
-                    sb.append(", h=").append(dst.getDstH());
-                }
-                sb.append("}");
-                changes.add(sb.toString());
-            });
-        });
-        String changeLogs = String.join("\n", changes);
-        Lwjgl3Clipboard clipboard = new Lwjgl3Clipboard();
-        clipboard.setContents(changeLogs);
-        ImGuiNotify.info("Copied changes to clipboard");
+        eventHistory.squash();
+        CustomChanges customChanges = new CustomChanges();
+        customChanges.setVersion("1");
+        customChanges.setEvents(eventHistory.getEvents().stream().map(Event::persist).toList());
+        ObjectMapper om = new ObjectMapper();
+        try {
+            om.writeValue(Paths.get(skinDirectory, "custom.json").toFile(), customChanges);
+            ImGuiNotify.success("Export successfully");
+        } catch (Exception e) {
+            logger.error("Failed to copy changes to clipboard: ", e);
+            ImGuiNotify.error("Failed to copy changes to clipboard " + e.getMessage());
+        }
     }
 
     /**
@@ -508,252 +530,6 @@ public class SkinWidgetManager {
      */
     private record WidgetTableColumn(String name, ImBoolean show, boolean persistent,
                                      Function<SkinWidgetDestination, Float> getter, Event.EventType changeEventType) {
-    }
-
-    /**
-     * A simple wrapper class of SkinObject
-     *
-     * @implNote setter functions must provide an extra argument to not trigger event system
-     */
-    private static class SkinWidget {
-        private final String name;
-        // DON'T ACCESS THESE FIELDS DIRECTLY, USE GETTER/SETTER INSTEAD
-        private final SkinObject skinObject;
-        private final List<SkinWidgetDestination> destinations;
-
-        public SkinWidget(String name, SkinObject skinObject, List<SkinWidgetDestination> destinations) {
-            this.name = name;
-            this.skinObject = skinObject;
-            this.destinations = destinations;
-        }
-
-        public boolean isDrawingOnScreen() {
-            return skinObject.draw && skinObject.visible;
-        }
-
-        public void toggleVisible() {
-            toggleVisible(true);
-        }
-
-        public void toggleVisible(boolean createEvent) {
-            boolean isVisibleBefore = skinObject.visible;
-            if (createEvent) {
-                eventHistory.pushEvent(new ToggleVisibleEvent(this, isVisibleBefore));
-            }
-            skinObject.visible = !isVisibleBefore;
-        }
-    }
-
-    /**
-     * A simple wrapper class of SkinObject.SkinObjectDestination
-     *
-     * @implNote setter functions must provide an extra argument to not trigger event system
-     */
-    private static class SkinWidgetDestination {
-        private final String name;
-        private final SkinObject.SkinObjectDestination destination;
-        private SkinObject.SkinObjectDestination beforeMove = null;
-        /**
-         * <ul>
-         *     <li>0: haven't started moving</li>
-         *     <li>1: user enabled the move feature, but hasn't move around</li>
-         *     <li>2: user has moved the widget</li>
-         * </ul>
-         */
-        private int movingState;
-
-        public SkinWidgetDestination(String name, SkinObject.SkinObjectDestination destination) {
-            this.name = name;
-            this.destination = destination;
-            this.movingState = 0;
-        }
-
-        public float getDstX() {
-            return destination.region.x;
-        }
-
-        public float getDstY() {
-            return destination.region.y;
-        }
-
-        public float getDstW() {
-            return destination.region.width;
-        }
-
-        public float getDstH() {
-            return destination.region.height;
-        }
-
-        public void setDstX(float x) {
-            setDstX(x, true);
-        }
-
-        public void setDstX(float x, boolean createEvent) {
-            float previous = this.getDstX();
-            if (createEvent && Math.abs(x - previous) > eps) {
-                eventHistory.pushEvent(new ChangeSingleFieldEvent(Event.EventType.CHANGE_X, this, previous, x));
-            }
-            destination.region.x = x;
-        }
-
-        public void setDstY(float y) {
-            setDstY(y, true);
-        }
-
-        public void setDstY(float y, boolean createEvent) {
-            float previous = this.getDstY();
-            if (createEvent && Math.abs(y - previous) > eps) {
-                eventHistory.pushEvent(new ChangeSingleFieldEvent(Event.EventType.CHANGE_Y, this, previous, y));
-            }
-            destination.region.y = y;
-        }
-
-        public void setDstW(float w) {
-            setDstW(w, true);
-        }
-
-        public void setDstW(float w, boolean createEvent) {
-            float previous = this.getDstW();
-            if (createEvent && Math.abs(w - previous) > eps) {
-                eventHistory.pushEvent(new ChangeSingleFieldEvent(Event.EventType.CHANGE_W, this, previous, w));
-            }
-            destination.region.width = w;
-        }
-
-        public void setDstH(float h) {
-            setDstH(h, true);
-        }
-
-        public void setDstH(float h, boolean createEvent) {
-            float previous = this.getDstH();
-            if (createEvent && Math.abs(h - previous) > eps) {
-                eventHistory.pushEvent(new ChangeSingleFieldEvent(Event.EventType.CHANGE_H, this, previous, h));
-            }
-            destination.region.height = h;
-        }
-
-        /**
-         * Submit the move result, producing the event
-         */
-        public void submitMovement() {
-            if (beforeMove == null) {
-                ImGuiNotify.error("Cannot submit the move result because there's no original position");
-                return;
-            }
-            float nextX = getDstX();
-            float nextY = getDstY();
-            float nextW = getDstW();
-            float nextH = getDstH();
-            // Reset the position, to mimic that we are never left the original position
-            setDstX(beforeMove.region.x, false);
-            setDstY(beforeMove.region.y, false);
-            setDstW(beforeMove.region.width, false);
-            setDstH(beforeMove.region.height, false);
-            // Truly move to the target position
-            setDstX(nextX);
-            setDstY(nextY);
-            setDstW(nextW);
-            setDstH(nextH);
-            beforeMove = null;
-        }
-    }
-
-    private abstract static class Event<T> {
-        protected EventType type;
-        protected T handle; // reference to the event object
-
-        // NOTE: This is kinda naive, but it works...
-        enum EventType {
-            // ChangeSingleFieldEvent
-            CHANGE_X,
-            CHANGE_Y,
-            CHANGE_W,
-            CHANGE_H,
-            // ToggleVisibleEvent
-            TOGGLE_VISIBLE
-        }
-
-        public Event(EventType type, T handle) {
-            this.type = type;
-            this.handle = handle;
-        }
-
-        public abstract void undo();
-
-        public abstract String getDescription();
-
-        public abstract String getName();
-    }
-
-    /**
-     * Records the event when changing a single field from a widget
-     */
-    private static class ChangeSingleFieldEvent extends Event<SkinWidgetDestination> {
-        private final float previous;
-        private final float current;
-
-        public ChangeSingleFieldEvent(EventType type, SkinWidgetDestination dst, float previous, float current) {
-            super(type, dst);
-            this.previous = previous;
-            this.current = current;
-        }
-
-        @Override
-        public void undo() {
-            switch (type) {
-                case CHANGE_X -> handle.setDstX(previous, false);
-                case CHANGE_Y -> handle.setDstY(previous, false);
-                case CHANGE_W -> handle.setDstW(previous, false);
-                case CHANGE_H -> handle.setDstH(previous, false);
-                default -> { /* Intentionally do nothing */ }
-            }
-        }
-
-        @Override
-        public String getDescription() {
-            String fieldName = switch (type) {
-                case CHANGE_X -> "x";
-                case CHANGE_Y -> "y";
-                case CHANGE_W -> "width";
-                case CHANGE_H -> "height";
-                default -> "[ERROR] Not a ChangeSingleFieldEvent";
-            };
-            return String.format("Changed %s's %s from %.4f to %.4f", handle.name, fieldName, previous, current);
-        }
-
-        @Override
-        public String getName() {
-            return handle.name;
-        }
-    }
-
-    /**
-     * Records the event when toggling the visibility of a widget
-     */
-    private static class ToggleVisibleEvent extends Event<SkinWidget> {
-        private final boolean isVisibleBefore;
-
-        public ToggleVisibleEvent(SkinWidget handle, boolean isVisibleBefore) {
-            super(EventType.TOGGLE_VISIBLE, handle);
-            this.isVisibleBefore = isVisibleBefore;
-        }
-
-        @Override
-        public void undo() {
-            handle.toggleVisible(false);
-        }
-
-        @Override
-        public String getDescription() {
-            return isVisibleBefore
-                    ? String.format("Make %s widget invisible", handle.name)
-                    : String.format("Make %s widget visible", handle.name);
-        }
-
-        @Override
-        public String getName() {
-            return handle.name;
-        }
     }
 
     /**
@@ -777,6 +553,10 @@ public class SkinWidgetManager {
             eventStack.clear();
         }
 
+        public boolean isEmpty() {
+            return eventStack.isEmpty();
+        }
+
         public boolean hasEvent(String widgetName, Event.EventType eventType) {
             if (!targetNameToEvents.containsKey(widgetName)) {
                 return false;
@@ -791,6 +571,16 @@ public class SkinWidgetManager {
 
         public List<Event<?>> getEvents(String name) {
             return targetNameToEvents.getOrDefault(name, new ArrayList<>());
+        }
+
+        public void setEvents(List<Event<?>> events) {
+            eventStack.clear();
+            eventStack.addAll(events);
+            targetNameToEvents.clear();
+            eventStack.forEach(e -> {
+                targetNameToEvents.putIfAbsent(e.getName(), new ArrayList<>());
+                targetNameToEvents.get(e.getName()).add(e);
+            });
         }
 
         private void pushEvent(Event<?> event) {

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/events/ChangeSingleFieldEvent.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/events/ChangeSingleFieldEvent.java
@@ -1,0 +1,69 @@
+package bms.player.beatoraja.modmenu.skin.debugger.events;
+
+import bms.player.beatoraja.modmenu.skin.debugger.Event;
+import bms.player.beatoraja.modmenu.skin.debugger.PersistedEvent;
+import bms.player.beatoraja.modmenu.skin.debugger.SkinWidgetDestination;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Records the event when changing a single field from a widget
+ */
+public class ChangeSingleFieldEvent extends Event<SkinWidgetDestination> {
+	private float previous;
+	private float current;
+
+	public ChangeSingleFieldEvent(EventType type, SkinWidgetDestination dst, float previous, float current) {
+		super(type, dst);
+		this.previous = previous;
+		this.current = current;
+	}
+
+	@Override
+	public void redo() {
+		switch (type) {
+			case CHANGE_X -> handle.setDstX(current, false);
+			case CHANGE_Y -> handle.setDstY(current, false);
+			case CHANGE_W -> handle.setDstW(current, false);
+			case CHANGE_H -> handle.setDstH(current, false);
+			default -> { /* Intentionally do nothing */ }
+		}
+	}
+
+	@Override
+	public void undo() {
+		switch (type) {
+			case CHANGE_X -> handle.setDstX(previous, false);
+			case CHANGE_Y -> handle.setDstY(previous, false);
+			case CHANGE_W -> handle.setDstW(previous, false);
+			case CHANGE_H -> handle.setDstH(previous, false);
+			default -> { /* Intentionally do nothing */ }
+		}
+	}
+
+	@Override
+	public String getDescription() {
+		String fieldName = switch (type) {
+			case CHANGE_X -> "x";
+			case CHANGE_Y -> "y";
+			case CHANGE_W -> "width";
+			case CHANGE_H -> "height";
+			default -> "[ERROR] Not a ChangeSingleFieldEvent";
+		};
+		return String.format("Changed %s's %s from %.4f to %.4f", handle.name, fieldName, previous, current);
+	}
+
+	@Override
+	public String getName() {
+		return handle.name;
+	}
+
+	@Override
+	public PersistedEvent persist() {
+		Map<String, Object> payload = new HashMap<>();
+		payload.put("previous", previous);
+		payload.put("current", current);
+		return new PersistedEvent("1", "ChangeSingleFieldEvent", type.name(), handle.name, payload);
+	}
+}

--- a/core/src/bms/player/beatoraja/modmenu/skin/debugger/events/ToggleVisibleEvent.java
+++ b/core/src/bms/player/beatoraja/modmenu/skin/debugger/events/ToggleVisibleEvent.java
@@ -1,0 +1,49 @@
+package bms.player.beatoraja.modmenu.skin.debugger.events;
+
+import bms.player.beatoraja.modmenu.skin.debugger.Event;
+import bms.player.beatoraja.modmenu.skin.debugger.PersistedEvent;
+import bms.player.beatoraja.modmenu.skin.debugger.SkinWidget;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Records the event when toggling the visibility of a widget
+ */
+public class ToggleVisibleEvent extends Event<SkinWidget> {
+	private final boolean isVisibleBefore;
+
+	public ToggleVisibleEvent(SkinWidget handle, boolean isVisibleBefore) {
+		super(EventType.TOGGLE_VISIBLE, handle);
+		this.isVisibleBefore = isVisibleBefore;
+	}
+
+	@Override
+	public void redo() {
+		handle.toggleVisible(false);
+	}
+
+	@Override
+	public void undo() {
+		handle.toggleVisible(false);
+	}
+
+	@Override
+	public String getDescription() {
+		return isVisibleBefore
+				? String.format("Make %s widget invisible", handle.name)
+				: String.format("Make %s widget visible", handle.name);
+	}
+
+	@Override
+	public String getName() {
+		return handle.name;
+	}
+
+	@Override
+	public PersistedEvent persist() {
+		Map<String, Object> payload = new HashMap<>();
+		payload.put("isVisibleBefore", isVisibleBefore);
+		return new PersistedEvent("1", "ToggleVisibleEvent", type.name(), handle.name, payload);
+	}
+}

--- a/core/src/bms/player/beatoraja/play/SkinGauge.java
+++ b/core/src/bms/player/beatoraja/play/SkinGauge.java
@@ -104,7 +104,7 @@ public class SkinGauge extends SkinObject {
 			gauge = state.resource.getGrooveGauge();
 		}
 		if (gauge == null) {
-			draw = false;
+			undraw("Gauge is null");
 			return;
 		}
 

--- a/core/src/bms/player/beatoraja/play/SkinHidden.java
+++ b/core/src/bms/player/beatoraja/play/SkinHidden.java
@@ -70,7 +70,7 @@ public class SkinHidden extends SkinObject {
 	@Override
 	public void prepare(long time, MainState state) {
 		if(originalImages == null) {
-			draw = false;
+			undraw("No original images");
 			return;
 		}
 		if(this.state != state) {

--- a/core/src/bms/player/beatoraja/play/SkinJudge.java
+++ b/core/src/bms/player/beatoraja/play/SkinJudge.java
@@ -81,7 +81,7 @@ public final class SkinJudge extends SkinObject {
 	public void prepare(long time, MainState state) {
         final int judgenow = ((BMSPlayer)state).getJudgeManager().getNowJudge(player) - 1;
         if(judgenow < 0) {
-        	draw = false;
+			undraw("judgenow is less than 0");
             return;
         }
 		super.prepare(time, state);
@@ -99,7 +99,7 @@ public final class SkinJudge extends SkinObject {
         if(nowJudge != null) {
         	nowJudge.prepare(time, state);
         } else {
-        	draw = false;
+			undraw("nowJudge is null");
         	return;
         }
         
@@ -109,8 +109,8 @@ public final class SkinJudge extends SkinObject {
             	nowJudge.region.x += shift ? -nowCount.getLength() / 2 : 0;
             }        		
     	} else {
-        	draw = false;
-        	return;    		
+			undraw("nowJudge is undrawn");
+        	return;
     	}
 	}
 

--- a/core/src/bms/player/beatoraja/play/SkinNote.java
+++ b/core/src/bms/player/beatoraja/play/SkinNote.java
@@ -45,7 +45,7 @@ public class SkinNote extends SkinObject {
 		if(renderer == null) {
 			final BMSPlayer player = (BMSPlayer) state;
 			if (player.getLanerender() == null) {
-				draw = false;
+				undraw("Lanerender is null");
 				return;
 			}
 			renderer = player.getLanerender();

--- a/core/src/bms/player/beatoraja/select/SkinBar.java
+++ b/core/src/bms/player/beatoraja/select/SkinBar.java
@@ -214,7 +214,7 @@ public final class SkinBar extends SkinObject {
     	if(render == null) {
     		render = ((MusicSelector) state).getBarRender();
     		if(render == null) {
-    			draw = false;
+				undraw("BarRender is not exist");
     			return;
     		}
     	}

--- a/core/src/bms/player/beatoraja/select/SkinDistributionGraph.java
+++ b/core/src/bms/player/beatoraja/select/SkinDistributionGraph.java
@@ -113,7 +113,7 @@ public class SkinDistributionGraph extends SkinObject {
     	final Bar bar = ((MusicSelector)state).getSelectedBar();
         this.currentBar = (bar instanceof DirectoryBar) ? (DirectoryBar)bar : null;
         if (!state.resource.getConfig().isFolderlamp()) {
-            draw = false;
+            undraw("Folder lamp option is not enabled");
             return;
         }
         super.prepare(time, state);

--- a/core/src/bms/player/beatoraja/skin/Skin.java
+++ b/core/src/bms/player/beatoraja/skin/Skin.java
@@ -5,6 +5,7 @@ import bms.player.beatoraja.MainState;
 import bms.player.beatoraja.Resolution;
 import bms.player.beatoraja.ShaderManager;
 import bms.player.beatoraja.SkinConfig.Offset;
+import bms.player.beatoraja.modmenu.skin.debugger.CustomChanges;
 import bms.player.beatoraja.skin.SkinObject.SkinOffset;
 import bms.player.beatoraja.skin.property.BooleanProperty;
 import bms.player.beatoraja.play.BMSPlayer;
@@ -89,6 +90,7 @@ public class Skin {
 
 	private final IntMap<CustomEvent> customEvents = new IntMap<CustomEvent>();
 	private final IntMap<CustomTimer> customTimers = new IntMap<CustomTimer>();
+	private CustomChanges customChanges = null;
 
 	/**
 	 * デバッグ用
@@ -402,7 +404,15 @@ public class Skin {
 	public double getScaleY() {
 		return dh;
 	}
-	
+
+	public CustomChanges getCustomChanges() {
+		return customChanges;
+	}
+
+	public void setCustomChanges(CustomChanges customChanges) {
+		this.customChanges = customChanges;
+	}
+
 	public static final class SkinObjectRenderer {
 		
 		private final SpriteBatch sprite;

--- a/core/src/bms/player/beatoraja/skin/SkinFloat.java
+++ b/core/src/bms/player/beatoraja/skin/SkinFloat.java
@@ -148,13 +148,13 @@ final public class SkinFloat extends SkinObject {
 		var v = value * gain;
 		if (value == Float.MIN_VALUE || value == Float.MAX_VALUE || Float.isInfinite(v) || Float.isNaN(v) || v == Float.MIN_VALUE || v == Float.MAX_VALUE || this.keta == 0) {
 			length = 0;
-			draw = false;
+			undraw("Value is -INF or +INF");
 			return;
 		}
 		final SkinSourceSet images = (mimage == null || v >= 0.0f) ? this.image : mimage;
 		if (images == null) {
 			length = 0;
-			draw = false;
+			undraw("No image");
 			return;
 		}
 		super.prepare(time, state, offsetX, offsetY);
@@ -165,7 +165,7 @@ final public class SkinFloat extends SkinObject {
 		TextureRegion[] image = images.getImages(time, state);
 		if(image == null) {
 			length = 0;
-			draw = false;
+			undraw("No image");
 			return;
 		}
 

--- a/core/src/bms/player/beatoraja/skin/SkinGraph.java
+++ b/core/src/bms/player/beatoraja/skin/SkinGraph.java
@@ -89,8 +89,8 @@ public final class SkinGraph extends SkinObject {
 			return;
 		}
 		if((currentImage = source.getImage(time, state)) == null) {
-			draw = false;
-			return;			
+			undraw("No image");
+			return;
 		}
 		currentValue = ref != null ? ref.get(state) : 0;
 	}

--- a/core/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
+++ b/core/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
@@ -83,7 +83,7 @@ public class SkinHitErrorVisualizer extends SkinObject {
 
 	public void prepare(long time, MainState state) {
 		if(!(state instanceof BMSPlayer)) {
-			draw = false;
+			undraw("Current scene is not play scene");
 			return;
 		}
 		super.prepare(time, state);

--- a/core/src/bms/player/beatoraja/skin/SkinImage.java
+++ b/core/src/bms/player/beatoraja/skin/SkinImage.java
@@ -126,7 +126,7 @@ public class SkinImage extends SkinObject {
 	
 	public void prepare(long time, MainState state, int value, float offsetX, float offsetY) {		
         if(image == null || value < 0) {
-            draw = false;
+			undraw("No image or value is less than 0");
             return;
         }
 		super.prepare(time, state, offsetX, offsetY);
@@ -135,8 +135,8 @@ public class SkinImage extends SkinObject {
         }
         currentImage = getImage(value, time, state);
         if(currentImage == null) {
-            draw = false;
-            return;        	
+			undraw("No image");
+            return;
         }
 	}
 

--- a/core/src/bms/player/beatoraja/skin/SkinLoader.java
+++ b/core/src/bms/player/beatoraja/skin/SkinLoader.java
@@ -1,6 +1,7 @@
 package bms.player.beatoraja.skin;
 
 import bms.player.beatoraja.*;
+import bms.player.beatoraja.modmenu.skin.debugger.CustomChanges;
 import bms.player.beatoraja.skin.json.JSONSkinLoader;
 import bms.player.beatoraja.skin.lr2.LR2SkinCSVLoader;
 import bms.player.beatoraja.skin.lr2.LR2SkinHeaderLoader;
@@ -9,7 +10,11 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ObjectMap;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.nio.file.*;
 
@@ -19,6 +24,7 @@ import java.nio.file.*;
  * @author exch
  */
 public abstract class SkinLoader {
+    private static final Logger logger = LoggerFactory.getLogger(SkinLoader.class);
     /**
      * スキンイメージのリソースプール
      */
@@ -46,6 +52,20 @@ public abstract class SkinLoader {
             skinConfig.validate();
             skin = load(state, skinType, skinConfig);
         }
+
+        if (skin != null) {
+            File customChangesFile = Paths.get(skin.header.getPath().getParent().toString(), "custom.json").toFile();
+            if (customChangesFile.exists()) {
+                ObjectMapper om = new ObjectMapper();
+                try {
+                    CustomChanges customChanges = om.readValue(customChangesFile, CustomChanges.class);
+                    skin.setCustomChanges(customChanges);
+                } catch (Exception e) {
+                    logger.error("Error reading custom changes: ", e);
+                }
+            }
+        }
+
         return skin;
     }
 

--- a/core/src/bms/player/beatoraja/skin/SkinManualEntry.java
+++ b/core/src/bms/player/beatoraja/skin/SkinManualEntry.java
@@ -1,0 +1,52 @@
+package bms.player.beatoraja.skin;
+
+import com.github.therapi.runtimejavadoc.CommentFormatter;
+import com.github.therapi.runtimejavadoc.FieldJavadoc;
+import com.github.therapi.runtimejavadoc.RuntimeJavadoc;
+
+/**
+ * Represents one skin property's manual
+ *
+ * @param <T> Skin property corresponding enums, see StringPropertyFactory.StringProperty for example
+ * @implNote getComment & getFullName are lazy functions
+ */
+public class SkinManualEntry<T extends Enum<T>> {
+    private static final CommentFormatter formatter = new CommentFormatter();
+
+    private final Enum<T> ref;
+    private final String name;
+    private final int id;
+    private String comment;
+    private String fullName;
+
+    public SkinManualEntry(Enum<T> ref, String name, int id) {
+        this.ref = ref;
+        this.name = name;
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getFullName() {
+        if (this.fullName != null) {
+            return this.fullName;
+        }
+        this.fullName = String.format("%s(%d)", this.name, this.id);
+        return this.fullName;
+    }
+
+    public String getComment() {
+        if (this.comment != null) {
+            return this.comment;
+        }
+        FieldJavadoc javadoc = RuntimeJavadoc.getJavadoc(ref);
+        this.comment = javadoc.isEmpty() ? "" : formatter.format(javadoc.getComment());
+        return this.comment;
+    }
+}

--- a/core/src/bms/player/beatoraja/skin/SkinNumber.java
+++ b/core/src/bms/player/beatoraja/skin/SkinNumber.java
@@ -132,13 +132,13 @@ public final class SkinNumber extends SkinObject {
 	public void prepare(long time, MainState state, int value, float offsetX, float offsetY) {
 		if (value == Integer.MIN_VALUE || value == Integer.MAX_VALUE) {
 			length = 0;
-			draw = false;
+			undraw("Value is -INF or +INF");
 			return;
 		}
 		final SkinSourceSet images = (value >= 0 || mimage == null) ? this.image : mimage;
 		if (images == null) {
 			length = 0;
-			draw = false;
+			undraw("No image");
 			return;
 		}
 		super.prepare(time, state, offsetX, offsetY);
@@ -149,7 +149,7 @@ public final class SkinNumber extends SkinObject {
 		TextureRegion[] image = images.getImages(time, state);
 		if(image == null) {
 			length = 0;
-			draw = false;
+			undraw("No image");
 			return;
 		}
 

--- a/core/src/bms/player/beatoraja/skin/SkinObject.java
+++ b/core/src/bms/player/beatoraja/skin/SkinObject.java
@@ -2,6 +2,7 @@ package bms.player.beatoraja.skin;
 
 import bms.player.beatoraja.DisposableObject;
 import bms.player.beatoraja.MainState;
+import bms.player.beatoraja.modmenu.skin.debugger.SkinWidgetManager;
 import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 import bms.player.beatoraja.skin.property.*;
 
@@ -99,6 +100,7 @@ public abstract class SkinObject extends DisposableObject {
 	private long endtime;
 
 	public boolean draw;
+	private boolean registeredRemovedReason = false;
 	// Controlled by debugger instead of constraints defined by skin
 	public boolean visible = true;
 	public Rectangle region = new Rectangle();
@@ -305,7 +307,7 @@ public abstract class SkinObject extends DisposableObject {
 
 		if (timer != null) {
 			if (timer.isOff(state)) {
-				draw = false;
+				undraw("Timer is passed");
 				return;
 			}
 			time -= timer.get(state);
@@ -324,7 +326,7 @@ public abstract class SkinObject extends DisposableObject {
 			}
 		}
 		if (starttime > time) {
-			draw = false;
+			undraw("Loop is ended");
 			return;
 		}
 		nowtime = time;
@@ -505,7 +507,7 @@ public abstract class SkinObject extends DisposableObject {
 	public void prepare(long time, MainState state, float offsetX, float offsetY) {
 		for (BooleanProperty draw : dstdraw) {
 			if(!draw.get(state)) {
-				this.draw = false;
+				undraw("Draw condition is not met");
 				return;
 			}
 		}
@@ -515,7 +517,7 @@ public abstract class SkinObject extends DisposableObject {
 		region.y += offsetY;
 		if (mouseRect != null && !mouseRect.contains(state.main.getInputProcessor().getMouseX() -region.x,
 				state.main.getInputProcessor().getMouseY() - region.y)) {
-			draw = false;
+			undraw("Mouse input area is not met");
 			return;
 		}
 
@@ -638,6 +640,14 @@ public abstract class SkinObject extends DisposableObject {
 
 	public void setRelative(boolean relative) {
 		this.relative = relative;
+	}
+
+	protected void undraw(String reason) {
+		this.draw = false;
+		if (!this.registeredRemovedReason) {
+			this.registeredRemovedReason = true;
+			SkinWidgetManager.registerRemovedObject(this.name, reason);
+		}
 	}
 
 	/**

--- a/core/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/core/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -1,6 +1,17 @@
 package bms.player.beatoraja.skin;
 
 public class SkinProperty {
+    public enum PropertyType {
+        Boolean,
+        Event,
+        Float,
+        Integer,
+        String,
+        Timer,
+	    // LR2 specials
+	    Number,
+	    Button,
+    }
 
 	public static final int IMAGE_STAGEFILE = 100;
 	public static final int IMAGE_BACKBMP = 101;

--- a/core/src/bms/player/beatoraja/skin/SkinSlider.java
+++ b/core/src/bms/player/beatoraja/skin/SkinSlider.java
@@ -107,8 +107,8 @@ public final class SkinSlider extends SkinObject {
 			return;
 		}
 		if((currentImage = source.getImage(time, state)) == null) {
-			draw = false;
-			return;			
+			undraw("No image");
+			return;
 		}
 		currentValue = ref != null ? ref.get(state) : 0;
 	}

--- a/core/src/bms/player/beatoraja/skin/SkinText.java
+++ b/core/src/bms/player/beatoraja/skin/SkinText.java
@@ -84,7 +84,7 @@ public abstract class SkinText extends SkinObject {
     	super.prepare(time, state);
         currentText = ref != null ? ref.get(state) : (constantText != null ? constantText : null);
         if(currentText == null || currentText.length() == 0) {
-        	draw = false;
+            undraw("No text provided");
             return;
         }
     }

--- a/core/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
+++ b/core/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
@@ -60,7 +60,7 @@ public class SkinTimingDistributionGraph extends SkinObject {
 
 	public void prepare(long time, MainState state) {
 		if(!(state instanceof MusicResult)) {
-			draw = false;
+			undraw("Current scene is not result scene");
 			return;
 		}
 		this.state = (MusicResult) state;

--- a/core/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
+++ b/core/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
@@ -75,7 +75,7 @@ public final class SkinTimingVisualizer extends SkinObject {
 
 	public void prepare(long time, MainState state) {
 		if(!(state instanceof BMSPlayer)) {
-			draw = false;
+			undraw("Current scene is not play scene");
 			return;
 		}
 		super.prepare(time, state);

--- a/core/src/bms/player/beatoraja/skin/lr2/LR2ButtonDef.java
+++ b/core/src/bms/player/beatoraja/skin/lr2/LR2ButtonDef.java
@@ -1,0 +1,258 @@
+package bms.player.beatoraja.skin.lr2;
+
+import bms.player.beatoraja.skin.SkinManualEntry;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+
+/**
+ * LR2 button types
+ */
+public enum LR2ButtonDef {
+	// Panel button
+	Panel1("Open Panel 1", 1),
+	Panel2("Open Panel 2", 2),
+	Panel3("Open Panel 3", 3),
+	Panel4("Open Panel 4", 4),
+	Panel5("Open Panel 5", 5),
+	Panel6("Open Panel 6", 6),
+	Panel7("Open Panel 7", 7),
+	Panel8("Open Panel 8", 8),
+	Panel9("Open Panel 9", 9),
+
+	// Song Select
+	DifficultyFilter("Difficulty filter", 10),
+	KeyModeFilter("Key mode filter", 11),
+	ChartSorting("Chart sorting", 12),
+	KeyConfig("Key Config", 13),
+	SkinSelect("Skin Select", 14),
+	Start("Start", 15),
+	Autoplay("Autoplay", 16),
+	OpenREADME("Open README", 17),
+	ResetTag("Reset Tag", 18),
+	Replay("Replay", 19),
+
+	// FX Options
+	FX0Mode("FX0 mode", 20),
+	FX1Mode("FX1 mode", 21),
+	FX2Mode("FX2 mode", 22),
+	FX0Toggle("FX0 toggle", 23),
+	FX1Toggle("FX1 toggle", 24),
+	FX2Toggle("FX2 toggle", 25),
+	FX0Target("FX0 target", 26),
+	FX1Target("FX1 target", 27),
+	FX2Target("FX2 target", 28),
+	Equalizer("Equalizer", 29),
+	EqualizerPreset("Equalizer preset (Doesn't work in LV)", 30),
+	AllowVolumeControl("Allow volume control", 31),
+	PITCHToggle("PITCH toggle", 32),
+	PITCHType("PITCH type", 33),
+
+	// Play Options
+	Gauge1P("Gauge 1P", 40),
+	Gauge2P("Gauge 2P", 41),
+	Lane1P("Lane 1P", 42),
+	Lane2P("Lane 2P", 43),
+	AutoScratch1P("Auto-Scratch 1P", 44),
+	AutoScratch2P("Auto-Scratch 2P", 45),
+	Shutters("Shutters (lane cover?)", 46),
+	OnePGreenNumber("1P Green number", 47),
+	TwoPGreenNumber("2P Green number", 48),
+	OnePLaneEffect("1P Lane Effect", 50),
+	TwoPLaneEffect("2P Lane Effect", 51),
+	DPFlip("DP Flip", 54),
+	HiSpeedFix("Hi-Speed fix", 55),
+	Battle("Battle", 56),
+	HiSpeed1PChange("Hi-Speed 1P change", 57),
+	HiSpeed2PChange("Hi-Speed 2P change", 58),
+
+	// Options screen
+	ScoreGraph("Score graph", 70),
+	GhostPosition("Ghost position", 71),
+	BGA("BGA", 72),
+	BGASize("BGA size", 73),
+	TimingOffsetChange("Timing offset change", 74),
+	TimingOffsetAutoAdjust("Timing offset Auto-adjust", 75),
+	DefaultTargetRate("Default target rate", 76),
+	Target("Target", 77),
+	ScreenModeLR2Only("Screen mode (LR2 only)", 80),
+	ColorMode("Color mode", 81),
+	Vsync("Vsync", 82),
+	ReplaySavePriority("Replay save priority", 83),
+	FavoriteOptions("Add favorite/Add ignore/Remove favorite/Remove ignore", 90),
+	AllDifficultyFilter("All difficulty filter", 91),
+	BeginnerFilter("Beginner filter", 92),
+	NormalFilter("Normal filter", 93),
+	HyperFilter("Hyper filter", 94),
+	AnotherFilter("Another filter", 95),
+	InsaneFilter("Insane filter", 96),
+
+	// Key Config
+	Key1_1P("1P Key 1", 101),
+	Key2_1P("1P Key 2", 102),
+	Key3_1P("1P Key 3", 103),
+	Key4_1P("1P Key 4", 104),
+	Key5_1P("1P Key 5", 105),
+	Key6_1P("1P Key 6", 106),
+	Key7_1P("1P Key 7", 107),
+	Key8_1P("1P Key 8", 108),
+	Key9_1P("1P Key 9", 109),
+	ScratchUp_1P("1P Scratch Up", 110),
+	ScratchDown_1P("1P Scratch Down", 111),
+	Start_1P("1P Start", 112),
+	Select_1P("1P Select", 113),
+	ScratchAbsolute_1P("1P Scratch Absolute", 116),
+	Key1_2P("2P Key 1", 121),
+	Key2_2P("2P Key 2", 122),
+	Key3_2P("2P Key 3", 123),
+	Key4_2P("2P Key 4", 124),
+	Key5_2P("2P Key 5", 125),
+	Key6_2P("2P Key 6", 126),
+	Key7_2P("2P Key 7", 127),
+	Key8_2P("2P Key 8", 128),
+	Key9_2P("2P Key 9", 129),
+	ScratchUp_2P("2P Scratch Up", 130),
+	ScratchDown_2P("2P Scratch Down", 131),
+	Start_2P("2P Start", 132),
+	Select_2P("2P Select", 133),
+	ScratchAbsolute_2P("2P Scratch Absolute", 136),
+	KeyChange7Keys("Key change (7 Keys)", 140),
+	KeyChange9Keys("Key change (9 Keys)", 141),
+	KeyChange5Keys("Key change (5 Keys)", 142),
+	KeyModeSwitch("Keymode switch", 143),
+	KeyConfigSlot1("Key Config slot 1", 150),
+	KeyConfigSlot2("Key Config slot 2", 151),
+	KeyConfigSlot3("Key Config slot 3", 152),
+	KeyConfigSlot4("Key Config slot 4", 153),
+	KeyConfigSlot5("Key Config slot 5", 154),
+	KeyConfigSlot6("Key Config slot 6", 155),
+	KeyConfigSlot7("Key Config slot 7", 156),
+	KeyConfigSlot8("Key Config slot 8", 157),
+
+	// Skin Select
+	SkinSelect7Keys("Skin Select 7 Keys", 170),
+	SkinSelect5Keys("Skin Select 5 Keys", 171),
+	SkinSelect14Keys("Skin Select 14 Keys", 172),
+	SkinSelect10Keys("Skin Select 10 Keys", 173),
+	SkinSelect9Keys("Skin Select 9 Keys", 174),
+	SkinSelectSelect("Skin Select Select", 175),
+	SkinSelectDecide("Skin Select Decide", 176),
+	SkinSelectResult("Skin Select Result", 177),
+	SkinSelectKeyConfig("Skin Select Key Config", 178),
+	SkinSelectSkinSelect("Skin Select Skin Select", 179),
+	SkinSelectSoundSet("Skin Select Sound set", 180),
+	SkinSelectTheme("Skin Select Theme", 181),
+	SkinSelect7KeysBattle("Skin Select 7 Keys Battle", 182),
+	SkinSelect5KeysBattle("Skin Select 5 Keys Battle", 183),
+	SkinSelect9KeysBattle("Skin Select 9 Keys Battle", 184),
+	SkinSelectCourseResults("Skin Select Course Results", 185),
+	SwitchBetweenSkinsInSkinSelect("Switch between skins in Skin Select", 190),
+
+	// Help file (Must be defined with #HELPFILE)
+	HelpFile1("Help file 1", 200),
+	HelpFile2("Help file 2", 201),
+	HelpFile3("Help file 3", 202),
+	HelpFile4("Help file 4", 203),
+	HelpFile5("Help file 5", 204),
+	HelpFile6("Help file 6", 205),
+	HelpFile7("Help file 7", 206),
+	HelpFile8("Help file 8", 207),
+	HelpFile9("Help file 9", 208),
+	HelpFile10("Help file 10", 209),
+	IRChartPageOpen("IR chart page open", 210),
+
+	// Skin Customization
+	SkinCustomizationItem1("Skin Customization Item 1", 220),
+	SkinCustomizationItem2("Skin Customization Item 2", 221),
+	SkinCustomizationItem3("Skin Customization Item 3", 222),
+	SkinCustomizationItem4("Skin Customization Item 4", 223),
+	SkinCustomizationItem5("Skin Customization Item 5", 224),
+	SkinCustomizationItem6("Skin Customization Item 6", 225),
+	SkinCustomizationItem7("Skin Customization Item 7", 226),
+	SkinCustomizationItem8("Skin Customization Item 8", 227),
+	SkinCustomizationItem9("Skin Customization Item 9", 228),
+	SkinCustomizationItem10("Skin Customization Item 10", 229),
+
+	// Course Select
+	CourseSelectDecide("Course Select Decide", 230),
+	CourseSelectCancel("Course Select Cancel", 231),
+	CourseSelectCourseEdit("Course Select Course Edit", 232),
+	CourseSelectDelete("Course Select Delete", 233),
+
+	// Course Option
+	CourseOptionStage1To2Transition("Course Option Stage 1-2 transition", 240),
+	CourseOptionStage2To3Transition("Course Option Stage 2-3 transition", 241),
+	CourseOptionStage3To4Transition("Course Option Stage 3-4 transition", 242),
+	CourseOptionStage4To5Transition("Course Option Stage 4-5 transition", 243),
+	CourseOptionStage5To6Transition("Course Option Stage 5-6 transition", 244),
+	CourseOptionStage6To7Transition("Course Option Stage 6-7 transition", 245),
+	CourseOptionStage7To8Transition("Course Option Stage 7-8 transition", 246),
+	CourseOptionStage8To9Transition("Course Option Stage 8-9 transition", 247),
+	CourseOptionStage9To10Transition("Course Option Stage 9-10 transition", 248),
+	CourseOptionStage10To11Transition("Course Option Stage 10-11 transition", 249),
+	CourseSoflanToggle("Course Soflan toggle", 250),
+	CourseGaugeToggle("Course gauge toggle", 251),
+	CourseOptionToggle("Course option toggle", 252),
+	CourseIRAvailabilityToggle("Course IR availability toggle", 253),
+
+	// Random Course
+	RandomCourseOptimalLevel("Random Course optimal level", 260),
+	RandomCourseMaximumLevel("Random Course maximum level", 261),
+	RandomCourseMinimumLevel("Random Course minimum level", 262),
+	RandomCourseBPMChange("Random Course BPM change", 263),
+	RandomCourseMaxBPM("Random Course max BPM", 264),
+	RandomCourseMinBPM("Random Course min BPM", 265),
+	RandomCourseStageCount("Random Course Stage count", 266),
+	CourseDefaultTransitionChange("Course Default transition change", 268),
+	CourseDefaultGaugeChange("Course Default gauge change", 269),
+
+	// Clear Type
+	OnePClearType("1P Clear Type", 270),
+	TwoPClearType("2P Clear Type", 271),
+
+	// ARENA Clear Type
+	Arena1PClearType("ARENA 1P Clear Type", 301),
+	Arena2PClearType("ARENA 2P Clear Type", 302),
+	Arena3PClearType("ARENA 3P Clear Type", 303),
+	Arena4PClearType("ARENA 4P Clear Type", 304),
+	Arena5PClearType("ARENA 5P Clear Type", 305),
+	Arena6PClearType("ARENA 6P Clear Type", 306),
+	Arena7PClearType("ARENA 7P Clear Type", 307),
+	Arena8PClearType("ARENA 8P Clear Type", 308),
+
+	// ARENA player ranking
+	ArenaPlayerRanking("ARENA player ranking", 310),
+	Arena1PRanking("ARENA 1P ranking", 311),
+	Arena2PRanking("ARENA 2P ranking", 312),
+	Arena3PRanking("ARENA 3P ranking", 313),
+	Arena4PRanking("ARENA 4P ranking", 314),
+	Arena5PRanking("ARENA 5P ranking", 315),
+	Arena6PRanking("ARENA 6P ranking", 316),
+	Arena7PRanking("ARENA 7P ranking", 317),
+	Arena8PRanking("ARENA 8P ranking", 318);
+
+	private final String name;
+	private final int value;
+
+	LR2ButtonDef(String name, int value) {
+		this.name = name;
+		this.value = value;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	@Nullable
+	public static LR2ButtonDef valueOf(int v) {
+		return Arrays.stream(LR2ButtonDef.values()).filter(def -> def.value == v).findAny().orElse(null);
+	}
+
+	public SkinManualEntry<LR2ButtonDef> intoManualEntry() {
+		return new SkinManualEntry<>(this, this.name, this.value);
+	}
+}

--- a/core/src/bms/player/beatoraja/skin/lr2/LR2DestinationOptions.java
+++ b/core/src/bms/player/beatoraja/skin/lr2/LR2DestinationOptions.java
@@ -1,0 +1,611 @@
+package bms.player.beatoraja.skin.lr2;
+
+import bms.player.beatoraja.skin.SkinManualEntry;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+
+/**
+ * LR2 destination options
+ */
+public enum LR2DestinationOptions {
+	// DST op values
+	AlwaysTrue("Always true", 0),
+	BarFocusedIsFolder("Bar focused is a folder", 1),
+	BarFocusedIsSong("Bar focused is a song", 2),
+	BarFocusedIsCourse("Bar focused is a course", 3),
+	BarFocusedIsNewCourse("Bar focused is a new course", 4),
+	BarFocusedIsPlayable("Bar focused is playable", 5),
+
+	CurrentModeIsDoubleOrDoubleBattle("Current mode is Double or Double Battle", 10),
+	CurrentModeIsBattle("Current mode is Battle", 11),
+	CurrentModeIsDoubleOrBattleOrDoubleBattle("Current mode is Double or Battle or Double Battle", 12),
+	CurrentModeIsGhostBattleOrBattle("Current mode is Ghost Battle or Battle", 13),
+
+	AllPanelsOff("All panels off", 20),
+	Panel1On("Panel 1 on", 21),
+	Panel2On("Panel 2 on", 22),
+	Panel3On("Panel 3 on", 23),
+	Panel4On("Panel 4 on", 24),
+	Panel5On("Panel 5 on", 25),
+	Panel6On("Panel 6 on", 26),
+	Panel7On("Panel 7 on", 27),
+	Panel8On("Panel 8 on", 28),
+	Panel9On("Panel 9 on", 29),
+
+	BGANormal("BGA Normal", 30),
+	BGAExtend("BGA extend", 31),
+	AutoplayOff("Autoplay off", 32),
+	AutoplayOn("Autoplay on", 33),
+	GhostOff("Ghost off", 34),
+	GhostTypeA("Ghost Type A (technically used for Fast/Slow)", 35),
+	GhostTypeB("Ghost Type B", 36),
+	GhostTypeC("Ghost Type C", 37),
+	ScoreGraphOff("Score Graph off", 38),
+	ScoreGraphOn("Score Graph on", 39),
+	BGAOff("BGA off", 40),
+	BGAOn("BGA on", 41),
+
+	HardOff_1P("1P Hard Off (normal gauge)", 42),
+	HardOn_1P("1P Hard On (hard gauge)", 43),
+	HardOff_2P("2P Hard Off (normal gauge)", 44),
+	HardOn_2P("2P Hard On (hard gauge)", 45),
+
+	DifficultyFilterOn("Difficulty filter on", 46),
+	DifficultyFilterOff("Difficulty filter off", 47),
+
+	EXHARD_1P("1P EX-HARD", 48),
+	EXHARD_2P("2P EX-HARD", 49),
+
+	LR2IROffline("LR2IR offline", 50),
+	LR2IROnline("LR2IR online", 51),
+
+	ExtraModeOff("Extra Mode off", 52),
+	ExtraModeOn("Extra Mode on", 53),
+
+	AutoScratchOff_1P("1P Auto-scratch off", 54),
+	AutoScratchOn_1P("1P Auto-scratch on", 55),
+	AutoScratchOff_2P("2P Auto-scratch off", 56),
+	AutoScratchOn_2P("2P Auto-scratch on", 57),
+
+	ScoreSavingNotAllowed("Score saving not allowed", 60),
+	ScoreSavingAllowed("Score saving allowed", 61),
+	SavesAsFailedOrNoPlay("Saves as failed or no play (Clear saving not allowed)", 62),
+	SelectedAssistEasyEasyGauge("Selected Assist Easy/Easy gauge (saves as Easy)", 63),
+	SelectedNormalGauge("Selected Normal gauge (saves as Clear)", 64),
+	SelectedHardExHardGATKGauge("Selected Hard/Ex-Hard/G-ATK gauge (saves as Hard Clear)", 65),
+	SelectedDeathPATKGauge("Selected Death/P-ATK gauge (saves as Full Combo)", 66),
+
+	// Max level value: Lv.9 for 5/10 Keys, Lv.12 for 7/14 Keys, Lv.42 for 9 Keys
+	BeginnerLevelDoesNotExceedMax("The level of the beginner chart in the same folder doesn't exceed the max value", 70),
+	NormalLevelDoesNotExceedMax("Normal", 71),
+	HyperLevelDoesNotExceedMax("Hyper", 72),
+	AnotherLevelDoesNotExceedMax("Another", 73),
+	InsaneLevelDoesNotExceedMax("Insane", 74),
+	BeginnerLevelExceedsMax("The level of the beginner chart in the same folder exceeds the max value", 75),
+	NormalLevelExceedsMax("Normal", 76),
+	HyperLevelExceedsMax("Hyper", 77),
+	AnotherLevelExceedsMax("Another", 78),
+	InsaneLevelExceedsMax("Insane", 79),
+
+	LoadingInProgress("Loading in progress", 80),
+	LoadingCompleted("Loading completed", 81),
+
+	ReplaySavingOff("Replay saving off", 82),
+	ReplaySavingOn("Replay saving on", 83),
+	PlayingReplay("Playing Replay", 84),
+
+	ResultClear("Result Clear", 90),
+	ResultsFailed("Results Failed", 91),
+
+	// Song select
+	NoPlay("No Play", 100),
+	Failed("Failed", 101),
+	EasyClear("Easy Clear", 102),
+	Clear("Clear", 103),
+	HardClear("Hard Clear", 104),
+	FullCombo("Full Combo", 105),
+	ExHardClear("Ex-Hard Clear", 106),
+	Perfect("Perfect", 107),
+	MAX("MAX", 108),
+	AssistEasy("Assist Easy", 109),
+
+	AAA("AAA", 110),
+	AA("AA", 111),
+	A("A", 112),
+	B("B", 113),
+	C("C", 114),
+	D("D", 115),
+	E("E", 116),
+	F("F", 117),
+
+	// Cleared gauge flags
+	GrooveCleared("Groove", 118),
+	HardCleared("Hard", 119),
+	HazardCleared("Hazard", 120),
+	EasyCleared("Easy", 121),
+	PAttackCleared("P-Attack", 122),
+	GAttackCleared("G-Attack", 123),
+
+	// Cleared lane flags
+	NormalCleared("Normal", 126),
+	MirrorCleared("Mirror", 127),
+	RandomCleared("Random", 128),
+	SRandomCleared("S-Random", 129),
+	HRandomCleared("H-Random (Scatter)", 130),
+	AllScratchCleared("All Scratch (Converge)", 131),
+
+	// Cleared effect flags
+	NoneEffect("None", 134),
+	HiddenEffect("Hidden", 135),
+	SuddenEffect("Sudden", 136),
+	HiddenSuddenEffect("Hidden + Sudden", 137),
+
+	// Other cleared flags
+	AutoScratchCleared("Auto-scratch (Disappears if you have cleared without it)", 142),
+	ExtraModeCleared("Extra Mode", 143),
+	DoubleBattleCleared("Double Battle", 144),
+	SPToDPCleared("SP to DP (Might be shared with DP to SP and 9 to 7?)", 145),
+
+	EasyClearFlag("Easy Clear", 146),
+	HardClearFlag("Hard Clear", 147),
+	FullComboFlag("Full Combo", 148),
+
+	Undefined("Undefined", 150),
+	Beginner("Beginner", 151),
+	Normal("Normal", 152),
+	Hyper("Hyper", 153),
+	Another("Another", 154),
+	Insane("Insane", 155),
+
+	// Original keycount
+	Original7Keys("7 Keys", 160),
+	Original5Keys("5 Keys", 161),
+	Original14Keys("14 Keys", 162),
+	Original10Keys("10 Keys", 163),
+	Original9Keys("9 Keys", 164),
+
+	// Keycount after modifications
+	Modified7Keys("7 Keys", 165),
+	Modified5Keys("5 Keys", 166),
+	Modified14Keys("14 Keys", 167),
+	Modified10Keys("10 Keys", 168),
+	Modified9Keys("9 Keys", 169),
+
+	NoBGA("No BGA", 170),
+	BGAAvailable("BGA available", 171),
+
+	NoLN("No LN", 172),
+	HasLN("Has LN", 173),
+
+	NoREADME("No README", 174),
+	HasREADME("README", 175),
+
+	NoBPMChanges("No BPM changes", 176),
+	HasBPMChanges("Has BPM changes", 177),
+
+	NoRANDOM("No #RANDOM", 178),
+	HasRANDOM("Has #RANDOM", 179),
+
+	JudgeRankVeryHard("Judge rank Very Hard", 180),
+	JudgeRankHard("Judge rank Hard", 181),
+	JudgeRankNormal("Judge rank Normal", 182),
+	JudgeRankEasy("Judge rank Easy", 183),
+
+	PlayLevelDoesNotExceedLimits("Play level of the current chart doesn't exceed limits (Check above)", 185),
+	PlayLevelExceedsLimits("Play level of the current chart exceed limits", 186),
+
+	NoSTAGEFILE("No STAGEFILE", 190),
+	HasSTAGEFILE("Has STAGEFILE", 191),
+	NoBANNER("No BANNER", 192),
+	HasBANNER("Has BANNER", 193),
+	NoBACKBMP("No BACKBMP", 194),
+	HasBACKBMP("Has BACKBMP", 195),
+
+	NoReplayFile("No replay file", 196),
+	HasReplayFile("Has replay file", 197),
+
+	// Play skin
+	AAA_1P("1P AAA", 200),
+	AA_1P("1P AA", 201),
+	A_1P("1P A", 202),
+	B_1P("1P B", 203),
+	C_1P("1P C", 204),
+	D_1P("1P D", 205),
+	E_1P("1P E", 206),
+	F_1P("1P F", 207),
+
+	AAA_2P("2P AAA", 210),
+	AA_2P("2P AA", 211),
+	A_2P("2P A", 212),
+	B_2P("2P B", 213),
+	C_2P("2P C", 214),
+	D_2P("2P D", 215),
+	E_2P("2P E", 216),
+	F_2P("2P F", 217),
+
+	AAAReached("AAA reached", 220),
+	AAReached("AA reached", 221),
+	AReached("A reached", 222),
+	BReached("B reached", 223),
+	CReached("C reached", 224),
+	DReached("D reached", 225),
+	EReached("E reached", 226),
+	FReached("F reached", 227),
+
+	GaugeX_1P("1P gauge x%", 230),
+	Gauge1X_1P("1P gauge 1x%", 231),
+	Gauge2X_1P("1P gauge 2x%", 232),
+	Gauge3X_1P("1P gauge 3x%", 233),
+	Gauge4X_1P("1P gauge 4x%", 234),
+	Gauge5X_1P("1P gauge 5x%", 235),
+	Gauge6X_1P("1P gauge 6x%", 236),
+	Gauge7X_1P("1P gauge 7x%", 237),
+	Gauge8X_1P("1P gauge 8x%", 238),
+	Gauge9X_1P("1P gauge 9x%", 239),
+	Gauge100_1P("1P gauge 100%", 240),
+
+	PGREAT_1P("1P PGREAT", 241),
+	GREAT_1P("1P GREAT", 242),
+	GOOD_1P("1P GOOD", 243),
+	BAD_1P("1P BAD", 244),
+	POOR_1P("1P POOR", 245),
+	EmptyPOOR_1P("1P Empty POOR", 246),
+
+	POORBGALayerEnd_1P("1P POORBGA layer end", 247),
+	POORBGALayerStart_1P("1P POORBGA layer start", 248),
+
+	GaugeX_2P("2P gauge x%", 250),
+	Gauge1X_2P("2P gauge 1x%", 251),
+	Gauge2X_2P("2P gauge 2x%", 252),
+	Gauge3X_2P("2P gauge 3x%", 253),
+	Gauge4X_2P("2P gauge 4x%", 254),
+	Gauge5X_2P("2P gauge 5x%", 255),
+	Gauge6X_2P("2P gauge 6x%", 256),
+	Gauge7X_2P("2P gauge 7x%", 257),
+	Gauge8X_2P("2P gauge 8x%", 258),
+	Gauge9X_2P("2P gauge 9x%", 259),
+	Gauge100_2P("2P gauge 100%", 260),
+
+	PGREAT_2P("2P PGREAT", 261),
+	GREAT_2P("2P GREAT", 262),
+	GOOD_2P("2P GOOD", 263),
+	BAD_2P("2P BAD", 264),
+	POOR_2P("2P POOR", 265),
+	EmptyPOOR_2P("2P Empty POOR", 266),
+
+	POORBGALayerEnd_2P("2P POORBGA layer end", 267),
+	POORBGALayerStart_2P("2P POORBGA layer start", 268),
+
+	ChangingSUD_1P("1P changing SUD+", 270),
+	ChangingSUD_2P("2P changing SUD+", 271),
+	ChangingHiSpeed_1P("1P changing Hi-speed", 272),
+	ChangingHiSpeed_2P("2P changing Hi-speed", 273),
+	UsesSUD_1P("1P uses SUD+", 274),
+	UsesSUD_2P("2P uses SUD+", 275),
+	UsesHIDOrLIFT_1P("1P uses HID+/LIFT", 276),
+	UsesHIDOrLIFT_2P("2P uses HID+/LIFT", 277),
+
+	CourseStage1("Course Stage 1", 280),
+	CourseStage2("Course Stage 2", 281),
+	CourseStage3("Course Stage 3", 282),
+	CourseStage4("Course Stage 4", 283),
+	CourseFinalStage("Course Final Stage", 289),
+
+	Course("Course", 290),
+	Nonstop("Nonstop", 291),
+	Expert("Expert", 292),
+	Dan("Dan", 293),
+
+	// Results
+	ResultAAA_1P("1P AAA", 300),
+	ResultAA_1P("1P AA", 301),
+	ResultA_1P("1P A", 302),
+	ResultB_1P("1P B", 303),
+	ResultC_1P("1P C", 304),
+	ResultD_1P("1P D", 305),
+	ResultE_1P("1P E", 306),
+	ResultF_1P("1P F", 307),
+	Result0Percent_1P("1P 0%", 308),
+
+	ResultAAA_2P("2P AAA", 310),
+	ResultAA_2P("2P AA", 311),
+	ResultA_2P("2P A", 312),
+	ResultB_2P("2P B", 313),
+	ResultC_2P("2P C", 314),
+	ResultD_2P("2P D", 315),
+	ResultE_2P("2P E", 316),
+	ResultF_2P("2P F", 317),
+	Result0Percent_2P("2P 0%", 318),
+
+	AAABeforeUpdate("AAA before Update", 320),
+	AABeforeUpdate("AA before Update", 321),
+	ABeforeUpdate("A before Update", 322),
+	BBeforeUpdate("B before Update", 323),
+	CBeforeUpdate("C before Update", 324),
+	DBeforeUpdate("D before Update", 325),
+	EBeforeUpdate("E before Update", 326),
+	FBeforeUpdate("F before Update", 327),
+
+	ScoreUpdated("Score updated", 330),
+	MaxComboUpdated("Max Combo updated", 331),
+	BadPoorUpdated("Bad+Poor updated", 332),
+	TrialUpdated("Trial updated", 333),
+	IRRankingUpdated("IR ranking updated", 334),
+	ScoreRankingUpdated("Score ranking updated", 335),
+
+	AfterUpdateAAA("After update AAA", 340),
+	AfterUpdateAA("After update AA", 341),
+	AfterUpdateA("After update A", 342),
+	AfterUpdateB("After update B", 343),
+	AfterUpdateC("After update C", 344),
+	AfterUpdateD("After update D", 345),
+	AfterUpdateE("After update E", 346),
+	AfterUpdateF("After update F", 347),
+
+	ResultFlipDisabled("Result flip disabled (no #FLIPRESULT or has #DISABLEFLIP)", 350),
+	ResultFlipEnabled("Result flip eabled (has #FLIPRESULT)", 351),
+
+	Win_1P_Lose_2P("1P Win, 2P Lose", 352),
+	Win_2P_Lose_1P("2P Win, 1P Lose", 353),
+	Draw("Draw", 354),
+
+	// Key Config
+	Keys_7_14("7/14 Keys", 400),
+	Keys_9("9 Keys", 401),
+	Keys_5_10("5/10 Keys", 402),
+
+	// Misc
+	BeginnerChartsNotExist("Beginner charts don't exist in folder", 500),
+	NormalChartsNotExist("Normal charts don't exist in folder", 501),
+	HyperChartsNotExist("Hyper charts don't exist in folder", 502),
+	AnotherChartsNotExist("Another charts don't exist in folder", 503),
+	InsaneChartsNotExist("Insane charts don't exist in folder", 504),
+
+	BeginnerChartsExist("Beginner charts exist in folder", 505),
+	NormalChartsExist("Normal charts exist in folder", 506),
+	HyperChartsExist("Hyper charts exist in folder", 507),
+	AnotherChartsExist("Another charts exist in folder", 508),
+	InsaneChartsExist("Insane charts exist in folder", 509),
+
+	Exactly1BeginnerChart("Exactly 1 Beginner chart exist in folder", 510),
+	Exactly1NormalChart("Exactly 1 Normal chart exist in folder", 511),
+	Exactly1HyperChart("Exactly 1 Hyper chart exist in folder", 512),
+	Exactly1AnotherChart("Exactly 1 Another chart exist in folder", 513),
+	Exactly1InsaneChart("Exactly 1 Insane chart exist in folder", 514),
+
+	MultipleBeginnerCharts("Multiple Beginner charts exist in folder", 515),
+	MultipleNormalCharts("Multiple Normal charts exist in folder", 516),
+	MultipleHyperCharts("Multiple Hyper charts exist in folder", 517),
+	MultipleAnotherCharts("Multiple Another charts exist in folder", 518),
+	MultipleInsaneCharts("Multiple Insane charts exist in folder", 519),
+
+	// Doesn't work in LV/LVF.
+	LevelBarBeginnerNoPlay("Level bar Beginner No Play", 520),
+	LevelBarBeginnerFailed("Level bar Beginner Failed", 521),
+	LevelBarBeginnerEasyClear("Level bar Beginner Easy Clear", 522),
+	LevelBarBeginnerClear("Level bar Beginner Clear", 523),
+	LevelBarBeginnerHardClear("Level bar Beginner Hard Clear", 524),
+	LevelBarBeginnerFullCombo("Level bar Beginner Full Combo", 525),
+
+	LevelBarNormalNoPlay("Level bar Normal No Play", 530),
+	LevelBarNormalFailed("Level bar Normal Failed", 531),
+	LevelBarNormalEasyClear("Level bar Normal Easy Clear", 532),
+	LevelBarNormalClear("Level bar Normal Clear", 533),
+	LevelBarNormalHardClear("Level bar Normal Hard Clear", 534),
+	LevelBarNormalFullCombo("Level bar Normal Full Combo", 535),
+
+	LevelBarHyperNoPlay("Level bar Hyper No Play", 540),
+	LevelBarHyperFailed("Level bar Hyper Failed", 541),
+	LevelBarHyperEasyClear("Level bar Hyper Easy Clear", 542),
+	LevelBarHyperClear("Level bar Hyper Clear", 543),
+	LevelBarHyperHardClear("Level bar Hyper Hard Clear", 544),
+	LevelBarHyperFullCombo("Level bar Hyper Full Combo", 545),
+
+	LevelBarAnotherNoPlay("Level bar Another No Play", 550),
+	LevelBarAnotherFailed("Level bar Another Failed", 551),
+	LevelBarAnotherEasyClear("Level bar Another Easy Clear", 552),
+	LevelBarAnotherClear("Level bar Another Clear", 553),
+	LevelBarAnotherHardClear("Level bar Another Hard Clear", 554),
+	LevelBarAnotherFullCombo("Level bar Another Full Combo", 555),
+
+	LevelBarInsaneNoPlay("Level bar Insane No Play", 560),
+	LevelBarInsaneFailed("Level bar Insane Failed", 561),
+	LevelBarInsaneEasyClear("Level bar Insane Easy Clear", 562),
+	LevelBarInsaneClear("Level bar Insane Clear", 563),
+	LevelBarInsaneHardClear("Level bar Insane Hard Clear", 564),
+	LevelBarInsaneFullCombo("Level bar Insane Full Combo", 565),
+
+	SelectingCourse("Selecting a course", 571),
+	NotSelectingCourse("Not selecting a course", 572),
+
+	FirstStageOrHigher("1st stage or higher", 580),
+	SecondStageOrHigher("2nd stage or higher", 581),
+	ThirdStageOrHigher("3rd stage or higher", 582),
+	FourthStageOrHigher("4th stage or higher", 583),
+	FifthStageOrHigher("5th stage or higher", 584),
+	SixthStageOrHigher("6th stage or higher", 585),
+	SeventhStageOrHigher("7th stage or higher", 586),
+	EighthStageOrHigher("8th stage or higher", 587),
+	NinthStageOrHigher("9th stage or higher", 588),
+	TenthStageOrHigher("10th stage or higher", 589),
+
+	SelectingStage1OfCourse("Selecting Stage 1 of Course", 590),
+	SelectingStage2OfCourse("Selecting Stage 2 of Course", 591),
+	SelectingStage3OfCourse("Selecting Stage 3 of Course", 592),
+	SelectingStage4OfCourse("Selecting Stage 4 of Course", 593),
+	SelectingStage5OfCourse("Selecting Stage 5 of Course", 594),
+	SelectingStage6OfCourse("Selecting Stage 6 of Course", 595),
+	SelectingStage7OfCourse("Selecting Stage 7 of Course", 596),
+	SelectingStage8OfCourse("Selecting Stage 8 of Course", 597),
+	SelectingStage9OfCourse("Selecting Stage 9 of Course", 598),
+	SelectingStage10OfCourse("Selecting Stage 10 of Course", 599),
+
+	// LR2 Internet Ranking
+	IRNotAvailable("IR Not available", 600),
+	FetchingIR("Fetching IR", 601),
+	IRFetchComplete("IR Fetch complete", 602),
+	NoPlayersOnIR("No players on IR", 603),
+	FailedToConnectToIR("Failed to connect to IR", 604),
+	BlacklistedChart("Blacklisted (BAN) chart", 605),
+	UploadingToIR("Uploading to IR", 606),
+	AccessingIR("Accessing IR", 607),
+	IRTimedOut("IR timed out", 608),
+
+	NotDisplayingRanking("Not displaying ranking", 620),
+	DisplayingRanking("Displaying ranking", 621),
+
+	NotInGhostBattle("Not in a Ghost Battle", 622),
+	InGhostBattle("In a Ghost Battle", 623),
+
+	NotComparingScoreToRival("Not comparing score to rival", 624),
+	ComparingScoreToRival("Comparing score to rival", 625),
+
+	// I'm not sure whose data these reads from.
+	NoPlayData("No Play", 640),
+	FailedData("Failed", 641),
+	EasyClearData("Easy Clear", 642),
+	ClearData("Clear", 643),
+	HardClearData("Hard Clear", 644),
+	FullComboData("Full Combo", 645),
+
+	AAAData("AAA", 650),
+	AAData("AA", 651),
+	AData("A", 652),
+	BData("B", 653),
+	CData("C", 654),
+	DData("D", 655),
+	EData("E", 656),
+	FData("F", 657),
+
+	// Course Stage 1
+	Stage1Undefined("Stage 1 Undefined", 700),
+	Stage1Beginner("Stage 1 Beginner", 701),
+	Stage1Normal("Stage 1 Normal", 702),
+	Stage1Hyper("Stage 1 Hyper", 703),
+	Stage1Another("Stage 1 Another", 704),
+	Stage1Insane("Stage 1 Insane", 705),
+
+	Stage2Undefined("Stage 2 Undefined", 710),
+	Stage2Beginner("Stage 2 Beginner", 711),
+	Stage2Normal("Stage 2 Normal", 712),
+	Stage2Hyper("Stage 2 Hyper", 713),
+	Stage2Another("Stage 2 Another", 714),
+	Stage2Insane("Stage 2 Insane", 715),
+
+	Stage3Undefined("Stage 3 Undefined", 720),
+	Stage3Beginner("Stage 3 Beginner", 721),
+	Stage3Normal("Stage 3 Normal", 722),
+	Stage3Hyper("Stage 3 Hyper", 723),
+	Stage3Another("Stage 3 Another", 724),
+	Stage3Insane("Stage 3 Insane", 725),
+
+	Stage4Undefined("Stage 4 Undefined", 730),
+	Stage4Beginner("Stage 4 Beginner", 731),
+	Stage4Normal("Stage 4 Normal", 732),
+	Stage4Hyper("Stage 4 Hyper", 733),
+	Stage4Another("Stage 4 Another", 734),
+	Stage4Insane("Stage 4 Insane", 735),
+
+	Stage5Undefined("Stage 5 Undefined", 740),
+	Stage5Beginner("Stage 5 Beginner", 741),
+	Stage5Normal("Stage 5 Normal", 742),
+	Stage5Hyper("Stage 5 Hyper", 743),
+	Stage5Another("Stage 5 Another", 744),
+	Stage5Insane("Stage 5 Insane", 745),
+
+	LaneCoverOn_1P("1P Lane Cover on", 800),
+	NoteTimeLockOn_1P("1P note time lock on", 801),
+	LaneCoverOn_2P("2P Lane Cover on", 810),
+	NoteTimeLockOn_2P("2P note time lock on", 811),
+
+	// 900-998 and 999 is used for skin customization options.
+	AlwaysFalse("Always false", 999),
+
+	ArenaOnline("Arena online", 1000),
+
+	ArenaPresent_1P("Arena 1P present", 1001),
+	ArenaPresent_2P("Arena 2P present", 1002),
+	ArenaPresent_3P("Arena 3P present", 1003),
+	ArenaPresent_4P("Arena 4P present", 1004),
+	ArenaPresent_5P("Arena 5P present", 1005),
+	ArenaPresent_6P("Arena 6P present", 1006),
+	ArenaPresent_7P("Arena 7P present", 1007),
+	ArenaPresent_8P("Arena 8P present", 1008),
+
+	AAA_Arena_1P("Arena 1P AAA", 1010),
+	AA_Arena_1P("Arena 1P AA", 1011),
+	A_Arena_1P("Arena 1P A", 1012),
+	B_Arena_1P("Arena 1P B", 1013),
+	C_Arena_1P("Arena 1P C", 1014),
+	D_Arena_1P("Arena 1P D", 1015),
+	E_Arena_1P("Arena 1P E", 1016),
+	F_Arena_1P("Arena 1P F", 1017),
+
+	BorderAAA_Arena_1P("Arena 1P Border AAA", 1021),
+	BorderAA_Arena_1P("Arena 1P Border AA", 1022),
+	BorderA_Arena_1P("Arena 1P Border A", 1023),
+	BorderB_Arena_1P("Arena 1P Border B", 1024),
+	BorderC_Arena_1P("Arena 1P Border C", 1025),
+	BorderD_Arena_1P("Arena 1P Border D", 1026),
+	BorderE_Arena_1P("Arena 1P Border E", 1027),
+	BorderF_Arena_1P("Arena 1P Border F", 1028),
+
+	GaugeX_Arena_1P("Arena 1P x% gauge", 1030),
+	Gauge1X_Arena_1P("Arena 1P 1x% gauge", 1031),
+	Gauge2X_Arena_1P("Arena 1P 2x% gauge", 1032),
+	Gauge3X_Arena_1P("Arena 1P 3x% gauge", 1033),
+	Gauge4X_Arena_1P("Arena 1P 4x% gauge", 1034),
+	Gauge5X_Arena_1P("Arena 1P 5x% gauge", 1035),
+	Gauge6X_Arena_1P("Arena 1P 6x% gauge", 1036),
+	Gauge7X_Arena_1P("Arena 1P 7x% gauge", 1037),
+	Gauge8X_Arena_1P("Arena 1P 8x% gauge", 1038),
+	Gauge9X_Arena_1P("Arena 1P 9x% gauge", 1039),
+	Gauge100_Arena_1P("Arena 1P 100% gauge", 1040),
+
+	Failed_Arena_1P("Arena 1P failed", 1041),
+	Easy_Arena_1P("Arena 1P easy", 1042),
+	Clear_Arena_1P("Arena 1P clear", 1043),
+	Hard_Arena_1P("Arena 1P hard", 1044),
+	FullCombo_Arena_1P("Arena 1P Full Combo", 1045),
+	EXHard_Arena_1P("Arena 1P EX-Hard", 1046),
+	AssistEasy_Arena_1P("Arena 1P Assist Easy", 1047),
+
+	// 1050-1089 Arena 2P, 1110-1149 Arena 3P, 1150-1189 Arena 4P, 1210-1249 Arena 5P, 1250-1289 Arena 6P, 1310-1349 Arena 7P, 1350-1389 Arena 8P
+
+	ArenaPlayerReady("Arena Player ready", 1400),
+	ArenaReady_1P("Arena 1P ready", 1401),
+	ArenaReady_2P("Arena 2P ready", 1402),
+	ArenaReady_3P("Arena 3P ready", 1403),
+	ArenaReady_4P("Arena 4P ready", 1404),
+	ArenaReady_5P("Arena 5P ready", 1405),
+	ArenaReady_6P("Arena 6P ready", 1406),
+	ArenaReady_7P("Arena 7P ready", 1407),
+	ArenaReady_8P("Arena 8P ready", 1408);
+
+
+	private final String name;
+	private final int value;
+
+	LR2DestinationOptions(String name, int value) {
+		this.name = name;
+		this.value = value;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	@Nullable
+	public static LR2DestinationOptions valueOf(int v) {
+		return Arrays.stream(LR2DestinationOptions.values()).filter(def -> def.value == v).findAny().orElse(null);
+	}
+
+	public SkinManualEntry<LR2DestinationOptions> intoManualEntry() {
+		return new SkinManualEntry<>(this, this.name, this.value);
+	}
+}

--- a/core/src/bms/player/beatoraja/skin/lr2/LR2NumberDef.java
+++ b/core/src/bms/player/beatoraja/skin/lr2/LR2NumberDef.java
@@ -1,0 +1,359 @@
+package bms.player.beatoraja.skin.lr2;
+
+import bms.player.beatoraja.skin.SkinManualEntry;
+import bms.player.beatoraja.skin.property.IntegerPropertyFactory;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static bms.player.beatoraja.skin.SkinProperty.*;
+
+/**
+ * LR2 number definition
+ */
+public enum LR2NumberDef {
+	// Play Options
+	HiSpeed_1P("1P Hi-speed", 10),
+	HiSpeed_2P("2P Hi-speed", 11),
+
+	CurrentJudgeTimingOffset("Current judge timing offset", 12),
+	DefaultTargetRate("Default target rate", 13),
+
+	SUDValue_1P("1P SUD+ value", 14),
+	SUDValue_2P("2P SUD+ value", 15),
+
+	// Date and Time
+	FPS("FPS", 20),
+	Year("Year", 21),
+	Month("Month", 22),
+	Day("Day", 23),
+	Hours("Hours", 24),
+	Minutes("Minutes", 25),
+	Seconds("Seconds", 26),
+
+	// For stats panel
+	TotalPlaycount("Total playcount", 30),
+	TotalClears("Total clears", 31),
+	TotalFails("Total fails", 32),
+
+	TotalPGREATs("Total PGREATs", 33),
+	TotalGREATs("Total GREATs", 34),
+	TotalGOODs("Total GOODs", 35),
+	TotalBADs("Total BADs", 36),
+	TotalPOORs("Total POORs (both Empty POORs and Miss POORs)", 37),
+
+	RunningCombo("Running combo (does not reset every chart, only on CBs)", 38),
+	MaxRunningCombo("Max Running combo", 39),
+
+	TrialLevel("Trial level (only 0)", 40),
+	PreviousTrialLevel("Previous trial level", 41),
+
+	LevelBeginnerInFolder("Level of Beginner chart in Folder", 45),
+	LevelNormalInFolder("Level of Normal chart in Folder", 46),
+	LevelHyperInFolder("Level of Hyper chart in Folder", 47),
+	LevelAnotherInFolder("Level of Another chart in Folder", 48),
+	LevelInsaneInFolder("Level of Insane chart in Folder", 49),
+
+	// Effects panel
+	Hz62("62Hz", 50),
+	Hz160("160Hz", 51),
+	Hz400("400Hz", 52),
+	Hz1K("1Khz", 53),
+	Hz2_5K("2.5Khz", 54),
+	Hz6_3K("6.3Khz", 55),
+	Hz16K("16Khz", 56),
+
+	MasterVolume("Master Volume", 57),
+	KeyVolume("Key Volume", 58),
+	BGMVolume("BGM Volume", 59),
+
+	FX0_1P("FX0 1P", 60),
+	FX0_2P("FX0 2P", 61),
+
+	FX1_1P("FX1 1P", 62),
+	FX1_2P("FX1 2P", 63),
+
+	FX2_1P("FX2 1P", 64),
+	FX2_2P("FX2 2P", 65),
+
+	FreqPitchSpeedValue("FREQ/PITCH/SPEED value", 66),
+
+	// Selecting songs
+	MoneyScore("Money score", 70),
+	EXScore("EX score", 71),
+	TargetEXScore("Target EX score", 72),
+	RatePercent("Rate %", 73),
+	TotalNotes("Total notes", 74),
+	MaxCombo("Max Combo", 75),
+	BadPoor("Bad + Poor", 76),
+	// Only shows 0 or 1 in LVF.
+	Plays("Plays", 77),
+	Clears("Clears", 78),
+	Fails("Fails", 79),
+
+	PGREATCount("PGREAT count", 80),
+	GREATCount("GREAT count", 81),
+	GOODCount("GOOD count", 82),
+	BADCount("BAD count", 83),
+	POORCount("POOR count", 84),
+	PGREATPercent("PGREAT %", 85),
+	GREATPercent("GREAT %", 86),
+	GOODPercent("GOOD %", 87),
+	BADPercent("BAD %", 88),
+	POORPercent("POOR %", 89),
+
+	MaxBPM("Max BPM", 90),
+	MinBPM("Min BPM", 91),
+
+	IRRank("IR rank", 92),
+	IRPlayers("IR players", 93),
+	IRClearRate("IR clear rate", 94),
+	IRRivalScoreDifference("IR rival score difference", 95),
+
+	// Playing 1P
+	MoneyScore_1P("Money score", 100),
+	EXScore_1P("EX score", 101),
+	Rate_1P("Rate", 102),
+	RateDecimal_1P("Rate decimal value (2 digits)", 103),
+	CurrentCombo_1P("Current combo", 104),
+	MaxCombo_1P("Max combo", 105),
+	TotalNotes_1P("Total notes", 106),
+	GrooveGauge_1P("Groove gauge", 107),
+	EXScoreDifferenceFrom2P_1P("EX score difference from 2P", 108),
+
+	PGREATs_1P("PGREATs", 110),
+	GREATs_1P("GREATs", 111),
+	GOODs_1P("GOODs", 112),
+	BADs_1P("BADs", 113),
+	POORs_1P("POORs", 114),
+	IncrementalRate_1P("Incremental Rate", 115),
+	IncrementalRateDecimal_1P("Incremental Rate decimal part (2 digits)", 116),
+
+	// Playing 2P
+	MoneyScore_2P("Money score", 120),
+	EXScore_2P("EX score", 121),
+	Rate_2P("Rate", 122),
+	RateDecimal_2P("Rate decimal value (2 digits)", 123),
+	CurrentCombo_2P("Current combo", 124),
+	MaxCombo_2P("Max combo", 125),
+	TotalNotes_2P("Total notes", 126),
+	GrooveGauge_2P("Groove gauge", 127),
+	EXScoreDifferenceFrom1P_2P("EX score difference from 1P", 128),
+
+	PGREATs_2P("PGREATs", 130),
+	GREATs_2P("GREATs", 131),
+	GOODs_2P("GOODs", 132),
+	BADs_2P("BADs", 133),
+	POORs_2P("POORs", 134),
+	IncrementalRate_2P("Incremental Rate", 135),
+	IncrementalRateDecimal_2P("Incremental Rate decimal part (2 digits)", 136),
+
+	// Result skin (MUST USE #DISABLEFLIP)
+	HighScore("High score", 150),
+	TargetScore("Target score", 151),
+	DifferenceHighScoreCurrentScore("Difference between high score and current score", 152),
+	DifferenceTargetScoreCurrentScore("Difference between target score and current score", 153),
+	DifferenceFromNextRank("Difference from next rank", 154),
+	HighScoreRate("High score RATE", 155),
+	HighScoreRateDecimal("High score RATE decimal part (2 digits)", 156),
+	TargetScoreRate("Target score RATE", 157),
+	TargetScoreRateDecimal("Target score RATE decimal part (2 digits)", 158),
+
+	// Play status
+	CurrentBPM("Current BPM", 160),
+	MinutesCurrent("Minutes", 161),
+	SecondsCurrent("Seconds", 162),
+	RemainingMinutes("Remaining minutes", 163),
+	RemainingSeconds("Remaining seconds", 164),
+	ChartLoadPercent("Chart load %", 165),
+
+	// Update screen
+	EXScoreBeforeUpdate("EX Score before Update", 170),
+	EXScoreAfterUpdate("EX Score after Update", 171),
+	EXScoreDifference("EX Score difference", 172),
+
+	MaxComboBeforeUpdate("Max Combo before Update", 173),
+	MaxComboAfterUpdate("Max Combo after Update", 174),
+	MaxComboDifference("Max Combo difference", 175),
+
+	BadPoorBeforeUpdate("Bad+Poor before Update", 176),
+	BadPoorAfterUpdate("Bad+Poor after Update", 177),
+	BadPoorDifference("Bad+Poor difference", 178),
+
+	IRRankUpdate("IR rank", 179),
+	IRTotalPlayersUpdate("IR total players", 180),
+	IRClearRateUpdate("IR clear rate", 181),
+	IRRankBeforeUpdate("IR rank before update", 182),
+
+	RateBeforeUpdate("Rate before update", 183),
+	RateDecimalBeforeUpdate("Rate decimal before update (2 digits)", 184),
+
+	// FAST/SLOW and stuff
+	HitOffset_1P("1P hit offset (ms)", 201),
+	FastSlow_1P("1P FAST/SLOW", 210),
+	FastSlow_2P("2P FAST/SLOW", 211),
+	// Combine with DST op 35 for SLOW, and -35 for FAST.
+	FastCount("Fast count", 212),
+	HitOffset_2P("2P hit offset (ms)", 213),
+	SlowCount("Slow count", 214),
+	ComboBreaks("Combo Breaks", 216),
+	RemainingNotes("Remaining notes", 217),
+	RunningNotes("Running notes", 218),
+
+	// LR2IR
+	IRPlayersInfo("IR players", 200),
+	IRTotalPlays("IR total plays", 201),
+
+	FailedPlayers("Failed players", 210),
+	FailedPlayersPercentage("Failed players percentage", 211),
+	EasyClearedPlayers("Easy cleared players", 212),
+	EasyClearedPlayersPercentage("Easy cleared players percentage", 213),
+	ClearedPlayers("Cleared players", 214),
+	ClearedPlayersPercentage("Cleared players percentage", 215),
+	HardClearedPlayers("Hard Cleared players", 216),
+	HardClearedPlayersPercentage("Hard Cleared players percentage", 217),
+	FullComboClearedPlayers("Full Combo Cleared players", 218),
+	FullComboClearedPlayersPercentage("Full Combo Cleared players percentage", 219),
+
+	TimeRemainingUntilIRAutoUpdate("Time remaining until IR auto update", 220),
+
+	// Course stage levels
+	CourseStage1Level("Course Stage 1 level", 250),
+	CourseStage2Level("Course Stage 2 level", 251),
+	CourseStage3Level("Course Stage 3 level", 252),
+	CourseStage4Level("Course Stage 4 level", 253),
+	CourseStage5Level("Course Stage 5 level", 254),
+
+	// In Rival folder
+	MoneyScoreRival("Money score", 270),
+	EXScoreRival("EX score", 271),
+	TargetEXScoreRival("Target EX score", 272),
+	RatePercentRival("Rate %", 273),
+	TotalNotesRival("Total notes", 274),
+	MaxComboRival("Max Combo", 275),
+	BadPoorRival("Bad + Poor", 276),
+	PlaysRival("Plays", 277),
+	ClearsRival("Clears", 278),
+	FailsRival("Fails", 279),
+
+	PGREATCountRival("PGREAT count", 280),
+	GREATCountRival("GREAT count", 281),
+	GOODCountRival("GOOD count", 282),
+	BADCountRival("BAD count", 283),
+	POORCountRival("POOR count", 284),
+	PGREATPercentRival("PGREAT %", 285),
+	GREATPercentRival("GREAT %", 286),
+	GOODPercentRival("GOOD %", 287),
+	BADPercentRival("BAD %", 288),
+	POORPercentRival("POOR %", 289),
+
+	MaxBPMRival("Max BPM", 290),
+	MinBPMRival("Min BPM", 291),
+
+	IRRankRival("IR rank", 292),
+	IRPlayersRival("IR players", 293),
+	IRClearRateRival("IR clear rate", 294),
+
+	RandomPattern_1P("1P random pattern (7 digit long from 1-7)", 295),
+	HitMean("Hit mean", 296),
+	HitMeanDecimal("Hit mean decimal part (2 digits)", 297),
+	StandardDeviation("Standard deviation", 298),
+	StandardDeviationDecimal("Standard deviation decimal part (2 digits)", 299),
+	Total("TOTAL", 301),
+	GreenNumber("Green number", 302),
+	WhiteNumber("White number", 303),
+	GreenNumberMin("Green number min", 304),
+	GreenNumberMax("Green number max", 305),
+
+	PARatio("PA ratio", 400),
+	PARatioDecimal("PA ratio decimal part", 401),
+	GARatio("GA ratio", 402),
+	GARatioDecimal("GA ratio decimal part", 403),
+
+	PGREATPercentage("PGREAT percentage", 404),
+	PGREATPercentageDecimal("PGREAT percentage decimal part", 405),
+	GREATPercentage("GREAT percentage", 406),
+	GREATPercentageDecimal("GREAT percentage decimal part", 407),
+	GOODPercentage("GOOD percentage", 408),
+	GOODPercentageDecimal("GOOD percentage decimal part", 409),
+	BADPercentage("BAD percentage", 410),
+	BADPercentageDecimal("BAD percentage decimal part", 411),
+	POORPercentage("POOR percentage", 412),
+	POORPercentageDecimal("POOR percentage decimal part", 413),
+
+	GreenNumberDecimal("Green number decimal part", 414),
+	WhiteNumberDecimal("White number decimal part", 415),
+
+	LIFTNumber("LIFT number", 416),
+	LIFTNumberDecimal("LIFT number decimal part", 417),
+
+	RandomPattern_2P("2P random pattern", 418),
+
+	CustomGauge("Custom gauge", 419),
+	CustomGaugeDecimal1("Custom gauge decimal part (1 digit)", 420),
+	CustomGaugeDecimal2("Custom gauge decimal part (2 digit)", 421),
+
+	TotalJudgements("Total judgements", 422),
+	WastedHumanCyclesSessionSeconds("Wasted human cycles this session (seconds)", 423),
+	WastedHumanCyclesSessionMinutes("Wasted human cycles this session (minutes)", 424),
+	WastedHumanCyclesSessionHours("Wasted human cycles this session (hours)", 425),
+	TotalWastedHumanCyclesSeconds("Total wasted human cycles (seconds)", 426),
+	TotalWastedHumanCyclesMinutes("Total wasted human cycles (minutes)", 427),
+	TotalWastedHumanCyclesHours("Total wasted human cycles (hours)", 428),
+
+	// Arena
+	ArenaEXScoreDifferenceTo1st("ARENA EX Score difference to 1st place", 450),
+
+	ArenaMoneyScore_1P("ARENA 1P money score", 500),
+	ArenaEXScore_1P("ARENA 1P EX Score", 501),
+	ArenaCurrentCombo_1P("ARENA 1P current combo", 502),
+	ArenaMaxCombo_1P("ARENA 1P max combo", 503),
+	ArenaRate_1P("ARENA 1P rate", 504),
+	ArenaRateDecimal_1P("ARENA 1P rate decimal part", 505),
+	ArenaTotalNotes_1P("ARENA 1P total notes", 506),
+	ArenaIncrementalRate_1P("ARENA 1P incremental rate", 507),
+	ArenaIncrementalRateDecimal_1P("ARENA 1P incremental rate decimal part", 508),
+	ArenaPGREATCount_1P("ARENA 1P PGREAT count", 509),
+	ArenaGREATCount_1P("ARENA 1P GREAT count", 510),
+	ArenaGOODCount_1P("ARENA 1P GOOD count", 511),
+	ArenaBADCount_1P("ARENA 1P BAD count", 512),
+	ArenaPOORCount_1P("ARENA 1P POOR count", 513),
+	ArenaEmptyPOORCount_1P("ARENA 1P Empty POOR count", 514),
+	ArenaMissCount_1P("ARENA 1P Miss count", 515),
+	ArenaBadPoorCount_1P("ARENA 1P Bad+Poor count", 516),
+	ArenaComboBreakCount_1P("ARENA 1P Combo Break count", 517),
+	ArenaGauge_1P("ARENA 1P gauge", 518),
+	ArenaEXScoreDifferenceToNextRank_1P("ARENA 1P EX Score difference to Next rank", 519),
+	ArenaEXScoreDifferenceTo1P_1P("ARENA 1P Ex Score difference to 1P (?)", 520);
+
+// Note: 530-559 ARENA 2P, 560-589 ARENA 3P, 590-619 ARENA 4P,
+// 620-649 ARENA 5P, 650-679 ARENA 6P, 680-709 ARENA 7P, 710-739 ARENA 8P
+// These ranges follow the same pattern as ARENA 1P (500-520) but for other players.
+// For brevity, we'll list the ranges as comments.
+
+	private final String name;
+	private final int value;
+
+	LR2NumberDef(String name, int value) {
+		this.name = name;
+		this.value = value;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	@Nullable
+	public static LR2NumberDef valueOf(int v) {
+		return Arrays.stream(LR2NumberDef.values()).filter(def -> def.value == v).findAny().orElse(null);
+	}
+
+	public SkinManualEntry<LR2NumberDef> intoManualEntry() {
+		return new SkinManualEntry<>(this, this.name, this.value);
+	}
+}

--- a/core/src/bms/player/beatoraja/skin/lr2/LR2TextDef.java
+++ b/core/src/bms/player/beatoraja/skin/lr2/LR2TextDef.java
@@ -1,0 +1,217 @@
+package bms.player.beatoraja.skin.lr2;
+
+import bms.player.beatoraja.skin.SkinManualEntry;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+
+/**
+ * text st definitions
+ */
+public enum LR2TextDef {
+	Rival("Target/Rival Name", 1),
+	Player("Player Name", 2),
+	CurrentSongTitle("Current Song Title", 10),
+	CurrentSongSubTitle("Current Song Sub Title", 11),
+	CurrentSongFullTitle("Current Song Full Title", 12),
+	CurrentSongGenre("Current Song Genre", 13),
+	CurrentSongArtist("Current Song Artist", 14),
+	CurrentSongSubArtist("Current Song Subartist", 15),
+	CurrentSongSearchText("Current Song Search Text", 16),
+	CurrentSongPlayLevel("Current Song Play Level", 17),
+	CurrentSongDifficultyNumber("Current Song Difficulty Number", 18),
+
+	// For editing
+	EditingCurrentSongTitle("Editing Current Song Title", 20),
+	EditingCurrentSongSubTitle("Editing Current Song Sub Title", 21),
+	EditingCurrentSongFullTitle("Editing Current Song Full Title", 22),
+	EditingCurrentSongGenre("Editing Current Song Genre", 23),
+	EditingCurrentSongArtist("Editing Current Song Artist", 24),
+	EditingCurrentSongSubartist("Editing Current Song Subartist", 25),
+	EditingCurrentSongSearchQuery("Editing Current Song Search query", 26),
+	EditingCurrentSongPlayLevel("Editing Current Song play level", 27),
+	EditingCurrentSongDifficultyNumber("Editing Current Song Difficulty Number", 28),
+	EditingCurrentSongInsaneLevel("Editing Current Song Insane level", 29),
+	EditingSearchTitleCurrentFolder("Search Title/Current Folder", 30),
+
+	KeybindSlot1("Keybind slot 1", 40),
+	KeybindSlot2("Keybind slot 2", 41),
+	KeybindSlot3("Keybind slot 3", 42),
+	KeybindSlot4("Keybind slot 4", 43),
+	KeybindSlot5("Keybind slot 5", 44),
+	KeybindSlot6("Keybind slot 6", 45),
+	KeybindSlot7("Keybind slot 7", 46),
+	KeybindSlot8("Keybind slot 8", 47),
+
+	SkinName("Skin name", 50),
+	SkinAuthor("Skin author", 51),
+
+	KeyMode("Key mode", 60),
+	SongSort("Song sort", 61),
+	Difficulty("Difficulty", 62),
+	Option1P("Option 1P", 63),
+	Option2P("Option 2P", 64),
+	Gauge1P("Gauge 1P", 65),
+	Gauge2P("Gauge 1P", 66),
+	AutoScratch1P("Auto Scratch 1P", 67),
+	AutoScratch2P("Auto Scratch 2P", 68),
+	Battle("Battle", 69),
+	DPFlip("DP Flip", 70),
+	ScoreGraph("Score graph", 71),
+	Ghost("Ghost", 72),
+	LaneCover("Lane cover", 73),
+	HiSpeedFix("Hi-speed fix", 74),
+	BGASize("BGA size", 75),
+	BGADisplay("BGA display", 76),
+	ColorMode("Color mode", 77),
+	Vsync("Vsync", 78),
+	ScreenMode("Screen mode", 79),
+	JudgeAutoAdjust("Judge Auto Adjust", 80),
+	ReplaySave("Replay save", 81),
+	TrialLine1("Trial Line 1", 82),
+	TrialLine2("Trial Line 2", 83),
+	FX1P("FX 1P", 84),
+	FX2P("FX 2P", 85),
+
+	FirstSkinCustomizationOption("1st skin customization option", 100),
+	SecondSkinCustomizationOption("2nd skin customization option", 101),
+	ThirdSkinCustomizationOption("3rd skin customization option", 102),
+	FourthSkinCustomizationOption("4th skin customization option", 103),
+	FifthSkinCustomizationOption("5th skin customization option", 104),
+	SixthSkinCustomizationOption("6th skin customization option", 105),
+	SeventhSkinCustomizationOption("7th skin customization option", 106),
+	EighthSkinCustomizationOption("8th skin customization option", 107),
+	NinthSkinCustomizationOption("9th skin customization option", 108),
+	TenthSkinCustomizationOption("10th skin customization option", 109),
+
+	FirstSkinCustomizationCurrentOption("1st skin customization current option", 110),
+	SecondSkinCustomizationCurrentOption("2nd skin customization current option", 111),
+	ThirdSkinCustomizationCurrentOption("3rd skin customization current option", 112),
+	FourthSkinCustomizationCurrentOption("4th skin customization current option", 113),
+	FifthSkinCustomizationCurrentOption("5th skin customization current option", 114),
+	SixthSkinCustomizationCurrentOption("6th skin customization current option", 115),
+	SeventhSkinCustomizationCurrentOption("7th skin customization current option", 116),
+	EighthSkinCustomizationCurrentOption("8th skin customization current option", 117),
+	NinthSkinCustomizationCurrentOption("9th skin customization current option", 118),
+	TenthSkinCustomizationCurrentOption("10th skin customization current option", 119),
+
+	Leaderboard1stPlayerName("Leaderboard 1st player name", 120),
+	Leaderboard2ndPlayerName("Leaderboard 2nd player name", 121),
+	Leaderboard3rdPlayerName("Leaderboard 3rd player name", 122),
+	Leaderboard4thPlayerName("Leaderboard 4th player name", 123),
+	Leaderboard5thPlayerName("Leaderboard 5th player name", 124),
+	Leaderboard6thPlayerName("Leaderboard 6th player name", 125),
+	Leaderboard7thPlayerName("Leaderboard 7th player name", 126),
+	Leaderboard8thPlayerName("Leaderboard 8th player name", 127),
+	Leaderboard9thPlayerName("Leaderboard 9th player name", 128),
+	Leaderboard10thPlayerName("Leaderboard 10th player name", 129),
+
+	// Courses
+	Course1stStageTitle("Course 1st stage Title", 150),
+	Course2ndStageTitle("Course 2nd stage Title", 151),
+	Course3rdStageTitle("Course 3rd stage Title", 152),
+	Course4thStageTitle("Course 4th stage Title", 153),
+	Course5thStageTitle("Course 5th stage Title", 154),
+	Course6thStageTitle("Course 6th stage Title", 155),
+	Course7thStageTitle("Course 7th stage Title", 156),
+	Course8thStageTitle("Course 8th stage Title", 157),
+	Course9thStageTitle("Course 9th stage Title", 158),
+	Course10thStageTitle("Course 10th stage Title", 159),
+
+	Course1stStageSubtitle("Course 1st stage Subtitle", 160),
+	Course2ndStageSubtitle("Course 2nd stage Subtitle", 161),
+	Course3rdStageSubtitle("Course 3rd stage Subtitle", 162),
+	Course4thStageSubtitle("Course 4th stage Subtitle", 163),
+	Course5thStageSubtitle("Course 5th stage Subtitle", 164),
+	Course6thStageSubtitle("Course 6th stage Subtitle", 165),
+	Course7thStageSubtitle("Course 7th stage Subtitle", 166),
+	Course8thStageSubtitle("Course 8th stage Subtitle", 167),
+	Course9thStageSubtitle("Course 9th stage Subtitle", 168),
+	Course10thStageSubtitle("Course 10th stage Subtitle", 169),
+
+	CourseName("Course name", 170),
+
+	CourseStage1To2Transition("Course stage 1-2 transition", 171),
+	CourseStage2To3Transition("Course stage 2-3 transition", 172),
+	CourseStage3To4Transition("Course stage 3-4 transition", 173),
+	CourseStage4To5Transition("Course stage 4-5 transition", 174),
+	CourseStage5To6Transition("Course stage 5-6 transition", 175),
+	CourseStage6To7Transition("Course stage 6-7 transition", 176),
+	CourseStage7To8Transition("Course stage 7-8 transition", 177),
+	CourseStage8To9Transition("Course stage 8-9 transition", 178),
+	CourseStage9To10Transition("Course stage 9-10 transition", 179),
+
+	CourseSoflan("Course Soflan", 180),
+	CourseGaugeType("Course gauge type", 181),
+	CourseBannedOptions("Course banned options", 182),
+	CourseIR("Course IR", 183),
+
+	RandomCourseOptimalLevel("Random Course optimal level", 190),
+	RandomCourseMaxLevel("Random Course Max level", 191),
+	RandomCourseMinLevel("Random Course Min level", 192),
+	RandomCourseBPMRange("Random Course BPM range", 193),
+	RandomCourseMaxBPM("Random Course Max BPM", 194),
+	RandomCourseMinBPM("Random Course Min BPM", 195),
+	RandomCourseStageCount("Random Course Stage count", 196),
+	DefaultCourseTransition("Default Course transition", 198),
+	DefaultCourseGauge("Default Course gauge", 199),
+
+	// Arena Extension
+	ArenaStatus("ARENA status", 260),
+	Arena1PName("ARENA 1P name", 261),
+	Arena2PName("ARENA 2P name", 262),
+	Arena3PName("ARENA 3P name", 263),
+	Arena4PName("ARENA 4P name", 264),
+	Arena5PName("ARENA 5P name", 265),
+	Arena6PName("ARENA 6P name", 266),
+	Arena7PName("ARENA 7P name", 267),
+	Arena8PName("ARENA 8P name", 268),
+
+	PlayerModifier("Player modifier", 270),
+	Arena1PModifiers("ARENA 1P modifiers", 271),
+	Arena2PModifiers("ARENA 2P modifiers", 272),
+	Arena3PModifiers("ARENA 3P modifiers", 273),
+	Arena4PModifiers("ARENA 4P modifiers", 274),
+	Arena5PModifiers("ARENA 5P modifiers", 275),
+	Arena6PModifiers("ARENA 6P modifiers", 276),
+	Arena7PModifiers("ARENA 7P modifiers", 277),
+	Arena8PModifiers("ARENA 8P modifiers", 278),
+
+	PlayerModifierShort("Player modifier short", 280),
+	Arena1PModifiersShort("ARENA 1P modifiers short", 281),
+	Arena2PModifiersShort("ARENA 2P modifiers short", 282),
+	Arena3PModifiersShort("ARENA 3P modifiers short", 283),
+	Arena4PModifiersShort("ARENA 4P modifiers short", 284),
+	Arena5PModifiersShort("ARENA 5P modifiers short", 285),
+	Arena6PModifiersShort("ARENA 6P modifiers short", 286),
+	Arena7PModifiersShort("ARENA 7P modifiers short", 287),
+	Arena8PModifiersShort("ARENA 8P modifiers short", 288),
+
+	// Not present in LR2 or any variants, only for compatibility
+	TableFullName("Table full name", 1003);
+
+	private final String name;
+	private final int value;
+
+	LR2TextDef(String name, int value) {
+		this.name = name;
+		this.value = value;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	@Nullable
+	public static LR2TextDef valueOf(int v) {
+		return Arrays.stream(LR2TextDef.values()).filter(def -> def.value == v).findAny().orElse(null);
+	}
+
+	public SkinManualEntry<LR2TextDef> intoManualEntry() {
+		return new SkinManualEntry<>(this, this.name, this.value);
+	}
+}

--- a/core/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
@@ -15,6 +15,7 @@ import bms.player.beatoraja.result.CourseResult;
 import bms.player.beatoraja.result.MusicResult;
 import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.select.bar.*;
+import bms.player.beatoraja.skin.SkinManualEntry;
 import bms.player.beatoraja.skin.SkinProperty;
 import bms.player.beatoraja.song.SongData;
 
@@ -676,10 +677,14 @@ public class BooleanPropertyFactory {
 		 * StringProperty
 		 */
 		private final BooleanProperty property;
-		
+
 		private BooleanType(int id, BooleanProperty property) {
 			this.id = id;
 			this.property = property;
+		}
+
+		public SkinManualEntry<BooleanType> intoManualEntry() {
+			return new SkinManualEntry<>(this, this.name(), this.id);
 		}
 	}
 }

--- a/core/src/bms/player/beatoraja/skin/property/EventFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/EventFactory.java
@@ -11,6 +11,7 @@ import bms.player.beatoraja.result.*;
 import bms.player.beatoraja.select.BarSorter;
 import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.select.bar.*;
+import bms.player.beatoraja.skin.SkinManualEntry;
 import bms.player.beatoraja.skin.SkinProperty;
 import bms.player.beatoraja.song.SongData;
 import com.badlogic.gdx.graphics.Color;
@@ -779,7 +780,11 @@ public class EventFactory {
 			this.id = id;
 			this.event = createTwoArgEvent(action, id);
 		}
-		
+
+		public SkinManualEntry<EventType> intoManualEntry() {
+			return new SkinManualEntry<>(this, this.name(), this.id);
+		}
+
 	    private static BiConsumer<MainState, Integer> changeAutoSaveReplay(final int index) {
 	    	return (state, arg1) -> {
 	    		if(state instanceof MusicSelector selector) {

--- a/core/src/bms/player/beatoraja/skin/property/FloatPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/FloatPropertyFactory.java
@@ -12,6 +12,7 @@ import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.select.bar.Bar;
 import bms.player.beatoraja.select.bar.GradeBar;
 import bms.player.beatoraja.select.bar.SongBar;
+import bms.player.beatoraja.skin.SkinManualEntry;
 import bms.player.beatoraja.song.SongData;
 import bms.player.beatoraja.result.AbstractResult;
 
@@ -22,9 +23,6 @@ import bms.player.beatoraja.result.AbstractResult;
  */
 public class FloatPropertyFactory {
 	
-	private static RateType[] RateTypeValues = RateType.values();
-	private static FloatType[] FloatTypeValues = FloatType.values();
-
 	private static final int PG = 0;
 	private static final int GR = 1;
 	private static final int GD = 2;
@@ -37,7 +35,7 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatProperty
 	 */
 	public static FloatProperty getRateProperty(int optionid) {
-		for(RateType t : RateTypeValues) {
+		for(RateType t : RateType.values()) {
 			if(t.id == optionid) {
 				return t.property;
 			}
@@ -52,7 +50,7 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatProperty
 	 */
 	public static FloatProperty getRateProperty(String name) {
-		for(RateType t : RateTypeValues) {
+		for(RateType t : RateType.values()) {
 			if(t.name().equals(name)) {
 				return t.property;
 			}
@@ -67,7 +65,7 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatWriter
 	 */
 	public static FloatWriter getRateWriter(int id) {
-		for(RateType t : RateTypeValues) {
+		for(RateType t : RateType.values()) {
 			if(t.id == id) {
 				return t.writer;
 			}
@@ -82,7 +80,7 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatWriter
 	 */
 	public static FloatWriter getRateWriter(String name) {
-		for(RateType t : RateTypeValues) {
+		for(RateType t : RateType.values()) {
 			if(t.name().equals(name)) {
 				return t.writer;
 			}
@@ -94,16 +92,16 @@ public class FloatPropertyFactory {
 	 * FloatType IDに対応するFloatPropertyを返す
 	 * なければRateType IDに対応するFloatPropertyを返す
 	 * 
-	 * @param id property ID
+	 * @param optionid property ID
 	 * @return 対応するFloatProperty
 	 */
 	public static FloatProperty getFloatProperty(int optionid) {
-		for(FloatType t : FloatTypeValues) {
+		for(FloatType t : FloatType.values()) {
 			if(t.id == optionid) {
 				return t.property;
 			}
 		}
-		for(RateType r : RateTypeValues) {
+		for(RateType r : RateType.values()) {
 			if(r.id == optionid) {
 				return r.property;
 			}
@@ -119,12 +117,12 @@ public class FloatPropertyFactory {
 	 * @return 対応するFloatProperty
 	 */
 	public static FloatProperty getFloatProperty(String name) {
-		for(FloatType t : FloatTypeValues) {
+		for(FloatType t : FloatType.values()) {
 			if(t.name().equals(name)) {
 				return t.property;
 			}
 		}
-		for(RateType r : RateTypeValues) {
+		for(RateType r : RateType.values()) {
 			if(r.name().equals(name)) {
 				return r.property;
 			}
@@ -493,6 +491,9 @@ public class FloatPropertyFactory {
 			this.property = property;
 		}
 
+		public SkinManualEntry<FloatType> intoManualEntry() {
+			return new SkinManualEntry<>(this, this.name(), this.id);
+		}
 	}
 
 	private static FloatProperty createIRClearRateProperty(int clearType) {

--- a/core/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
+++ b/core/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
@@ -14,8 +14,12 @@ import bms.player.beatoraja.result.AbstractResult;
 import bms.player.beatoraja.result.CourseResult;
 import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.select.bar.*;
+import bms.player.beatoraja.skin.SkinManualEntry;
 import bms.player.beatoraja.song.SongData;
 import com.badlogic.gdx.utils.IntMap;
+import com.github.therapi.runtimejavadoc.CommentFormatter;
+import com.github.therapi.runtimejavadoc.FieldJavadoc;
+import com.github.therapi.runtimejavadoc.RuntimeJavadoc;
 
 import java.util.*;
 
@@ -53,8 +57,10 @@ public class StringPropertyFactory {
 	}
 	
 	public enum StringType {
-		
-		rival(1, (state) -> {
+        /**
+         * In music select scene, it's the selected rival's name. Otherwise, it's based on the target score
+         */
+        rival(1, (state) -> {
 			if (state instanceof MusicSelector selector) {
 				final PlayerInformation rival = selector.getRival();
 				return rival != null ? rival.getName() : "";
@@ -63,7 +69,13 @@ public class StringPropertyFactory {
 				return rival != null ? rival.getPlayer() : "";
 			}
 		}),
+		/**
+		 * Current profile's player name
+		 */
 		player(2, (state) -> (state.resource.getPlayerConfig().getName())),
+		/**
+		 * In music select scene, it's the selected score rank target. Otherwise, it's based on the target score
+		 */
 		target(3, (state) -> {
 			if (state instanceof MusicSelector) {
 				return TargetProperty.getTargetName(state.resource.getPlayerConfig().getTargetid());					
@@ -72,6 +84,11 @@ public class StringPropertyFactory {
 				return target != null ? target.getPlayer() : "";
 			}
 		}),
+		/**
+		 * In music select scene, it's the current bar's name. In music decide and course result scene, it's the
+		 * course's title. Otherwise, it's the song's title.
+		 * When enabling rate mode, song's title has a special prefix like [1.20x] represents the current rate
+		 */
 		title(10, (state) -> {
 			if (state instanceof MusicSelector selector && selector.getSelectedBar() instanceof DirectoryBar) {
 				return selector.getSelectedBar().getTitle();
@@ -86,6 +103,9 @@ public class StringPropertyFactory {
 			}
 			return song != null ? song.getTitle() : "";
 		}),
+		/**
+		 * In music select scene, it's the current bar's sub title. Otherwise, it's the current song's sub title
+		 */
         subtitle(11, (state) -> {
 			if (state instanceof MusicSelector selector && selector.getSelectedBar() instanceof FunctionBar) {
 				return ((FunctionBar) selector.getSelectedBar()).getSubtitle();
@@ -311,7 +331,11 @@ public class StringPropertyFactory {
 		public static StringType get(int id) {
 			return ID_MAP.get(id);
 		}
-		
+
+        public SkinManualEntry<StringType> intoManualEntry() {
+            return new SkinManualEntry<>(this, this.name(), this.id);
+        }
+
 		private StringType(int id, StringProperty property) {
 			this.id = id;
 			this.property = property;
@@ -406,4 +430,17 @@ public class StringPropertyFactory {
 			};
 		}		
 	}
+
+    public static void main(String[] args) {
+        CommentFormatter formatter = new CommentFormatter();
+        FieldJavadoc javadoc = RuntimeJavadoc.getJavadoc(StringType.rival);
+        if (javadoc.isEmpty()) {
+            System.out.println("No documentation");
+            return ;
+        }
+
+        System.out.println(javadoc.getName());
+        System.out.println(formatter.format(javadoc.getComment()));
+        System.out.println();
+    }
 }

--- a/core/src/bms/tool/util/Pair.java
+++ b/core/src/bms/tool/util/Pair.java
@@ -81,7 +81,7 @@ public final class Pair<K, V> {
 		return condition.test(this.first, this.second);
 	}
 
-	public <T extends Comparable<T>, U extends Comparable<U>> Comparator<Pair<T, U>> DEFAULT_COMPARATOR() {
+	public static <T extends Comparable<T>, U extends Comparable<U>> Comparator<Pair<T, U>> DEFAULT_COMPARATOR() {
 		return (o1, o2) -> o1.first.equals(o2.first)
 				? o1.second.compareTo(o2.second)
 				: o1.first.compareTo(o2.first);

--- a/core/src/bms/tool/utils/Either.java
+++ b/core/src/bms/tool/utils/Either.java
@@ -1,0 +1,54 @@
+package bms.tool.utils;
+
+import java.util.function.Function;
+
+public class Either<T, U> {
+    private final boolean isLeft;
+    private final T left;
+    private final U right;
+
+    private Either(T left, U right) {
+        this.isLeft = left != null;
+        this.left = left;
+        this.right = right;
+    }
+
+    public static <T, U> Either<T, U> of(T left, U right) {
+        if (left != null && right != null) {
+            throw new IllegalArgumentException();
+        }
+        return new Either<>(left, right);
+    }
+
+    public <K, V> Either<K, V> apply(Function<T, K> onLeft, Function<U, V> onRight) {
+        return isLeft
+                ? Either.of(onLeft.apply(left), null)
+                : Either.of(null, onRight.apply(right));
+    }
+
+    public static Either<Integer, String> parseInteger(String maybeInteger) {
+        try {
+            Integer r = Integer.parseInt(maybeInteger);
+            return Either.of(r, null);
+        } catch (NumberFormatException e) {
+            // Do nothing
+        }
+        return Either.of(null, maybeInteger);
+    }
+
+    public T getLeft() {
+        return left;
+    }
+
+    public U getRight() {
+        return right;
+    }
+
+    public static <T> T unwrap(Either<T, T> either) {
+        return either.isLeft ? either.left : either.right;
+    }
+
+    public boolean isLeft() {
+        return isLeft;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ ebur128java = "1.2.6-2"
 jna = "5.13.0"
 websocket = "1.6.0"
 slf4j = "2.0.17"
+runtime-javadoc = "0.13.0"
+
 junit-bom = "6.0.3"
 
 [libraries]
@@ -86,6 +88,9 @@ slf4j-jul = { group = "org.slf4j", name = "slf4j-jdk14", version.ref = "slf4j" }
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit-bom" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
+
+runtime-javadoc-scribe = { group = "com.github.therapi", name = "therapi-runtime-javadoc-scribe", version.ref = "runtime-javadoc"}
+runtime-javadoc = { group = "com.github.therapi", name = "therapi-runtime-javadoc", version.ref = "runtime-javadoc"}
 
 [bundles]
 libgdx = ["gdx-core", "gdx-backend", "gdx-freetype", "gdx-controllers-core", "gdx-controllers-desktop"]


### PR DESCRIPTION
This pr is the combination of some old, intertwined prs (#181, #186) and some extracted parts from new prs (#218), aiming to restart the uncompleted prs, which are not working on for months because they're affecting each other, and to lower the pressure of the pr reviewers. Since the old prs are interacting themselves and the new pr (#218) is too big and too many base work that is not very related to the topic of #218.

Goals:

- In-game skin property watcher
- In-game skin property manual for both raja and LR2
- Show the reason why a skin object is not drawn on screen 
<img width="1634" height="728" alt="image" src="https://github.com/user-attachments/assets/ee98da9a-505b-44a9-befb-1399d338247e" />
- And many other small things introduced in #218 
- Filter widgets by name

https://github.com/user-attachments/assets/808e3d79-b7c2-4c59-a5ce-90858dd9087d

- A real export button, which actually persists changes and makes them being able to across sessions:

<img width="3456" height="2166" alt="fe035e53285ac97d27e653a5a1ad7649" src="https://github.com/user-attachments/assets/8e4c19cf-7d3c-4045-b3b1-231182df8255" />


 