### PR TITLE
Add personal best pacemaker target

### DIFF
--- a/core/src/bms/player/beatoraja/PlayerConfig.java
+++ b/core/src/bms/player/beatoraja/PlayerConfig.java
@@ -71,11 +71,17 @@ public final class PlayerConfig {
 	 */
 	private String targetid = "MAX";
 	
-	private String[] targetlist = new String[] {"RATE_A-","RATE_A", "RATE_A+","RATE_AA-","RATE_AA", "RATE_AA+", "RATE_AAA-", "RATE_AAA", "RATE_AAA+", "RATE_MAX-", "MAX"
-			,"RANK_NEXT", "IR_NEXT_1", "IR_NEXT_2", "IR_NEXT_3", "IR_NEXT_4", "IR_NEXT_5", "IR_NEXT_10"
+	private static final String[] DEFAULT_TARGET_LIST = new String[] {"RATE_A-","RATE_A", "RATE_A+","RATE_AA-","RATE_AA", "RATE_AA+", "RATE_AAA-", "RATE_AAA", "RATE_AAA+", "RATE_MAX-", "MAX"
+			,"RANK_NEXT", "IR_PERSONAL_BEST", "IR_NEXT_1", "IR_NEXT_2", "IR_NEXT_3", "IR_NEXT_4", "IR_NEXT_5", "IR_NEXT_10"
 			, "IR_RANK_1", "IR_RANK_5", "IR_RANK_10", "IR_RANK_20", "IR_RANK_30", "IR_RANK_40", "IR_RANK_50"
 			, "IR_RANKRATE_5", "IR_RANKRATE_10", "IR_RANKRATE_15", "IR_RANKRATE_20", "IR_RANKRATE_25", "IR_RANKRATE_30", "IR_RANKRATE_35", "IR_RANKRATE_40", "IR_RANKRATE_45","IR_RANKRATE_50"
 			,"RIVAL_RANK_1","RIVAL_RANK_2","RIVAL_RANK_3","RIVAL_NEXT_1","RIVAL_NEXT_2","RIVAL_NEXT_3"};
+
+	/**
+	 * List of pacemaker targets - not final as more targets may be added for rivals in MainController.java
+	 */
+	private String[] targetlist = DEFAULT_TARGET_LIST;
+
 	/**
 	 * 判定タイミング
 	 */
@@ -564,11 +570,9 @@ public final class PlayerConfig {
 	}
 
 	public String[] getTargetlist() {
-		return targetlist;
-	}
-
-	public void setTargetlist(String[] targetlist) {
-		this.targetlist = targetlist;
+		Set<String> targetSet = new HashSet<>(Set.of(DEFAULT_TARGET_LIST));
+        targetSet.addAll(Arrays.asList(targetlist));
+		return targetSet.stream().sorted().toArray(String[]::new);
 	}
 
 	public int getMisslayerDuration() {
@@ -857,7 +861,7 @@ public final class PlayerConfig {
 		doubleoption = MathUtils.clamp(doubleoption, 0, 3);
 		chartReplicationMode = chartReplicationMode != null ? chartReplicationMode : "NONE";
 		targetid = targetid!= null ? targetid : "MAX";
-		targetlist = targetlist != null ? targetlist : new String[0];
+		targetlist = targetlist != null ? targetlist : DEFAULT_TARGET_LIST;
 		judgetiming = MathUtils.clamp(judgetiming, JUDGETIMING_MIN, JUDGETIMING_MAX);
 		misslayerDuration = MathUtils.clamp(misslayerDuration, 0, 5000);
 		lnmode = MathUtils.clamp(lnmode, 0, 2);
@@ -895,7 +899,7 @@ public final class PlayerConfig {
 				irconfig[i].setIrname(irnames[i]);
 			}
 		}
-		
+
 		for(int i = 0;i < irconfig.length;i++) {
 			if(irconfig[i] == null || irconfig[i].getIrname() == null) {
 				continue;

--- a/core/src/bms/player/beatoraja/play/TargetProperty.java
+++ b/core/src/bms/player/beatoraja/play/TargetProperty.java
@@ -74,7 +74,26 @@ public abstract class TargetProperty {
     }
 
     public abstract String getName(MainController main);
-    public abstract ScoreData getTarget(MainController main);    
+    public abstract ScoreData getTarget(MainController main);
+	public ScoreData getNowScoreData(MainController main) {
+		ScoreData scoreData = main.getPlayDataAccessor().readScoreData(
+				main.getPlayerResource().getBMSModel(),
+				main.getPlayerConfig().getLnmode()
+		);
+		if (scoreData == null) {
+			scoreData = new ScoreData();
+		}
+		return scoreData;
+	}
+
+    /**
+     * Convenience method to set option, PGREAT and GREAT notes on target score
+     */
+	protected void updateTargetScore(ScoreData newScore) {
+		targetScore.setEpg(newScore.getExscore() / 2);
+		targetScore.setEgr(newScore.getExscore() % 2);
+		targetScore.setOption(newScore.getOption());
+	}
 }
 
 /**
@@ -309,8 +328,7 @@ class NextRankTargetProperty extends TargetProperty {
 
     @Override
     public ScoreData getTarget(MainController main) {
-        ScoreData now = main.getPlayDataAccessor().readScoreData(main.getPlayerResource().getBMSModel()
-                , main.getPlayerConfig().getLnmode());
+        ScoreData now = getNowScoreData(main);
         final int nowscore = now != null ? now.getExscore() : 0;
         final int max = main.getPlayerResource().getBMSModel().getTotalNotes() * 2;
         int targetscore = max;
@@ -339,7 +357,7 @@ class InternetRankingTargetProperty extends TargetProperty {
     private final Target target;
     
     private final int value;
-    
+
     private InternetRankingTargetProperty(Target target, int value) {
     	super("IR_" + target.name() + "_" + value);
         this.target = target;
@@ -349,6 +367,8 @@ class InternetRankingTargetProperty extends TargetProperty {
 	@Override
 	public String getName(MainController main) {
     	switch(target) {
+		case PERSONAL_BEST:
+			return "PERSONAL BEST";
     	case NEXT:
     		return "IR NEXT " + value + "RANK";
     	case RANK:
@@ -362,27 +382,22 @@ class InternetRankingTargetProperty extends TargetProperty {
     @Override
     public ScoreData getTarget(MainController main) {
     	final RankingData ranking = main.getPlayerResource().getRankingData();
+		ScoreData nowScore = getNowScoreData(main);
     	if(ranking == null) {
-			targetScore.setPlayer("NO DATA");
+			String name = target == Target.PERSONAL_BEST ? "PB (LOCAL)" : "NO DATA";
+			targetScore.setPlayer(name);
 			targetScore.setOption(0);
-			return targetScore;    		
+			if (target == Target.PERSONAL_BEST) {
+				updateTargetScore(nowScore);
+			}
+			return targetScore;
     	}
-    	
+
     	if(ranking.getState() == RankingData.FINISH) {
-    		if(ranking.getTotalPlayer() > 0) {
-    			final int index = getTargetRank(main, ranking);
-    			final IRScoreData irScore = ranking.getScore(index);
-    			final int targetscore = irScore.getExscore();
-    			targetScore.setPlayer(irScore.player.length() > 0 ? irScore.player : "YOU");
-        		targetScore.setEpg(targetscore / 2);
-        		targetScore.setEgr(targetscore % 2);
-				targetScore.setOption(irScore.option);
-    		} else {
-    			targetScore.setPlayer("NO DATA");
-    			targetScore.setOption(0);
-    		}
+			setTargetScoreToIrScore(main, ranking, target);
     		return targetScore;
     	}
+
 		Thread irprocess = new Thread(() -> {
     		ranking.load(main.getCurrentState(), main.getPlayerResource().getSongdata());
 			while(ranking.getState() == RankingData.NONE  || ranking.getState() == RankingData.ACCESS) {
@@ -392,29 +407,39 @@ class InternetRankingTargetProperty extends TargetProperty {
 				}
 			}
 	    	if(ranking.getState() == RankingData.FINISH) {
-	    		if(ranking.getTotalPlayer() > 0) {
-	    			final int index = getTargetRank(main, ranking);
-	    			final IRScoreData irScore = ranking.getScore(index);
-	    			final int targetscore = irScore.getExscore();
-	    			targetScore.setPlayer(irScore.player.length() > 0 ? irScore.player : "YOU");
-	        		targetScore.setEpg(targetscore / 2);
-	        		targetScore.setEgr(targetscore % 2);
-	    			targetScore.setOption(irScore.option);
-	    		} else {
-	    			targetScore.setPlayer("NO DATA");
-	    			targetScore.setOption(0);
-	    		}
-	    		
+				setTargetScoreToIrScore(main, ranking, target);
 				main.getCurrentState().getScoreDataProperty().updateTargetScore(targetScore.getExscore());	    		
 	    	}
 		});
 		irprocess.start();
         return targetScore;
     }
+
+	private void setTargetScoreToIrScore(MainController main, RankingData ranking, Target target) {
+		final int index = getTargetRank(main, ranking);
+		final IRScoreData irScore = ranking.getScore(index);
+		if(ranking.getTotalPlayer() > 0 && irScore != null && index >= 0) {
+			targetScore.setPlayer(!(irScore.player == null || irScore.player.isEmpty()) ? irScore.player : "YOU");
+			updateTargetScore(irScore.convertToScoreData());
+		} else {
+			targetScore.setPlayer("NO DATA");
+			targetScore.setOption(0);
+		}
+
+		if (target == Target.PERSONAL_BEST) {
+			ScoreData nowScore = getNowScoreData(main);
+			if (irScore != null && index >= 0 && nowScore.getExscore() < irScore.getExscore()) {
+				targetScore.setPlayer("PB (IR)");
+				updateTargetScore(irScore.convertToScoreData());
+			} else {
+				targetScore.setPlayer("PB (LOCAL)");
+				updateTargetScore(nowScore);
+			}
+		}
+	}
     
     private int getTargetRank(MainController main, RankingData ranking) {
-        ScoreData now = main.getPlayDataAccessor().readScoreData(main.getPlayerResource().getBMSModel()
-                , main.getPlayerConfig().getLnmode());
+        ScoreData now = getNowScoreData(main);
         final int nowscore = now != null ? now.getExscore() : 0;
 		switch(target) {
 		case NEXT:
@@ -425,7 +450,8 @@ class InternetRankingTargetProperty extends TargetProperty {
 				}
 			}
 			return 0;
-			
+		case PERSONAL_BEST:
+			return ranking.getRank() - 1;
 		case RANK:
 			// n位のプレイヤー
 			return Math.min(ranking.getTotalPlayer(), value) - 1;
@@ -437,6 +463,9 @@ class InternetRankingTargetProperty extends TargetProperty {
     }
     
     public static TargetProperty getTargetProperty(String id) {
+		if (id.equals("IR_PERSONAL_BEST")) {
+			return new InternetRankingTargetProperty(Target.PERSONAL_BEST, 0);
+		}
     	if(id.startsWith("IR_NEXT_")) {
     		try {
         		int index = Integer.parseInt(id.substring(8));
@@ -471,7 +500,10 @@ class InternetRankingTargetProperty extends TargetProperty {
     }
     
     enum Target {
-    	NEXT, RANK, RANKRATE
+    	NEXT,
+		RANK,
+		RANKRATE,
+		PERSONAL_BEST
     }
 
 }


### PR DESCRIPTION
This MR adds a pacemaker target for your personal best score between IR and local scores, whichever is higher.

This is a test done by temporarily moving my score.db to simulate a score existing locally but not on IR
<img width="2560" height="1440" alt="Screenshot_20260422_151031" src="https://github.com/user-attachments/assets/af7d2465-ea26-4ee1-85f1-4a5fa54f90a2" />

| Case | IR score | Target value |
| --- | --- | --- |
| Local score is higher than IR score | <img width="593" height="307" alt="Screenshot_20260422_164724" src="https://github.com/user-attachments/assets/cad198bc-a7f4-49f9-9ec2-ddc27ab34e8e" /> | <img width="362" height="99" alt="Screenshot_20260422_164816" src="https://github.com/user-attachments/assets/8d43f419-80aa-426f-925f-6f82c981f1af" /> |
| IR score is higher than local score | <img width="589" height="293" alt="Screenshot_20260422_164205" src="https://github.com/user-attachments/assets/3f9eb613-2636-43da-9f5d-337e25141396" /> | <img width="380" height="250" alt="Screenshot_20260422_161225" src="https://github.com/user-attachments/assets/c3e46d43-30df-479f-a0df-0d840c52d743" /> | 
| Unplayed on both | N/A | <img width="358" height="97" alt="image" src="https://github.com/user-attachments/assets/09b799aa-a472-4030-937c-799b8b1e3408" /> |

Limitations: ghost data is not used due to how the pacemaker targets work - instead it works in a similar way to the score grade targets

