### PR TITLE
Hide the override download url feature

### DIFF
--- a/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
+++ b/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
@@ -419,14 +419,6 @@
 
                     <CheckBox fx:id="enableHttp" mnemonicParsing="false" prefHeight="18.0" text="%ENABLE_HTTP" />
                     <ComboBox fx:id="httpDownloadSource" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                    <GridPane hgap="10" vgap="5">
-                        <children>
-                            <Label text="Default Http Server URL" prefHeight="25.0" GridPane.rowIndex="0" GridPane.columnIndex="0" />
-                            <TextField fx:id="defaultDownloadURL" prefHeight="25.0" prefWidth="400" GridPane.rowIndex="0" GridPane.columnIndex="1" />
-                            <Label text="Override Http Server URL" prefHeight="25.0" GridPane.rowIndex="1" GridPane.columnIndex="0" />
-                            <TextField fx:id="overrideDownloadURL" prefHeight="25.0" prefWidth="400" GridPane.rowIndex="1" GridPane.columnIndex="1" />
-                        </children>
-                    </GridPane>
 
                <VBox prefHeight="150.0" prefWidth="100.0" visible="false">
                   <children>

--- a/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
+++ b/core/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
@@ -263,10 +263,6 @@ public class PlayConfigurationView implements Initializable {
 	private CheckBox enableHttp;
 	@FXML
 	private ComboBox<String> httpDownloadSource;
-	@FXML
-	private TextField defaultDownloadURL;
-	@FXML
-	private TextField overrideDownloadURL;
 
 	@FXML
 	private VBox skin;
@@ -483,8 +479,6 @@ public class PlayConfigurationView implements Initializable {
 
 		enableHttp.setSelected(config.isEnableHttp());
 		httpDownloadSource.setValue(config.getDownloadSource());
-		defaultDownloadURL.setText(config.getDefaultDownloadURL());
-		overrideDownloadURL.setText(config.getOverrideDownloadURL());
 
 		if(players.getItems().contains(config.getPlayername())) {
 			players.setValue(config.getPlayername());
@@ -631,7 +625,6 @@ public class PlayConfigurationView implements Initializable {
 
 		config.setEnableHttp(enableHttp.isSelected());
 		config.setDownloadSource(httpDownloadSource.getValue());
-		config.setOverrideDownloadURL(overrideDownloadURL.getText());
 
 		config.setClipboardWhenScreenshot(clipboardScreenshot.isSelected());
 


### PR DESCRIPTION
This commit cuts the configurable option `overrideDownloadURL` from launcher. This will make it:

- Unconfigurable
- No longer takes effect

This reason I coded this feature was because `wriggle` is designed to serve a 'direct' download endpoint, compared to what `ginger` and `konmai` does: they require client to "ask if the package was presenting on the server" before "giving the direct download link back". As wriggle was the only download source we can use before, such a feature that allows you tweak the download source is good enough to adapt the issues like server domain changes. No need to say it actually happens a serveral times.

However, such a design cannot be used on `ginger` and `konmai` because they require client to ask before downloading, and the response data structure from server varies. Also this feature is more hard to understand for casual users, we have seen how many times this misleads the users trying to use this feature to switch to `konmai` or `ginger`. As mentioned before, this design is not capable with these servers.

So in this commit it's getting removed, but not entirely: some of the inner implementation is preserved. This is trying to not make a big change instantly.