### PR TITLE
Auto change download source to default if the using one is not existed

### DIFF
--- a/core/src/bms/player/beatoraja/Config.java
+++ b/core/src/bms/player/beatoraja/Config.java
@@ -7,6 +7,8 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.text.ParseException;
+
+import bms.tool.mdprocessor.HttpDownloadSourceMeta;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -870,6 +872,7 @@ public class Config implements Validatable {
 		playerpath = playerpath != null ? playerpath : PLAYERPATH_DEFAULT;
 		skinpath = skinpath != null ? skinpath : SKINPATH_DEFAULT;
 		downloadDirectory = validatePath(downloadDirectory) ? downloadDirectory : DEFAULT_DOWNLOAD_DIRECTORY;
+		downloadSource = validateDownloadSource(downloadSource) ? downloadSource : HttpDownloadProcessor.getDefaultDownloadSource().getName();
 		return true;
 	}
 
@@ -982,5 +985,9 @@ public class Config implements Validatable {
 			return false;
 		}
 		return true;
+	}
+
+	private boolean validateDownloadSource(String downloadSource) {
+		return HttpDownloadProcessor.DOWNLOAD_SOURCES.containsKey(downloadSource);
 	}
 }

--- a/core/src/bms/tool/mdprocessor/HttpDownloadProcessor.java
+++ b/core/src/bms/tool/mdprocessor/HttpDownloadProcessor.java
@@ -46,9 +46,6 @@ public class HttpDownloadProcessor {
         // Ginger
         HttpDownloadSourceMeta gingerDownloadSourceMeta = GingerDownloadSource.META;
         DOWNLOAD_SOURCES.put(gingerDownloadSourceMeta.getName(), gingerDownloadSourceMeta);
-        // Wriggle
-        HttpDownloadSourceMeta wriggleDownloadSourceMeta = WriggleDownloadSource.META;
-        DOWNLOAD_SOURCES.put(wriggleDownloadSourceMeta.getName(), wriggleDownloadSourceMeta);
         // Konmai
         HttpDownloadSourceMeta konmaiDownloadSourceMeta = KonmaiDownloadSource.META;
         DOWNLOAD_SOURCES.put(konmaiDownloadSourceMeta.getName(), konmaiDownloadSourceMeta);

--- a/core/src/bms/tool/mdprocessor/WriggleDownloadSource.java
+++ b/core/src/bms/tool/mdprocessor/WriggleDownloadSource.java
@@ -2,6 +2,11 @@ package bms.tool.mdprocessor;
 
 import bms.player.beatoraja.Config;
 
+/**
+ * Wriggle download source is shutdown during the development of 0.4.0. It's not an usable download source
+ *  anymore. The code retained here is only for use of reference.
+ */
+@Deprecated
 public class WriggleDownloadSource implements HttpDownloadSource {
     public static final HttpDownloadSourceMeta META = new HttpDownloadSourceMeta(
             "wriggle",


### PR DESCRIPTION
This pr auto switches the download source to default configured one if the download source configured in config file is no longer existed. Specifically wriggle. 