### PR TITLE
Add toggle for notifications in misc settings

### DIFF
--- a/core/src/bms/player/beatoraja/modmenu/ImGuiNotify.java
+++ b/core/src/bms/player/beatoraja/modmenu/ImGuiNotify.java
@@ -3,6 +3,8 @@ package bms.player.beatoraja.modmenu;
 import imgui.ImGui;
 import imgui.flag.ImGuiWindowFlags;
 import javafx.util.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +13,7 @@ import static bms.player.beatoraja.modmenu.ImGuiRenderer.windowHeight;
 import static bms.player.beatoraja.modmenu.ImGuiRenderer.windowWidth;
 
 public class ImGuiNotify {
+    private static final Logger logger = LoggerFactory.getLogger(ImGuiNotify.class);
 
     public static final float NOTIFY_PADDING_X = 20.0f;
     public static final float NOTIFY_PADDING_Y = 20.0f;
@@ -31,6 +34,7 @@ public class ImGuiNotify {
     };
 
     private static ToastPos DEFAULT_TOAST_POS = ToastPos.TopLeft;
+    private static boolean NOTIFY_ENABLED = true;
 
     public enum ToastType {
         None,
@@ -225,7 +229,8 @@ public class ImGuiNotify {
     private static final List<Toast> notifications = new ArrayList<>();
 
     public static void insertNotification(Toast toast) {
-        notifications.add(toast);
+        if (NOTIFY_ENABLED) notifications.add(toast);
+        else logger.info("Toast({}): {}", toast.type.name(), toast.getContent());
     }
 
     public static void removeNotification(int index) {
@@ -399,5 +404,9 @@ public class ImGuiNotify {
 
     public static void setNotificationPosition(int index) {
         DEFAULT_TOAST_POS = ToastPos.valueOf(NOTIFICATION_POSITIONS[index]);
+    }
+
+    public static void setEnabled(boolean enabled) {
+        NOTIFY_ENABLED = enabled;
     }
 }

--- a/core/src/bms/player/beatoraja/modmenu/MiscSettingMenu.java
+++ b/core/src/bms/player/beatoraja/modmenu/MiscSettingMenu.java
@@ -31,6 +31,7 @@ public class MiscSettingMenu {
     // This is the true play mode value, PLAY_MODE_VALUE is for rendering
     private static Mode CURRENT_PLAY_MODE = null;
 
+    private static final ImBoolean ENABLE_NOTIFICATION = new ImBoolean(true);
     private static final ImInt NOTIFICATION_POSITION = new ImInt(0);
     private static final ImBoolean ENABLE_LIFT = new ImBoolean(false);
     private static final ImInt LIFT_VALUE = new ImInt(0);
@@ -60,6 +61,10 @@ public class MiscSettingMenu {
         ImGui.setNextWindowPos(relativeX, relativeY, ImGuiCond.FirstUseEver);
 
         if (ImGui.begin("Misc Settings", showMiscSetting, ImGuiWindowFlags.AlwaysAutoResize)) {
+            if (ImGui.checkbox("Enable Notification", ENABLE_NOTIFICATION)) {
+                ImGuiNotify.setEnabled(ENABLE_NOTIFICATION.get());
+            }
+
             if (ImGui.combo("Notification Positions", NOTIFICATION_POSITION, ImGuiNotify.NOTIFICATION_POSITIONS)) {
                 ImGuiNotify.setNotificationPosition(NOTIFICATION_POSITION.get());
             }


### PR DESCRIPTION
<img width="499" height="618" alt="image" src="https://github.com/user-attachments/assets/4a7884b6-e34f-404b-8f14-94740dfd54a8" />
This pr adds an option to toggle toast notifications.
When disabled, notifications are suppressed in the UI and redirected to the logs instead.

I originally planned to only disable screenshot notifications, but the code was getting a bit messy, so I decided to make it a global setting for all notifications.
I'm not sure if there are any critical notifications that should never be hidden, because this toggle will hide everything.