### PR TITLE
Feat: borderless fullscreen mode scales to the screen size

### DIFF
--- a/core/src/bms/player/beatoraja/MainController.java
+++ b/core/src/bms/player/beatoraja/MainController.java
@@ -18,6 +18,8 @@ import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.g2d.*;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator.FreeTypeFontParameter;
+import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.*;
 import com.badlogic.gdx.utils.StringBuilder;
@@ -100,6 +102,9 @@ public class MainController {
 
 	private RankingDataCache ircache = new RankingDataCache();
 
+	private FrameBuffer renderFbo;
+	private TextureRegion renderFboRegion;
+	private Matrix4 fboProjectionMatrix;
 	private SpriteBatch sprite;
 	/**
 	 * 1曲プレイで指定したBMSファイル
@@ -417,6 +422,16 @@ public class MainController {
 
 	public void create() {
 		final long t = System.currentTimeMillis();
+
+		Resolution renderResolution = config.getResolution();
+
+		renderFbo = new FrameBuffer(Pixmap.Format.RGB888, renderResolution.width, renderResolution.height, false);
+		renderFboRegion = new TextureRegion(renderFbo.getColorBufferTexture());
+		renderFboRegion.flip(false, true);
+
+		fboProjectionMatrix = new Matrix4();
+		fboProjectionMatrix.setToOrtho2D(0.0f, 0.0f, renderResolution.width, renderResolution.height);
+
 		sprite = SpriteBatchHelper.createSpriteBatch();
 		SkinLoader.initPixmapResourcePool(config.getSkinPixmapGen());
 
@@ -611,6 +626,13 @@ public class MainController {
 
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
+		Matrix4 oldProjectionMatrix = sprite.getProjectionMatrix().cpy();
+		sprite.setProjectionMatrix(fboProjectionMatrix);
+
+		renderFbo.begin();
+		Gdx.gl.glClearColor(0, 0, 0, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
 		current.render();
 		sprite.begin();
 		if (current.getSkin() != null) {
@@ -688,6 +710,27 @@ public class MainController {
 
 			sprite.end();
 		}
+
+		renderFbo.end();
+
+		Resolution renderResolution = config.getResolution();
+		float displayWidth = Gdx.graphics.getWidth();
+		float displayHeight = Gdx.graphics.getHeight();
+		float scaleX = displayWidth / (float) renderResolution.width;
+		float scaleY = displayHeight / (float) renderResolution.height;
+		float scale = Math.min(scaleX, scaleY);
+		float renderDisplayWidth = renderResolution.width * scale;
+		float renderDisplayHeight = renderResolution.height * scale;
+		float offsetX = (displayWidth - renderDisplayWidth) / 2;
+		float offsetY = (displayHeight - renderDisplayHeight) / 2;
+		Color oldColor = sprite.getColor().cpy();
+		sprite.setProjectionMatrix(oldProjectionMatrix);
+		sprite.setColor(Color.WHITE);
+		sprite.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		sprite.begin();
+		sprite.draw(renderFboRegion, offsetX, offsetY, renderDisplayWidth, renderDisplayHeight);
+		sprite.end();
+		sprite.setColor(oldColor);
 
         periodicConfigSave();
 
@@ -867,6 +910,9 @@ public class MainController {
 		}
 		if (loudnessAnalyzer != null) {
 			loudnessAnalyzer.shutdown();
+		}
+		if (renderFbo != null) {
+			renderFbo.dispose();
 		}
 
 		logger.info("全リソース破棄完了");

--- a/core/src/bms/player/beatoraja/MainLoader.java
+++ b/core/src/bms/player/beatoraja/MainLoader.java
@@ -207,15 +207,18 @@ public class MainLoader extends Application {
 					gdxDisplayMode = targetMonitor == null ? Lwjgl3ApplicationConfiguration.getDisplayMode() : Lwjgl3ApplicationConfiguration.getDisplayMode(targetMonitor);
 				}
             } else {
+                Graphics.DisplayMode d = targetMonitor == null
+						? Lwjgl3ApplicationConfiguration.getDisplayMode()
+						: Lwjgl3ApplicationConfiguration.getDisplayMode(targetMonitor);
                 if (config.getDisplaymode() == Config.DisplayMode.BORDERLESS) {
                     gdxConfig.setDecorated(false);
                     //System.setProperty("org.lwjgl.opengl.Window.undecorated", "true");
+					gdxConfig.setWindowedMode(d.width, d.height);
                 } else {
 					gdxConfig.setDecorated(true);
+					gdxConfig.setWindowedMode(w, h);
 				}
-                gdxConfig.setWindowedMode(w, h);
                 if (targetMonitor != null) {
-                    Graphics.DisplayMode d = Lwjgl3ApplicationConfiguration.getDisplayMode(targetMonitor);
 					if (config.getDisplaymode() == Config.DisplayMode.BORDERLESS) {
 						int posX = targetMonitor.virtualX;
 						int posY = targetMonitor.virtualY;
@@ -223,7 +226,7 @@ public class MainLoader extends Application {
 					}
 					gdxDisplayMode = d;
                 } else {
-					gdxDisplayMode = Lwjgl3ApplicationConfiguration.getDisplayMode();
+					gdxDisplayMode = d;
                 }
             }
             // vSync

--- a/core/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
+++ b/core/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
@@ -176,10 +176,23 @@ public class KeyBoardInputProcesseor extends BMSPlayerInputDevice implements Inp
 		return false;
 	}
 
+	private void setBmsPlayerInputProcessorMousePos(int screenX, int screenY) {
+		int displayWidth = Gdx.graphics.getWidth();
+		int displayHeight = Gdx.graphics.getHeight();
+		float scaleX = displayWidth / (float) resolution.width;
+		float scaleY = displayHeight / (float) resolution.height;
+		float scale = Math.min(scaleX, scaleY);
+		float renderDisplayWidth = resolution.width * scale;
+		float renderDisplayHeight = resolution.height * scale;
+		float offsetX = (displayWidth - renderDisplayWidth) / 2f;
+		float offsetY = (displayHeight - renderDisplayHeight) / 2f;
+		this.bmsPlayerInputProcessor.mousex = Math.round((screenX - offsetX) / scale);
+		this.bmsPlayerInputProcessor.mousey = Math.round(resolution.height - ((screenY - offsetY) / scale));
+	}
+
 	public boolean mouseMoved(int x, int y) {
 		this.bmsPlayerInputProcessor.setMouseMoved(true);
-		this.bmsPlayerInputProcessor.mousex = x * resolution.width / Gdx.graphics.getWidth();
-		this.bmsPlayerInputProcessor.mousey = resolution.height - y * resolution.height / Gdx.graphics.getHeight();
+		setBmsPlayerInputProcessorMousePos(x, y);
 		return false;
 	}
 
@@ -199,17 +212,13 @@ public class KeyBoardInputProcesseor extends BMSPlayerInputDevice implements Inp
 
 	public boolean touchDown(int x, int y, int point, int button) {
 		this.bmsPlayerInputProcessor.mousebutton = button;
-		this.bmsPlayerInputProcessor.mousex = x * resolution.width / Gdx.graphics.getWidth();
-		this.bmsPlayerInputProcessor.mousey = resolution.height - y * resolution.height
-				/ Gdx.graphics.getHeight();
+		setBmsPlayerInputProcessorMousePos(x, y);
 		this.bmsPlayerInputProcessor.mousepressed = true;
 		return false;
 	}
 
 	public boolean touchDragged(int x, int y, int point) {
-		this.bmsPlayerInputProcessor.mousex = x * resolution.width / Gdx.graphics.getWidth();
-		this.bmsPlayerInputProcessor.mousey = resolution.height - y * resolution.height
-				/ Gdx.graphics.getHeight();
+		setBmsPlayerInputProcessorMousePos(x, y);
 		this.bmsPlayerInputProcessor.mousedragged = true;
 		return false;
 	}

--- a/core/src/bms/player/beatoraja/skin/Skin.java
+++ b/core/src/bms/player/beatoraja/skin/Skin.java
@@ -251,16 +251,19 @@ public class Skin {
 
 	public void drawAllObjects(SpriteBatch sprite, MainState state) {
 		if(renderer == null) {
-			SkinOffset offsetAll = getOffsetAll(state);
-			Matrix4 transform = new Matrix4();
-			if(offsetAll != null) {
-				transform.set(width * offsetAll.x /100, height * offsetAll.y / 100, 0, 0, 0, 0, 0, (offsetAll.w + 100) / 100, (offsetAll.h + 100) / 100, 1);
-			} else {
-				transform.set(0, 0, 0, 0, 0, 0, 0, 1, 1, 1);
-			}
-			sprite.setTransformMatrix(transform);
 			renderer = new SkinObjectRenderer(sprite);
 		}
+
+		SkinOffset offsetAll = getOffsetAll(state);
+		Matrix4 offsetTransform = new Matrix4();
+		if(offsetAll != null) {
+			offsetTransform.set(width * offsetAll.x /100, height * offsetAll.y / 100, 0, 0, 0, 0, 0, (offsetAll.w + 100) / 100, (offsetAll.h + 100) / 100, 1);
+		} else {
+			offsetTransform.set(0, 0, 0, 0, 0, 0, 0, 1, 1, 1);
+		}
+		Matrix4 previousTransform = sprite.getTransformMatrix().cpy();
+		Matrix4 composedTransform = previousTransform.cpy().mul(offsetTransform);
+		sprite.setTransformMatrix(composedTransform);
 		
 		final long microtime = state.timer.getNowMicroTime();
 
@@ -314,6 +317,8 @@ public class Skin {
 				}
 			}
 		}
+
+		sprite.setTransformMatrix(previousTransform);
 	}
 
 	public void mousePressed(MainState state, int button, int x, int y) {


### PR DESCRIPTION
Makes borderless fullscreen mode act normally like every other rhythm games do: offscreen render on desired resolution, and scale that surface to the window with proper letterboxing.

Used codex for porting the patch

Originally from: https://github.com/phu54321/beatoraja/tree/feature/borderless_fullscreen

## Before:

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/d799d655-f036-498a-ac22-804af3c4267e" />

## After:

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/a7684b8a-da36-4304-84d1-4fecd7946072" />

