### PR TITLE
Fix sometimes the texture is mixing up pixmaps multiple times

### DIFF
--- a/core/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/core/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -25,19 +25,28 @@ public class BGImageProcessor {
 	 */
 	private Pixmap[] bgamap = new Pixmap[1000];
 	/**
+	 *
 	 * BGイメージのキャッシュ
 	 */
-	private Texture[] bgacache;
-	/**
-	 * キャッシュされているBGイメージID
-	 */
-	private int[] bgacacheid;
+	private Map<Integer, Texture> bgacache;
 
 	private final PixmapResourcePool cache;
 
 	public BGImageProcessor(int size, int maxgen) {
-		bgacache = new Texture[size];
-		bgacacheid = new int[size];
+		bgacache = new LinkedHashMap<>(size + 1, .75F, true) {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<Integer, Texture> eldest) {
+				if (size() > size) {
+					Texture tex = eldest.getValue();
+					if (tex != null) {
+						tex.dispose();
+					}
+					return true;
+				}
+				return false;
+			}
+		};
+
 		cache = new PixmapResourcePool(maxgen) {
 
 			protected Pixmap convert(Pixmap pixmap) {
@@ -76,24 +85,19 @@ public class BGImageProcessor {
 	 */
 	public void prepare(TimeLine[] timelines) {
 		long l = System.currentTimeMillis();
-		Arrays.fill(bgacacheid, -1);
-		for (Texture bga : bgacache) {
-			if (bga != null) {
-				bga.dispose();
-			}
-		}
-		Arrays.fill(bgacache, null);
+		bgacache.forEach((k, tex) -> tex.dispose());
+		bgacache.clear();
 
 		int count = 0;
 		for (TimeLine tl : timelines) {
 			int bga = tl.getBGA();
-			if (bga >= 0 && bgacache[bga % bgacache.length] == null && bga < bgamap.length && bgamap[bga] != null) {
+			if (bga >= 0 && !bgacache.containsKey(bga) && bga < bgamap.length && bgamap[bga] != null) {
 				getTexture(bga);
 				count++;
 			}
 
 			bga = tl.getLayer();
-			if (bga >= 0 && bgacache[bga % bgacache.length] == null && bga < bgamap.length && bgamap[bga] != null) {
+			if (bga >= 0 && bgacache.containsKey(bga) && bga < bgamap.length && bgamap[bga] != null) {
 				getTexture(bga);
 				count++;
 			}
@@ -102,23 +106,14 @@ public class BGImageProcessor {
 	}
 
 	public Texture getTexture(int id) {
-		final int cid = id % bgacache.length;
-		// BGイメージキャッシュにTextureがある場合
-		if (bgacacheid[cid] == id) {
-			return bgacache[cid];
+		if (bgacache.containsKey(id)) {
+			return bgacache.get(id);
 		}
 		// BGイメージキャッシュにTextureがない場合
 		if (id < bgamap.length && bgamap[id] != null){
-			if(bgacache[cid] == null) {
-				bgacache[cid] = new Texture(bgamap[id]);				
-			} else if(bgacache[cid].getWidth() != bgamap[id].getWidth() || bgacache[cid].getHeight() != bgamap[id].getHeight()){
-				bgacache[cid].dispose();
-				bgacache[cid] = new Texture(bgamap[id]);				
-			} else {
-				bgacache[cid].draw(bgamap[id], 0, 0);
-			}
-			bgacacheid[cid] = id;
-			return bgacache[cid];
+			Texture tex = new Texture(bgamap[id]);
+			bgacache.put(id, tex);
+			return tex;
 		}
 		return null;
 	}
@@ -127,12 +122,8 @@ public class BGImageProcessor {
 	 * リソースを開放する
 	 */
 	public void dispose() {
-		for (Texture bga : bgacache) {
-			if (bga != null) {
-				bga.dispose();
-			}
-		}
-		bgacache = new Texture[0];
+		bgacache.forEach((k, tex) -> tex.dispose());
+		bgacache.clear();
 
 		cache.dispose();
 	}	


### PR DESCRIPTION
Close #210 

<img width="2560" height="1496" alt="7798ae79661fadaa317a4ef40b543c9b" src="https://github.com/user-attachments/assets/c6f450d2-3173-48b4-bb03-6c2f819aa1ff" />

The reason why the bga is broken is because the cache strategy beatoraja codes. Somehow, it mixes up multiple pixmaps into one texture, eventually causing the image that has transparent pixels drawn on screen looks funny.

In this pr, I removed the complex strategy at all, replacing it with a mindless strategy which forces to create a new texture each time if the cache is not perfectly matched. Personally I don't think the original complex strategy is *that beneficial* on lowering the bga loading process pressure. So I think this replacement is *good enough*.

This pr might need further test on whether it breaks other bms' bga. 